### PR TITLE
Check environment variable/sys.path when adding

### DIFF
--- a/pyzoo/zoo/util/engine.py
+++ b/pyzoo/zoo/util/engine.py
@@ -69,8 +69,9 @@ def __prepare_analytics_zoo_env():
 
     def append_path(env_var_name, path):
         try:
-            print("Adding %s to %s" % (path, env_var_name))
-            os.environ[env_var_name] = path + ":" + os.environ[env_var_name]  # noqa
+            if path not in os.environ[env_var_name]:
+                print("Adding %s to %s" % (path, env_var_name))
+                os.environ[env_var_name] = path + ":" + os.environ[env_var_name]  # noqa
         except KeyError:
             os.environ[env_var_name] = path
 
@@ -79,8 +80,9 @@ def __prepare_analytics_zoo_env():
 
     if conf_paths:
         assert len(conf_paths) == 1, "Expecting one conf, but got: %s" % len(conf_paths)
-        print("Prepending %s to sys.path" % conf_paths[0])
-        sys.path.insert(0, conf_paths[0])
+        if conf_paths[0] not in sys.path:
+            print("Prepending %s to sys.path" % conf_paths[0])
+            sys.path.insert(0, conf_paths[0])
 
     if extra_resources_paths:
         for resource in extra_resources_paths:

--- a/pyzoo/zoo/util/engine.py
+++ b/pyzoo/zoo/util/engine.py
@@ -57,8 +57,10 @@ def __prepare_spark_env():
         print("Using %s" % spark_home)
         py4j = glob.glob(os.path.join(spark_home, 'python/lib', 'py4j-*.zip'))[0]
         pyspark = glob.glob(os.path.join(spark_home, 'python/lib', 'pyspark*.zip'))[0]
-        sys.path.insert(0, py4j)
-        sys.path.insert(0, pyspark)
+        if py4j not in sys.path:
+            sys.path.insert(0, py4j)
+        if pyspark not in sys.path:
+            sys.path.insert(0, pyspark)
 
 
 def __prepare_analytics_zoo_env():
@@ -86,8 +88,9 @@ def __prepare_analytics_zoo_env():
 
     if extra_resources_paths:
         for resource in extra_resources_paths:
-            print("Prepending %s to sys.path" % resource)
-            sys.path.insert(0, resource)
+            if resource not in extra_resources_paths:
+                print("Prepending %s to sys.path" % resource)
+                sys.path.insert(0, resource)
 
     if os.environ.get("BIGDL_JARS", None) and is_spark_below_2_2():
         for jar in os.environ["BIGDL_JARS"].split(":"):
@@ -95,7 +98,8 @@ def __prepare_analytics_zoo_env():
 
     if os.environ.get("BIGDL_PACKAGES", None):
         for package in os.environ["BIGDL_PACKAGES"].split(":"):
-            sys.path.insert(0, package)
+            if package not in sys.path:
+                sys.path.insert(0, package)
 
 
 def get_analytics_zoo_classpath():


### PR DESCRIPTION
Before appending to environment variables, check if it already exists.
Fix this in Analytics Zoo. But as BigDL also has such code, print "Adding ... to ..." multiple times is still unavoidable unless we fix in BigDL.

As far as I test, now even if the message is printed multiple times, `BIGDL_JARS` only has one jar as we desire. Without the check, there will be two duplicate jars.