### PR TITLE
support model with single output for NNClassifier.

### DIFF
--- a/pyzoo/test/zoo/pipeline/nnframes/test_nn_classifier.py
+++ b/pyzoo/test/zoo/pipeline/nnframes/test_nn_classifier.py
@@ -321,6 +321,37 @@ class TestNNClassifer():
             row_prediction = data[i][2]
             assert row_label == row_prediction
 
+    def test_nnclassifier_fit_with_Sigmoid(self):
+        model = Sequential().add(Linear(2, 1)).add(Sigmoid())
+        criterion = BCECriterion()
+        classifier = NNClassifier(model, criterion, SeqToTensor([2])) \
+            .setBatchSize(4) \
+            .setLearningRate(0.2).setMaxEpoch(40)
+
+        data = self.sc.parallelize([
+            ((2.0, 1.0), 0.0),
+            ((1.0, 2.0), 1.0),
+            ((2.0, 1.0), 0.0),
+            ((1.0, 2.0), 1.0)])
+
+        schema = StructType([
+            StructField("features", ArrayType(DoubleType(), False), False),
+            StructField("label", DoubleType(), False)])
+        df = self.sqlContext.createDataFrame(data, schema)
+        nnClassifierModel = classifier.fit(df)
+        assert(isinstance(nnClassifierModel, NNClassifierModel))
+        res = nnClassifierModel.transform(df)
+        res.registerTempTable("nnClassifierModelDF")
+        results = self.sqlContext.table("nnClassifierModelDF")
+
+        count = results.rdd.count()
+        data = results.rdd.collect()
+
+        for i in range(count):
+            row_label = data[i][1]
+            row_prediction = data[i][2]
+            assert row_label == row_prediction
+
     def test_nnclassifierModel_set_Preprocessing(self):
         model = Sequential().add(Linear(2, 2))
         criterion = ClassNLLCriterion()

--- a/pyzoo/zoo/pipeline/nnframes/nn_classifier.py
+++ b/pyzoo/zoo/pipeline/nnframes/nn_classifier.py
@@ -99,6 +99,39 @@ class HasOptimMethod:
         return self.optimMethod
 
 
+class HasThreshold(Params):
+    """
+    Mixin for param Threshold in binary classification.
+
+    The threshold applies to the raw output of the model. If the output is greater than
+    threshold, then predict 1, else 0. A high threshold encourages the model to predict 0
+    more often; a low threshold encourages the model to predict 1 more often.
+
+    Note: the param is different from the one in Spark ProbabilisticClassifier which is compared
+    against estimated probability.
+
+    Default is 0.5.
+    """
+
+    def __init__(self):
+        super(HasThreshold, self).__init__()
+        self.threshold = Param(self, "threshold", "threshold")
+        self._setDefault(threshold=0.5)
+
+    def setThreshold(self, val):
+        """
+        Sets the value of :py:attr:`threshold`.
+        """
+        self._paramMap[self.threshold] = val
+        return self
+
+    def getThreshold(self):
+        """
+        Gets the value of threshold or its default value.
+        """
+        return self.getOrDefault(self.threshold)
+
+
 class NNEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, HasBatchSize,
                   HasOptimMethod, HasSamplePreprocessing, JavaValue):
     """
@@ -434,7 +467,7 @@ class NNClassifier(NNEstimator):
         return classifierModel
 
 
-class NNClassifierModel(NNModel):
+class NNClassifierModel(NNModel, HasThreshold):
     """
     NNClassifierModel is a specialized [[NNModel]] for classification tasks. The prediction
     column will have the datatype of Double.

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNClassifier.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNClassifier.scala
@@ -24,7 +24,7 @@ import com.intel.analytics.zoo.feature.common._
 import com.intel.analytics.zoo.pipeline.nnframes.NNModel.NNModelWriter
 import org.apache.spark.ml.DefaultParamsWriterWrapper
 import org.apache.spark.ml.adapter.SchemaUtils
-import org.apache.spark.ml.param.ParamMap
+import org.apache.spark.ml.param.{DoubleParam, ParamMap}
 import org.apache.spark.ml.util.{Identifiable, MLReadable, MLReader}
 import org.apache.spark.sql.types._
 import org.json4s.DefaultFormats
@@ -139,11 +139,38 @@ object NNClassifier {
  */
 class NNClassifierModel[T: ClassTag] private[zoo] (
     @transient override val model: Module[T],
-    override val uid: String = "DLClassifierModel"
+    override val uid: String = Identifiable.randomUID("nnClassifierModel")
   )(implicit ev: TensorNumeric[T]) extends NNModel[T](model) {
 
+  /**
+    * Param for threshold in binary classification prediction.
+    *
+    * The threshold applies to the raw output of the model. If the output is greater than
+    * threshold, then predict 1, else 0. A high threshold encourages the model to predict 0
+    * more often; a low threshold encourages the model to predict 1 more often.
+    *
+    * Note: the param is different from the one in Spark ProbabilisticClassifier which is compared
+    * against estimated probability.
+    *
+    * Default is 0.5.
+    */
+  final val threshold = new DoubleParam(this, "threshold", "threshold in binary" +
+    " classification prediction")
+
+  def getThreshold: Double = $(threshold)
+
+  def setThreshold(value: Double): this.type = {
+    set(threshold, value)
+  }
+  setDefault(threshold, 0.5)
+
   protected override def outputToPrediction(output: Tensor[T]): Any = {
-    ev.toType[Double](output.max(1)._2.valueAt(1))
+    if (output.size().deep == Array(1).deep) {
+      val raw = ev.toType[Double](output.toArray().head)
+      if (raw > 0.5) 1.0 else 0.0
+    } else {
+      ev.toType[Double](output.max(1)._2.valueAt(1))
+    }
   }
 
   override def transformSchema(schema : StructType): StructType = {
@@ -208,10 +235,10 @@ object NNClassifierModel extends MLReadable[NNClassifierModel[_]] {
       val (meta, model, typeTag, feaTran) = NNModel.getMetaAndModel(path, sc)
       val nnModel = typeTag match {
         case "TensorDouble" =>
-          new NNClassifierModel[Double](model.asInstanceOf[Module[Double]])
+          new NNClassifierModel[Double](model.asInstanceOf[Module[Double]], meta.uid)
             .setSamplePreprocessing(feaTran.asInstanceOf[Preprocessing[Any, Sample[Double]]])
         case "TensorFloat" =>
-          new NNClassifierModel[Float](model.asInstanceOf[Module[Float]])
+          new NNClassifierModel[Float](model.asInstanceOf[Module[Float]], meta.uid)
             .setSamplePreprocessing(feaTran.asInstanceOf[Preprocessing[Any, Sample[Float]]])
         case _ =>
           throw new Exception("Only support float and double for now")

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNClassifier.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNClassifier.scala
@@ -143,17 +143,17 @@ class NNClassifierModel[T: ClassTag] private[zoo] (
   )(implicit ev: TensorNumeric[T]) extends NNModel[T](model) {
 
   /**
-    * Param for threshold in binary classification prediction.
-    *
-    * The threshold applies to the raw output of the model. If the output is greater than
-    * threshold, then predict 1, else 0. A high threshold encourages the model to predict 0
-    * more often; a low threshold encourages the model to predict 1 more often.
-    *
-    * Note: the param is different from the one in Spark ProbabilisticClassifier which is compared
-    * against estimated probability.
-    *
-    * Default is 0.5.
-    */
+   * Param for threshold in binary classification prediction.
+   *
+   * The threshold applies to the raw output of the model. If the output is greater than
+   * threshold, then predict 1, else 0. A high threshold encourages the model to predict 0
+   * more often; a low threshold encourages the model to predict 1 more often.
+   *
+   * Note: the param is different from the one in Spark ProbabilisticClassifier which is compared
+   * against estimated probability.
+   *
+   * Default is 0.5.
+   */
   final val threshold = new DoubleParam(this, "threshold", "threshold in binary" +
     " classification prediction")
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimator.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimator.scala
@@ -43,7 +43,7 @@ import scala.reflect.ClassTag
 
 private[nnframes] trait HasBatchSize extends Params {
 
-   final val batchSize: IntParam = new IntParam(this, "batchSize", "batchSize")
+  final val batchSize: IntParam = new IntParam(this, "batchSize", "batchSize")
 
   def getBatchSize: Int = $(batchSize)
 }
@@ -528,7 +528,7 @@ class NNModel[T: ClassTag] private[zoo] (
         val featureSeq = rowBatch.map(r => r.get(featureColIndex))
         val samples = featureSteps(featureSeq.iterator)
         val predictions = toBatch(samples).flatMap { batch =>
-          val batchResult = localModel.forward(batch.getInput()).toTensor.squeeze()
+          val batchResult = localModel.forward(batch.getInput()).toTensor
           if (batchResult.size().length == 2) {
             batchResult.split(1).map(outputToPrediction)
           } else if (batchResult.size().length == 1) {


### PR DESCRIPTION
Allow  NNClassifier to support model with a single scalar output, like a model with single sigmoid output.
