### PR TITLE
Update python tfnet predict example

### DIFF
--- a/pyzoo/zoo/examples/tfnet/predict.py
+++ b/pyzoo/zoo/examples/tfnet/predict.py
@@ -28,19 +28,16 @@ def predict(model_path, img_path, partition_num=4):
     inputs = "ToFloat:0"
     outputs = ["num_detections:0", "detection_boxes:0",
                "detection_scores:0", "detection_classes:0"]
-    model = Sequential()
-    detector = TFNet(model_path, inputs, outputs)
-    model.add(detector)
-    # Select the detection_boxes from the output.
-    model.add(SelectTable(2))
+
+    model = TFNet(model_path, inputs, outputs)
     image_set = ImageSet.read(img_path, sc, partition_num)
     transformer = ChainedPreprocessing([ImageResize(256, 256), ImageMatToTensor(format="NHWC"),
                                         ImageSetToSample()])
     transformed_image_set = image_set.transform(transformer)
     output = model.predict_image(transformed_image_set.to_image_frame(), batch_per_partition=1)
-    # Print the detection box with the highest score of the first prediction result.
-    result = output.get_predict().first()
-    print(result[1][0])
+    # Print the detection result of the first image.
+    result = ImageSet.from_image_frame(output).get_predict().first()
+    print(result)
 
 
 if __name__ == "__main__":

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/tfnet/Predict.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/tfnet/Predict.scala
@@ -35,7 +35,7 @@ object Predict {
   val logger = Logger.getLogger(getClass)
 
   case class PredictParam(image: String = "/tmp/datasets/cat_dog/train_sampled",
-                          model: String = "/tmp/models/ssd_mobilenet_v1_coco_2017_11_17" +
+                          model: String = "/tmp/models/ssd_mobilenet_v1_coco_2018_01_28" +
                             "/frozen_inference_graph.pb",
                           nPartition: Int = 4)
 


### PR DESCRIPTION
After @dding3 's fix on get_predict(), remove SelectTable() layer in the example.

BTW, tensorflow has updated the download link from 20171117 to 20180128