### PR TITLE
bytes array to imageset

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageSet.scala
@@ -126,11 +126,29 @@ object ImageSet {
   }
 
   /**
+   * create LocalImageSet from array of bytes
+   * @param data nested array of bytes, expect inner array is a image
+   */
+  def array(data: Array[Array[Byte]]): LocalImageSet = {
+    val images = data.map(ImageFeature(_))
+    ImageSet.array(images)
+  }
+
+  /**
    * create DistributedImageSet
    * @param data rdd of ImageFeature
    */
   def rdd(data: RDD[ImageFeature]): DistributedImageSet = {
     new DistributedImageSet(data)
+  }
+
+  /**
+   * create DistributedImageSet for a RDD of array bytes
+   * @param data rdd of array of bytes
+   */
+  def rddBytes(data: RDD[Array[Byte]]): DistributedImageSet = {
+    val images = data.map(ImageFeature(_))
+    ImageSet.rdd(images)
   }
 
   /**

--- a/zoo/src/test/scala/com/intel/analytics/zoo/feature/FeatureSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/feature/FeatureSpec.scala
@@ -15,14 +15,13 @@
  */
 package com.intel.analytics.zoo.feature
 
-import com.intel.analytics.zoo.common.NNContext
+import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
+import com.intel.analytics.zoo.common.{NNContext, Utils}
 import com.intel.analytics.zoo.feature.common.{BigDLAdapter, Preprocessing}
 import com.intel.analytics.zoo.feature.image.{ImageBytesToMat, ImageResize, ImageSet}
-
+import org.apache.commons.io.FileUtils
 import org.apache.spark.{SparkConf, SparkContext}
-
 import org.opencv.imgcodecs.Imgcodecs
-
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 
@@ -58,6 +57,22 @@ class FeatureSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val imf = image.toDistributed().rdd.collect().head
     require(imf.getHeight() == 200)
     require(imf.getWidth() == 200)
+  }
+
+  "Local ImageSet" should "work with bytes" in {
+    val files = Utils.listLocalFiles(resource.getFile)
+    val bytes = files.map { p =>
+      FileUtils.readFileToByteArray(p)
+    }
+    ImageSet.array(bytes)
+  }
+
+  "Distribute ImageSet" should "work with bytes" in {
+    val data = sc.binaryFiles(resource.getFile).map { case (p, stream) =>
+      stream.toArray()
+    }
+    val images = ImageSet.rddBytes(data)
+    images.rdd.collect()
   }
 
   "ImageBytesToMat" should "work with png and jpg" in {


### PR DESCRIPTION
Support imageset constructor accepts array[Bytes] (or RDD of array bytes)

Fix https://github.com/intel-analytics/zoo/issues/354#event-1771881130