### PR TITLE
fix incompatible spark version  and bigdl spark verion in pom.xml

### DIFF
--- a/zoo/pom.xml
+++ b/zoo/pom.xml
@@ -50,7 +50,7 @@
                 <java.version>1.8</java.version>
                 <javac.version>1.8</javac.version>
                 <spark-version.project>2.0</spark-version.project>
-                <spark.version>2.0.0</spark.version>
+                <spark.version>2.1.0</spark.version>
                 <scala.major.version>2.11</scala.major.version>
                 <scala.version>2.11.8</scala.version>
                 <scala.macros.version>2.1.0</scala.macros.version>


### PR DESCRIPTION
fix issue of spark version properties is different with bigdl spark verion in pom.xml

Related issue:
https://github.com/intel-analytics/zoo/issues/290
