### PR TITLE
fix a typo in predict

### DIFF
--- a/pyzoo/zoo/pipeline/api/keras/engine/topology.py
+++ b/pyzoo/zoo/pipeline/api/keras/engine/topology.py
@@ -190,7 +190,7 @@ class KerasNet(ZooKerasLayer):
         distributed: Boolean. Whether to do prediction in distributed mode or local mode.
                      Default is True. In local mode, x must be a Numpy array.
         """
-        if is_distributed:
+        if distributed:
             if isinstance(x, np.ndarray):
                 features = to_sample_rdd(x, np.zeros([x.shape[0]]))
             elif isinstance(x, RDD):


### PR DESCRIPTION
cc @JasonChu1313
A typo just noticed... should be `distributed`...