### PR TITLE
Fix Net.load_keras()

### DIFF
--- a/pyzoo/test/zoo/pipeline/api/keras/test_net.py
+++ b/pyzoo/test/zoo/pipeline/api/keras/test_net.py
@@ -73,11 +73,13 @@ class TestLayer(ZooTestCase):
         model_json = model.to_json()
         with open(tmp_path_json, "w") as json_file:
             json_file.write(model_json)
-        reloaded_json_model = Net.load_keras(json_path=tmp_path_json)
+        zmodel = Net.load_keras(json_path=tmp_path_json)
+        assert isinstance(zmodel, Sequential)
 
         tmp_path_hdf5 = create_tmp_path() + ".h5"
         model.save(tmp_path_hdf5)
-        reloaded_hdf5_model = Net.load_keras(hdf5_path=tmp_path_hdf5)
+        zmodel2 = Net.load_keras(hdf5_path=tmp_path_hdf5)
+        assert isinstance(zmodel2, Sequential)
 
     def test_load_tf(self):
         linear = Linear(10, 2)()

--- a/pyzoo/zoo/pipeline/api/net.py
+++ b/pyzoo/zoo/pipeline/api/net.py
@@ -176,7 +176,7 @@ class Net:
                         If set as True, only layers with the same name will be loaded.
         :return: A BigDL model.
         """
-        BModel.load_keras(json_path, hdf5_path, by_name)
+        return BModel.load_keras(json_path, hdf5_path, by_name)
 
 
 class TFNet(Layer):


### PR DESCRIPTION
A bug brought by https://github.com/intel-analytics/analytics-zoo/pull/132
Need to add `return`, otherwise the return result is None.