### PR TITLE
Restrict pyspark version for pip install; doc update

### DIFF
--- a/docs/docs/PythonUserGuide/install.md
+++ b/docs/docs/PythonUserGuide/install.md
@@ -33,7 +33,7 @@ sc = init_nncontext()
 2. Pip install supports __Mac__ and __Linux__ platforms.
 3. Pip install only supports __local__ mode. Cluster mode might be supported in the future. For those who want to use Analytics Zoo in cluster mode, please try to [install without pip](#install-without-pip).
 4. You need to install Java __>= JDK8__ before running Analytics Zoo, which is required by `pyspark`.
-5. `bigdl==0.5.0` and its dependencies will be automatically installed if they haven't been detected in the current Python environment.
+5. `pyspark`(2.2), `bigdl==0.6.0` and its dependencies will be automatically installed if they haven't been detected in the current Python environment.
 
 
 ---

--- a/pyzoo/setup.py
+++ b/pyzoo/setup.py
@@ -93,7 +93,7 @@ def setup_package():
         license='Apache License, Version 2.0',
         url='https://github.com/intel-analytics/analytics-zoo',
         packages=packages,
-        install_requires=['pyspark<2.3.0', 'bigdl==0.6.0'],
+        install_requires=['pyspark>=2.2,<2.3', 'bigdl==0.6.0'],
         dependency_links=['https://d3kbcqa49mib13.cloudfront.net/spark-2.0.0-bin-hadoop2.7.tgz'],
         include_package_data=True,
         package_data={"zoo.share": ['lib/analytics-zoo*with-dependencies.jar', 'conf/*', 'bin/*',

--- a/pyzoo/setup.py
+++ b/pyzoo/setup.py
@@ -93,7 +93,7 @@ def setup_package():
         license='Apache License, Version 2.0',
         url='https://github.com/intel-analytics/analytics-zoo',
         packages=packages,
-        install_requires=['bigdl==0.6.0'],
+        install_requires=['pyspark<2.3.0', 'bigdl==0.6.0'],
         dependency_links=['https://d3kbcqa49mib13.cloudfront.net/spark-2.0.0-bin-hadoop2.7.tgz'],
         include_package_data=True,
         package_data={"zoo.share": ['lib/analytics-zoo*with-dependencies.jar', 'conf/*', 'bin/*',


### PR DESCRIPTION
Fix https://github.com/intel-analytics/zoo/issues/336
As this example will fail for spark 2.3.1.