### PR TITLE
Fix recommender for Python 3

### DIFF
--- a/pyzoo/zoo/examples/autograd/customloss.py
+++ b/pyzoo/zoo/examples/autograd/customloss.py
@@ -23,6 +23,7 @@ def mean_absolute_error(y_true, y_pred):
     result = mean(abs(y_true - y_pred), axis=1)
     return result
 
+
 if __name__ == "__main__":
     data_len = 1000
     X_ = np.random.uniform(0, 1, (1000, 2))

--- a/pyzoo/zoo/models/recommendation/neuralcf.py
+++ b/pyzoo/zoo/models/recommendation/neuralcf.py
@@ -43,14 +43,14 @@ class NeuralCF(Recommender):
                  item_embed=20, hidden_layers=(40, 20, 10), include_mf=True,
                  mf_embed=20, bigdl_type="float"):
         super(NeuralCF, self).__init__(None, bigdl_type,
-                                       user_count,
-                                       item_count,
-                                       class_num,
-                                       user_embed,
-                                       item_embed,
-                                       hidden_layers,
+                                       int(user_count),
+                                       int(item_count),
+                                       int(class_num),
+                                       int(user_embed),
+                                       int(item_embed),
+                                       [int(unit) for unit in hidden_layers],
                                        include_mf,
-                                       mf_embed)
+                                       int(mf_embed))
 
     @staticmethod
     def load_model(path, weight_path=None, bigdl_type="float"):

--- a/pyzoo/zoo/models/recommendation/recommender.py
+++ b/pyzoo/zoo/models/recommendation/recommender.py
@@ -104,7 +104,7 @@ class Recommender(ZooModel):
         result_rdd = callBigDlFunc(self.bigdl_type, "recommendForUser",
                                    self.value,
                                    self._to_tuple_rdd(feature_rdd),
-                                   max_items)
+                                   int(max_items))
         return self._to_prediction_rdd(result_rdd)
 
     def recommend_for_item(self, feature_rdd, max_users):
@@ -119,7 +119,7 @@ class Recommender(ZooModel):
         result_rdd = callBigDlFunc(self.bigdl_type, "recommendForItem",
                                    self.value,
                                    self._to_tuple_rdd(feature_rdd),
-                                   max_users)
+                                   int(max_users))
         return self._to_prediction_rdd(result_rdd)
 
     @staticmethod

--- a/pyzoo/zoo/models/recommendation/wide_and_deep.py
+++ b/pyzoo/zoo/models/recommendation/wide_and_deep.py
@@ -52,6 +52,7 @@ class ColumnFeatureInfo(object):
                    List of int. Default is an empty list.
     embed_out_dims: The dimensions of embeddings. List of int. Default is an empty list.
     continuous_cols: Data of continuous_cols is treated as continuous values for the deep model.
+                     List of String. Default is an empty list.
     label: The name of the 'label' column. String. Default is 'label'.
     """
     def __init__(self, wide_base_cols=None, wide_base_dims=None, wide_cross_cols=None,
@@ -59,14 +60,14 @@ class ColumnFeatureInfo(object):
                  embed_cols=None, embed_in_dims=None, embed_out_dims=None,
                  continuous_cols=None, label="label", bigdl_type="float"):
         self.wide_base_cols = [] if not wide_base_cols else wide_base_cols
-        self.wide_base_dims = [] if not wide_base_dims else wide_base_dims
+        self.wide_base_dims = [] if not wide_base_dims else [int(d) for d in wide_base_dims]
         self.wide_cross_cols = [] if not wide_cross_cols else wide_cross_cols
-        self.wide_cross_dims = [] if not wide_cross_dims else wide_cross_dims
+        self.wide_cross_dims = [] if not wide_cross_dims else [int(d) for d in wide_cross_dims]
         self.indicator_cols = [] if not indicator_cols else indicator_cols
-        self.indicator_dims = [] if not indicator_dims else indicator_dims
+        self.indicator_dims = [] if not indicator_dims else [int(d) for d in indicator_dims]
         self.embed_cols = [] if not embed_cols else embed_cols
-        self.embed_in_dims = [] if not embed_in_dims else embed_in_dims
-        self.embed_out_dims = [] if not embed_out_dims else embed_out_dims
+        self.embed_in_dims = [] if not embed_in_dims else [int(d) for d in embed_in_dims]
+        self.embed_out_dims = [] if not embed_out_dims else [int(d) for d in embed_out_dims]
         self.continuous_cols = [] if not continuous_cols else continuous_cols
         self.label = label
         self.bigdl_type = bigdl_type
@@ -103,8 +104,8 @@ class WideAndDeep(Recommender):
                  hidden_layers=(40, 20, 10), bigdl_type="float"):
         super(WideAndDeep, self).__init__(None, bigdl_type,
                                           model_type,
-                                          class_num,
-                                          hidden_layers,
+                                          int(class_num),
+                                          [int(unit) for unit in hidden_layers],
                                           col_info.wide_base_cols,
                                           col_info.wide_base_dims,
                                           col_info.wide_cross_cols,

--- a/pyzoo/zoo/models/textclassification/text_classifier.py
+++ b/pyzoo/zoo/models/textclassification/text_classifier.py
@@ -39,11 +39,11 @@ class TextClassifier(ZooModel):
     def __init__(self, class_num, token_length, sequence_length=500,
                  encoder="cnn", encoder_output_dim=256, bigdl_type="float"):
         super(TextClassifier, self).__init__(None, bigdl_type,
-                                             class_num,
-                                             token_length,
-                                             sequence_length,
+                                             int(class_num),
+                                             int(token_length),
+                                             int(sequence_length),
                                              encoder,
-                                             encoder_output_dim)
+                                             int(encoder_output_dim))
 
     @staticmethod
     def load_model(path, weight_path=None, bigdl_type="float"):


### PR DESCRIPTION
This is actually not a problem for recommender but for all python warps that involve `numpy.int64` will have this error http://172.168.2.101:8080/view/ZOO-PR/job/ZOO-PR-Python-AppTests/46/consoleFull 

This PR fixes this for recommender and corresponding APIs; namely cast input to int.
So that Python notebooks for recommenders can pass jenkins.

https://github.com/intel-analytics/zoo/issues/222