### PR TITLE
Fix textclassification example running on cluster

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/WordEmbedding.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/WordEmbedding.scala
@@ -291,7 +291,7 @@ object WordEmbedding {
         require(len != 0, "weight length should not be zero," +
           "please set logging level to debug for more information")
         val w = new Array[Byte](len)
-        timing("reading graph def from stream") {
+        timing("reading weight from stream") {
           var numOfBytes = 0
           while (numOfBytes < len) {
             val read = in.read(w, numOfBytes, len - numOfBytes)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/WordEmbedding.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/WordEmbedding.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.zoo.pipeline.api.keras.layers
 
-import java.io._
+import java.io.File
 import java.util.concurrent.atomic.AtomicInteger
 
 import com.intel.analytics.bigdl.nn.Identity
@@ -26,7 +26,6 @@ import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.Shape
 import com.intel.analytics.zoo.pipeline.api.keras.layers.WordEmbedding.EmbeddingMatrixHolder
 import com.intel.analytics.zoo.pipeline.api.net.{NetUtils, RegistryMap, SerializationHolder}
-import org.apache.commons.lang.SerializationUtils
 import org.slf4j.LoggerFactory
 
 import scala.collection.mutable.{Map => MMap}


### PR DESCRIPTION
Not sure why previous `SerializationUtils.deserialize(weight)` will throw exception:
```
Caused by: org.apache.commons.lang.SerializationException: java.lang.ClassNotFoundException: com.intel.analytics.bigdl.tensor.DenseTensor$mcF$sp
	at org.apache.commons.lang.SerializationUtils.deserialize(SerializationUtils.java:166)
	at org.apache.commons.lang.SerializationUtils.deserialize(SerializationUtils.java:193)
	at com.intel.analytics.zoo.pipeline.api.keras.layers.WordEmbedding$EmbeddingMatrixHolder$$anonfun$5.apply(WordEmbedding.scala:295)
	at com.intel.analytics.zoo.pipeline.api.keras.layers.WordEmbedding$EmbeddingMatrixHolder$$anonfun$5.apply(WordEmbedding.scala:283)
	at com.intel.analytics.zoo.pipeline.api.net.RegistryMap.getOrCreate(NetUtils.scala:386)
	at com.intel.analytics.zoo.pipeline.api.keras.layers.WordEmbedding$EmbeddingMatrixHolder.readInternal(WordEmbedding.scala:283)
	at com.intel.analytics.zoo.pipeline.api.net.SerializationHolder.readObject(NetUtils.scala:324)
```

Just try not to use this for serialization as a fix...