### PR TITLE
Remove bigdl in jar and add it as a pip dependency

### DIFF
--- a/pyzoo/dev/release/release.sh
+++ b/pyzoo/dev/release/release.sh
@@ -25,7 +25,7 @@ ANALYTICS_ZOO_PYTHON_DIR="$(cd ${RUN_SCRIPT_DIR}/../../../pyzoo; pwd)"
 echo $ANALYTICS_ZOO_PYTHON_DIR
 
 if (( $# < 2)); then
-  echo "Bad parameters. Usage: bash release.sh linux spark_2.x false 0.1.0.dev0"
+  echo "Bad parameters. Usage example: bash release.sh linux without_bigdl false 0.1.0.dev0"
   exit -1
 fi
 
@@ -42,11 +42,11 @@ fi
 
 cd ${ANALYTICS_ZOO_DIR}
 if [ "$platform" ==  "mac" ]; then
-    echo "Building analytics zoo for mac system"
+    echo "Building Analytics Zoo for mac system"
     dist_profile="-P mac -P $spark_profile"
     verbose_pname="macosx_10_11_x86_64"
 elif [ "$platform" == "linux" ]; then
-    echo "Building analytics zoo for linux system"
+    echo "Building Analytics Zoo for linux system"
     dist_profile="-P $spark_profile"
     verbose_pname="manylinux1_x86_64"
 else

--- a/pyzoo/setup.py
+++ b/pyzoo/setup.py
@@ -71,20 +71,20 @@ def init_env():
 
 
 def setup_package():
-    jar_file = 'lib/analytics-zoo-'+VERSION+'.jar'
-    if ".dev0" in jar_file:
-        jar_file = jar_file.replace(".dev0", "-SNAPSHOT")
     metadata = dict(
         name='analytics-zoo',
         version=VERSION,
         description='Analytics + AI platform for Apache Spark and BigDL',
         author='Analytics Zoo Authors',
-        author_email='zoo-user-group@googlegroups.com',
+        author_email='analytics-zoo-user-group@googlegroups.com',
         license='Apache License, Version 2.0',
         url='https://github.com/intel-analytics/analytics-zoo',
         packages=['zoo',
                   'zoo.common',
                   'zoo.examples',
+                  'zoo.examples.autograd',
+                  'zoo.examples.imageclassification',
+                  'zoo.examples.nnframes',
                   'zoo.examples.objectdetection',
                   'zoo.examples.textclassification',
                   'zoo.feature',
@@ -93,6 +93,7 @@ def setup_package():
                   'zoo.models.common',
                   'zoo.models.image',
                   'zoo.models.image.common',
+                  'zoo.models.image.imageclassification',
                   'zoo.models.image.objectdetection',
                   'zoo.models.recommendation',
                   'zoo.models.textclassification',
@@ -108,8 +109,8 @@ def setup_package():
         install_requires=['bigdl==0.5.0'],
         dependency_links=['https://d3kbcqa49mib13.cloudfront.net/spark-2.0.0-bin-hadoop2.7.tgz'],
         include_package_data=True,
-        package_dir={"bigdl": '../backend/bigdl/pyspark/bigdl', "zoo.share": TEMP_PATH},
-        package_data={"zoo.share": [jar_file, 'conf/*', 'bin/*',
+        # package_dir={"bigdl": '../backend/bigdl/pyspark/bigdl', "zoo.share": TEMP_PATH},
+        package_data={"zoo.share": ['lib/analytics-zoo*with-dependencies.jar', 'conf/*', 'bin/*',
                                     'extra-resources/*']},
         classifiers=[
             'License :: OSI Approved :: Apache Software License',

--- a/pyzoo/setup.py
+++ b/pyzoo/setup.py
@@ -71,6 +71,9 @@ def init_env():
 
 
 def setup_package():
+    jar_file = 'lib/analytics-zoo-'+VERSION+'.jar'
+    if ".dev0" in jar_file:
+        jar_file = jar_file.replace(".dev0", "-SNAPSHOT")
     metadata = dict(
         name='analytics-zoo',
         version=VERSION,
@@ -101,29 +104,12 @@ def setup_package():
                   'zoo.pipeline.api.keras.metrics',
                   'zoo.pipeline.nnframes',
                   'zoo.util',
-                  'zoo.share',
-                  'bigdl',
-                  'bigdl.dataset',
-                  'bigdl.nn',
-                  'bigdl.nn.keras',
-                  'bigdl.transform',
-                  'bigdl.transform.vision',
-                  'bigdl.keras',
-                  'bigdl.examples',
-                  'bigdl.examples.keras',
-                  'bigdl.models',
-                  'bigdl.models.lenet',
-                  'bigdl.models.local_lenet',
-                  'bigdl.models.ml_pipeline',
-                  'bigdl.models.rnn',
-                  'bigdl.models.textclassifier',
-                  'bigdl.optim',
-                  'bigdl.util'],
-        install_requires=['numpy>=1.7', 'pyspark>=2.2', 'six>=1.10.0'],
+                  'zoo.share'],
+        install_requires=['bigdl==0.5.0'],
         dependency_links=['https://d3kbcqa49mib13.cloudfront.net/spark-2.0.0-bin-hadoop2.7.tgz'],
         include_package_data=True,
         package_dir={"bigdl": '../backend/bigdl/pyspark/bigdl', "zoo.share": TEMP_PATH},
-        package_data={"zoo.share": ['lib/analytics-zoo*with-dependencies.jar', 'conf/*', 'bin/*',
+        package_data={"zoo.share": [jar_file, 'conf/*', 'bin/*',
                                     'extra-resources/*']},
         classifiers=[
             'License :: OSI Approved :: Apache Software License',

--- a/pyzoo/setup.py
+++ b/pyzoo/setup.py
@@ -109,7 +109,6 @@ def setup_package():
         install_requires=['bigdl==0.5.0'],
         dependency_links=['https://d3kbcqa49mib13.cloudfront.net/spark-2.0.0-bin-hadoop2.7.tgz'],
         include_package_data=True,
-        # package_dir={"bigdl": '../backend/bigdl/pyspark/bigdl', "zoo.share": TEMP_PATH},
         package_data={"zoo.share": ['lib/analytics-zoo*with-dependencies.jar', 'conf/*', 'bin/*',
                                     'extra-resources/*']},
         classifiers=[

--- a/zoo/pom.xml
+++ b/zoo/pom.xml
@@ -18,6 +18,7 @@
         <java.version>1.7</java.version>
         <javac.version>1.7</javac.version>
         <spark-scope>provided</spark-scope>
+        <bigdl-scope>compile</bigdl-scope>
         <scala.major.version>2.11</scala.major.version>
         <scala.version>2.11.8</scala.version>
         <scala.macros.version>2.1.0</scala.macros.version>
@@ -54,6 +55,13 @@
                 <scala.version>2.11.8</scala.version>
                 <scala.macros.version>2.1.0</scala.macros.version>
                 <bigdl.artifactId>bigdl-SPARK_2.1</bigdl.artifactId>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>without_bigdl</id>
+            <properties>
+                <bigdl-scope>provided</bigdl-scope>
             </properties>
         </profile>
 
@@ -196,6 +204,7 @@
             <groupId>com.intel.analytics.bigdl</groupId>
             <artifactId>${bigdl.artifactId}</artifactId>
             <version>${bigdl.version}</version>
+            <scope>${bigdl-scope}</scope>
         </dependency>
         <dependency>
             <groupId>org.spark-project.spark</groupId>


### PR DESCRIPTION
Fix https://github.com/intel-analytics/zoo/issues/226

cc @jason-dai 
I try if we remove bigdl in our package, and add bigdl as a dependency, it can work and the whl file size will definitely be smaller.
I test using the following code after pip install the whl file and start python REPL:
```
from zoo.common.nncontext import *
sc = get_nncontext()
from zoo.pipeline.api.keras.layers import *
from zoo.pipeline.api.keras.models import *
model = Sequential()
model.add(Dense(3, input_shape=(10, )))
```

My preference is to use `bigdl==0.5.0` as a dependency and in this case we don't need to worry anything about the pypi file size. Moreover, if we use the current way, there will possibly be potential problem if users have already install bigdl.
Possibly we need a jar that includes all other dependencies except bigdl in the case where analytics-zoo have some dependencies that bigdl doesn't have.

Wondering if you want to link to other released versions of bigdl (ie. up to a certain commit...)