### PR TITLE
ncf goes public

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/recommendation/NeuralCF.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/recommendation/NeuralCF.scala
@@ -40,7 +40,7 @@ import scala.reflect.ClassTag
  * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now.
  */
 
-class NeuralCF[T: ClassTag] private(
+class NeuralCF[T: ClassTag](
     val userCount: Int,
     val itemCount: Int,
     val numClasses: Int,

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/recommendation/WideAndDeep.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/recommendation/WideAndDeep.scala
@@ -77,7 +77,7 @@ case class ColumnFeatureInfo(wideBaseCols: Array[String] = Array[String](),
  *                       Default is Array(40, 20, 10).
  * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now.
  */
-class WideAndDeep[T: ClassTag] private(
+class WideAndDeep[T: ClassTag] (
     val modelType: String = "wide_n_deep",
     val numClasses: Int,
     val wideBaseDims: Array[Int] = Array[Int](),


### PR DESCRIPTION
Changed Recommender models(NCF and WideAndDeep) from private to public.

Currently, features of recommender models are well fixed according to the papers and blogs, customers might want to add different features in different formats. For example, NCF only uses userId and itemId as features, but jobs2career wants to have features of vectors. 
https://github.com/intel-analytics/Jobs2Careers/blob/master/src/main/scala/com/intel/analytics/bigdl/apps/recommendation/NCFJob2Career.scala

Public NCF/WideAndDeep gives customers flexibility to build different recommender models with different features.