### PR TITLE
Expose a summary() method for Python to view ZooModel topology

### DIFF
--- a/pyzoo/test/zoo/models/recommendation/test_neuralcf.py
+++ b/pyzoo/test/zoo/models/recommendation/test_neuralcf.py
@@ -36,6 +36,7 @@ class TestNeuralCF(ZooTestCase):
 
     def test_forward_backward_with_mf(self):
         model = NeuralCF(10, 10, 5, 5, 5)
+        model.summary()
         input_data = np.random.randint(10, size=(3, 2))
         self.assert_forward_backward(model, input_data)
 

--- a/pyzoo/test/zoo/models/recommendation/test_wideanddeep.py
+++ b/pyzoo/test/zoo/models/recommendation/test_wideanddeep.py
@@ -74,6 +74,7 @@ class TestWideAndDeep(ZooTestCase):
     def test_wide_and_deep_forward_backward(self):
         column_info = self.column_info
         model = WideAndDeep(5, column_info, "wide_n_deep")
+        model.summary()
         data = self.data_in.rdd.map(lambda r: [get_wide_tensor(r, column_info),
                                                get_deep_tensor(r, column_info)])
         data.map(lambda input_data: self.assert_forward_backward(model, input_data))

--- a/pyzoo/test/zoo/models/textclassification/test_textclassifier.py
+++ b/pyzoo/test/zoo/models/textclassification/test_textclassifier.py
@@ -27,6 +27,7 @@ class TestTextClassifier(ZooTestCase):
 
     def test_forward_backward(self):
         model = TextClassifier(10, 30, 100)
+        model.summary()
         input_data = np.random.random([3, 100, 30])
         self.assert_forward_backward(model, input_data)
 

--- a/pyzoo/zoo/models/common/zoo_model.py
+++ b/pyzoo/zoo/models/common/zoo_model.py
@@ -49,6 +49,10 @@ class ZooModel(ZooModelCreator, Container):
         callBigDlFunc(self.bigdl_type, "saveZooModel",
                       self.value, path, weight_path, over_write)
 
+    def summary(self):
+        print(callBigDlFunc(self.bigdl_type, "zooModelSummary",
+                            self.value))
+
     @staticmethod
     def _do_load(jmodel, bigdl_type="float"):
         model = Layer(jvalue=jmodel, bigdl_type=bigdl_type)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/common/ZooModel.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/common/ZooModel.scala
@@ -70,6 +70,14 @@ abstract class ZooModel[A <: Activity: ClassTag, B <: Activity: ClassTag, T: Cla
     this.saveModule(path, weightPath, overWrite)
   }
 
+  def modelSummary: String = {
+    super.toString() + " summary: \n" + model.toString()
+  }
+
+  def summary(): Unit = {
+    println(this.modelSummary)
+  }
+
   override def updateOutput(input: A): B = {
     output = model.updateOutput(input)
     output

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/python/PythonZooModel.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/python/PythonZooModel.scala
@@ -55,6 +55,11 @@ class PythonZooModel[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonB
     model.saveModel(path, weightPath, overWrite)
   }
 
+  def zooModelSummary(
+      model: ZooModel[Activity, Activity, T]): String = {
+    model.modelSummary
+  }
+
   def createZooTextClassifier(
       classNum: Int,
       tokenLength: Int,

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/textclassification/TextClassifier.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/textclassification/TextClassifier.scala
@@ -22,7 +22,7 @@ import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.Shape
 import com.intel.analytics.zoo.models.common.ZooModel
 import com.intel.analytics.zoo.pipeline.api.keras.layers._
-import com.intel.analytics.zoo.pipeline.api.keras.models.Sequential
+import com.intel.analytics.zoo.pipeline.api.keras.models.{KerasNet, Sequential}
 
 import scala.reflect.ClassTag
 
@@ -66,6 +66,10 @@ class TextClassifier[T: ClassTag] private (
     model.add(Activation("relu"))
     model.add(Dense(classNum, activation = "softmax"))
     model.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+  }
+
+  override def modelSummary: String = {
+    super.toString() + " summary: \n" + model.asInstanceOf[KerasNet[T]].modules(0).toString()
   }
 }
 


### PR DESCRIPTION
A temporary fix for this release for building python models from scratch.

Since currently users cannot see anything about the model, using `summary()`, users can at least view what layers the model consist of.
For example, TextClassifier
```
model = TextClassifier(10, 30, 100)
model.summary()
```
will print the following:
```
TextClassifier[7823d6c7] summary: 
Sequential[dd9e8315]{
  [input -> (1) -> (2) -> (3) -> (4) -> (5) -> (6) -> (7) -> output]
  (1): Input[39a1a23e]
  (2): Convolution1D[c5609743]
  (3): GlobalMaxPooling1D[f4d1c130]
  (4): Dense[db3a905f]
  (5): Dropout[9afa9027]
  (6): Activation[568faa4c]
  (7): Dense[682b87df]
}
```