### PR TITLE
Explicitly claim imported library

### DIFF
--- a/pyzoo/zoo/models/image/common/image_config.py
+++ b/pyzoo/zoo/models/image/common/image_config.py
@@ -17,8 +17,6 @@
 import sys
 from bigdl.util.common import JavaValue
 from bigdl.util.common import callBigDlFunc
-from bigdl.util.common import *
-from bigdl.transform.vision.image import *
 
 if sys.version >= '3':
     long = int

--- a/pyzoo/zoo/models/image/imageclassification/image_classification.py
+++ b/pyzoo/zoo/models/image/imageclassification/image_classification.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-from bigdl.transform.vision.image import *
+from bigdl.transform.vision.image import FeatureTransformer
 from zoo.models.image.common.image_model import ImageModel
 from zoo.feature.image.imageset import *
 

--- a/pyzoo/zoo/models/image/objectdetection/object_detector.py
+++ b/pyzoo/zoo/models/image/objectdetection/object_detector.py
@@ -17,8 +17,7 @@
 import sys
 from bigdl.util.common import JavaValue
 from bigdl.util.common import callBigDlFunc
-from bigdl.util.common import *
-from bigdl.transform.vision.image import *
+from bigdl.transform.vision.image import FeatureTransformer
 
 from zoo.models.image.common.image_model import ImageModel
 from zoo.feature.image.imageset import *

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageSet.scala
@@ -16,7 +16,8 @@
 
 package com.intel.analytics.zoo.feature.image
 
-import com.intel.analytics.bigdl.transform.vision.image._
+import com.intel.analytics.bigdl.transform.vision.image.{FeatureTransformer,
+       ImageFeature, ImageFrame, BytesToMat, LocalImageFrame, DistributedImageFrame}
 import com.intel.analytics.zoo.common.Utils
 
 import org.apache.commons.io.FileUtils

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/image/objectdetection/ObjectDetectionConfig.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/image/objectdetection/ObjectDetectionConfig.scala
@@ -19,8 +19,11 @@ package com.intel.analytics.zoo.models.image.objectdetection
 import com.intel.analytics.bigdl.dataset.PaddingParam
 import com.intel.analytics.bigdl.numeric.NumericFloat
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
-import com.intel.analytics.bigdl.transform.vision.image._
-import com.intel.analytics.bigdl.transform.vision.image.augmentation.{AspectScale, ChannelNormalize, Resize}
+import com.intel.analytics.bigdl.transform.vision.image.{FeatureTransformer,
+       ImageFeature, ImageFrameToSample, MatToTensor}
+import com.intel.analytics.bigdl.transform.vision.image.augmentation.{AspectScale,
+       Resize, ChannelNormalize}
+
 import com.intel.analytics.zoo.models.image.common.ImageConfigure
 import com.intel.analytics.zoo.models.image.objectdetection.ObjectDetectorDataset.{Coco, Pascal}
 


### PR DESCRIPTION
Currently in our code, there is "from bigdl.util.common import *". It may overwrite the class defined in zoo(eg, Brightness) when loading. It would be better if we can explictly declare what's needed from BigDL, 