### PR TITLE
Fix LossFunction updateOutput

### DIFF
--- a/pyzoo/zoo/pipeline/api/keras/objectives.py
+++ b/pyzoo/zoo/pipeline/api/keras/objectives.py
@@ -70,6 +70,7 @@ class SparseCategoricalCrossEntropy(LossFunction):
 
     >>> loss = SparseCategoricalCrossEntropy()
     creating: createZooKerasSparseCategoricalCrossEntropy
+    >>> import numpy as np
     >>> np.random.seed(1128)
     >>> weights = np.random.uniform(0, 1, (2,)).astype("float32")
     >>> loss = SparseCategoricalCrossEntropy(weights=weights)

--- a/pyzoo/zoo/pipeline/api/keras/objectives.py
+++ b/pyzoo/zoo/pipeline/api/keras/objectives.py
@@ -68,7 +68,11 @@ class SparseCategoricalCrossEntropy(LossFunction):
                    return zero output and the backward process will also return
                    zero grad_input. Default is -1.
 
-    >>> metrics = SparseCategoricalCrossEntropy()
+    >>> loss = SparseCategoricalCrossEntropy()
+    creating: createZooKerasSparseCategoricalCrossEntropy
+    >>> np.random.seed(1128)
+    >>> weights = np.random.uniform(0, 1, (2,)).astype("float32")
+    >>> loss = SparseCategoricalCrossEntropy(weights=weights)
     creating: createZooKerasSparseCategoricalCrossEntropy
     """
     def __init__(self, log_prob_as_input=False, zero_based_label=True,
@@ -91,7 +95,7 @@ class MeanAbsoluteError(LossFunction):
               mini-batch. Default is True. If False, the losses are instead
               summed for each mini-batch.
 
-    >>> metrics = MeanAbsoluteError()
+    >>> loss = MeanAbsoluteError()
     creating: createZooKerasMeanAbsoluteError
     """
     def __init__(self, size_average=True, bigdl_type="float"):

--- a/pyzoo/zoo/pipeline/api/keras/objectives.py
+++ b/pyzoo/zoo/pipeline/api/keras/objectives.py
@@ -59,7 +59,7 @@ class SparseCategoricalCrossEntropy(LossFunction):
                        as input. Default is False and inputs should be probabilities.
     zero_based_label: Boolean. Whether target labels start from 0. Default is True.
                       If False, labels start from 1.
-    weights: Weights of each class if you have an unbalanced training set.
+    weights: A Numpy array. Weights of each class if you have an unbalanced training set.
     size_average: Boolean. Whether losses are averaged over observations for each
                   mini-batch. Default is True. If False, the losses are instead
                   summed for each mini-batch.

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/objectives/LossFunction.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/objectives/LossFunction.scala
@@ -35,14 +35,12 @@ abstract class LossFunction[A <: Activity: ClassTag, B <: Activity: ClassTag, T:
   protected val loss: AbstractCriterion[A, B, T]
 
   override def updateOutput(input: A, target: B): T = {
-    loss.updateOutput(input, target)
-    output = loss.output
+    output = loss.updateOutput(input, target)
     output
   }
 
   def updateGradInput(input: A, target: B): A = {
-    loss.updateGradInput(input, target)
-    gradInput = loss.gradInput
+    gradInput = loss.updateGradInput(input, target)
     gradInput
   }
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/objectives/SparseCategoricalCrossEntropy.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/objectives/SparseCategoricalCrossEntropy.scala
@@ -19,7 +19,7 @@ package com.intel.analytics.zoo.pipeline.api.keras.objectives
 import com.intel.analytics.bigdl.nn.abstractnn.TensorCriterion
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
-import com.intel.analytics.bigdl.nn.{ClassNLLCriterion => BigDLClassNLLCriterion}
+import com.intel.analytics.bigdl.nn.ClassNLLCriterion
 
 import scala.reflect.ClassTag
 
@@ -34,14 +34,15 @@ import scala.reflect.ClassTag
  *                       as input. Default is false and inputs should be probabilities.
  * @param zeroBasedLabel Boolean. Whether target labels start from 0. Default is true.
  *                       If false, labels start from 1.
- * @param weights Weights of each class if you have an unbalanced training set.
+ * @param weights Tensor. Weights of each class if you have an unbalanced training set.
+ *                Default is null.
  * @param sizeAverage Boolean. Whether losses are averaged over observations for each
  *                    mini-batch. Default is true. If false, the losses are instead
  *                    summed for each mini-batch.
  * @param paddingValue Integer. If the target is set to this value, the training process
  *                     will skip this sample. In other words, the forward process will
  *                     return zero output and the backward process will also return
- *                     zero gradInput. Default is 1.
+ *                     zero gradInput. Default is -1.
  */
 class SparseCategoricalCrossEntropy[T: ClassTag](
     val logProbAsInput: Boolean = false,
@@ -52,7 +53,7 @@ class SparseCategoricalCrossEntropy[T: ClassTag](
   extends TensorLossFunction[T] {
 
   override val loss: TensorCriterion[T] =
-    BigDLClassNLLCriterion[T](weights, sizeAverage, logProbAsInput, paddingValue)
+    ClassNLLCriterion[T](weights, sizeAverage, logProbAsInput, paddingValue)
 
   private val targetBuffer: Tensor[T] = Tensor[T]()
 
@@ -60,12 +61,10 @@ class SparseCategoricalCrossEntropy[T: ClassTag](
     if (zeroBasedLabel) {
       targetBuffer.resizeAs(target)
       targetBuffer.fill(ev.one).add(target)
-      output = loss.updateOutput(input, targetBuffer)
-      output
+      super.updateOutput(input, targetBuffer)
     }
     else {
-      output = loss.updateOutput(input, target)
-      output
+      super.updateOutput(input, target)
     }
   }
 
@@ -73,12 +72,10 @@ class SparseCategoricalCrossEntropy[T: ClassTag](
     if (zeroBasedLabel) {
       targetBuffer.resizeAs(target)
       targetBuffer.fill(ev.one).add(target)
-      gradInput = loss.updateGradInput(input, targetBuffer)
-      gradInput
+      super.updateGradInput(input, targetBuffer)
     }
     else {
-      gradInput = loss.updateGradInput(input, target)
-      gradInput
+      super.updateGradInput(input, target)
     }
   }
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/python/PythonZooKeras.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/python/PythonZooKeras.scala
@@ -1126,10 +1126,11 @@ class PythonZooKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonB
   def createZooKerasSparseCategoricalCrossEntropy(
       logProbAsInput: Boolean = false,
       zeroBasedLabel: Boolean = true,
-      weights: Tensor[T] = null,
+      weights: JTensor = null,
       sizeAverage: Boolean = true,
       paddingValue: Int = -1): SparseCategoricalCrossEntropy[T] = {
-    SparseCategoricalCrossEntropy(logProbAsInput, zeroBasedLabel, weights,
+    SparseCategoricalCrossEntropy(logProbAsInput, zeroBasedLabel,
+      if (weights == null) null else toTensor(weights),
       sizeAverage, paddingValue)
   }
 


### PR DESCRIPTION
Due to the inconsistency of implementations of criterions in BigDL, directly assign the value of `updateOutput` to output in LossFunction instead of getting `loss.output`