### PR TITLE
resolve array index out of bound issue

### DIFF
--- a/pipeline/objectDetection/common/src/main/scala/com/intel/analytics/zoo/pipeline/common/dataset/Coco.scala
+++ b/pipeline/objectDetection/common/src/main/scala/com/intel/analytics/zoo/pipeline/common/dataset/Coco.scala
@@ -34,11 +34,20 @@ class Coco(val imageSet: String, devkitPath: String) extends Imdb {
   override def getRoidb(readImage: Boolean = true): LocalImageFrame = {
     val imageSetFile = Paths.get(devkitPath, "ImageSets", s"$imageSet.txt").toFile
     assert(imageSetFile.exists(), "Path does not exist " + imageSetFile.getAbsolutePath)
+
+    var imageSet_new = imageSet
+    if (imageSet == "val2014" || imageSet == "minival2014" || imageSet == "valminusminival2014"){
+      imageSet_new = "val2014"
+    } else if (imageSet == "test-dev2015"){
+      imageSet_new = "test2015"
+    }
     val array = Source.fromFile(imageSetFile).getLines()
       .map(line => line.trim.split("\\s")).map(x => {
-      val imagePath = devkitPath + "/" + x(0)
+      val imagePath = devkitPath + "/images/" + imageSet_new + "/" + x(0) + ".jpg"
+      val annoPath = devkitPath + "/Annotations/" + imageSet + "/" + x(0) + ".json"
+
       val image = if (readImage) loadImage(imagePath) else null
-      ImageFeature(image, Coco.loadAnnotation(devkitPath + "/" + x(1)), imagePath)
+      ImageFeature(image, Coco.loadAnnotation(annoPath), imagePath)
     }).toArray
 
     ImageFrame.array(array)

--- a/pipeline/objectDetection/common/src/main/scala/com/intel/analytics/zoo/pipeline/common/dataset/RoiImageSeqGenerator.scala
+++ b/pipeline/objectDetection/common/src/main/scala/com/intel/analytics/zoo/pipeline/common/dataset/RoiImageSeqGenerator.scala
@@ -65,7 +65,7 @@ object RoiImageSeqGenerator {
         Imdb.getImdb(param.imageSet.get, param.folder).getRoidb(false)
       }
 
-      val total = roidbs.array
+      val total = roidbs.array.length
       val iter = Imdb.data(roidbs.array)
 
       (0 until param.parallel).map(tid => {

--- a/pipeline/objectDetection/common/src/main/scala/com/intel/analytics/zoo/pipeline/common/dataset/roiimage/Types.scala
+++ b/pipeline/objectDetection/common/src/main/scala/com/intel/analytics/zoo/pipeline/common/dataset/roiimage/Types.scala
@@ -23,14 +23,14 @@ import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
 import com.intel.analytics.bigdl.transform.vision.image.util.BboxUtil
 
 
-
 /**
- * A batch of data feed into the model. The first size is batchsize
- * @param input
- * @param target
- */
+  * A batch of data feed into the model. The first size is batchsize
+  *
+  * @param input
+  * @param target
+  */
 class SSDMiniBatch(val input: Tensor[Float], val target: Tensor[Float],
-  val imInfo: Tensor[Float] = null)
+                   val imInfo: Tensor[Float] = null)
   extends MiniBatch[Float] {
 
   private val targetIndices = if (target != null) BboxUtil.getGroundTruthIndices(target) else null


### PR DESCRIPTION
This PR resolves the ArrayIndexOutOfBoundsException issue that block converting COCO dataset to sequence file. 

$  java -cp /mnt/disk1/SSD_Predict/models/ssd/jars/object-detection-0.1-SNAPSHOT-jar-with-dependencies-and-spark.jar com.intel.analytics.zoo.pipeline.common.dataset.RoiImageSeqGenerator -f /mnt/disk1/SSD_Predict/data/COCO -o /mnt/disk1/SSD_Predict/data/COCO/seq/coco-minival -i coco_minival2014 -p 50
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException: 1
        at com.intel.analytics.zoo.pipeline.common.dataset.Coco$$anonfun$2.apply(Coco.scala:41)
        at com.intel.analytics.zoo.pipeline.common.dataset.Coco$$anonfun$2.apply(Coco.scala:38)
        at scala.collection.Iterator$$anon$11.next(Iterator.scala:409)
        at scala.collection.Iterator$class.foreach(Iterator.scala:893)
        at scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
        at scala.collection.generic.Growable$class.$plus$plus$eq(Growable.scala:59)
        at scala.collection.mutable.ArrayBuffer.$plus$plus$eq(ArrayBuffer.scala:104)
        at scala.collection.mutable.ArrayBuffer.$plus$plus$eq(ArrayBuffer.scala:48)
        at scala.collection.TraversableOnce$class.to(TraversableOnce.scala:310)
        at scala.collection.AbstractIterator.to(Iterator.scala:1336)
        at scala.collection.TraversableOnce$class.toBuffer(TraversableOnce.scala:302)
        at scala.collection.AbstractIterator.toBuffer(Iterator.scala:1336)
        at scala.collection.TraversableOnce$class.toArray(TraversableOnce.scala:289)
        at scala.collection.AbstractIterator.toArray(Iterator.scala:1336)
        at com.intel.analytics.zoo.pipeline.common.dataset.Coco.getRoidb(Coco.scala:42)