### PR TITLE
remove unnecessary require in Reshape

### DIFF
--- a/pyzoo/test/zoo/pipeline/api/keras/test_layer.py
+++ b/pyzoo/test/zoo/pipeline/api/keras/test_layer.py
@@ -190,7 +190,7 @@ class TestLayer(ZooTestCase):
 
     def test_reshape(self):
         a = np.random.random((2, 2, 3, 4))
-        i1 = ZLayer.Input(shape = (2, 3, 4))
+        i1 = ZLayer.Input(shape=(2, 3, 4))
         s = ZLayer.Reshape((-1, 2, 12))(i1)
         m = ZModel.Model(i1, s)
         # predict should not generate exception

--- a/pyzoo/test/zoo/pipeline/api/keras/test_layer.py
+++ b/pyzoo/test/zoo/pipeline/api/keras/test_layer.py
@@ -188,6 +188,14 @@ class TestLayer(ZooTestCase):
         input_data = [np.random.random([2, 10]), np.random.random([2, 10])]
         self.compare_layer(kmodel, zmodel, input_data, self.convert_two_dense)
 
+    def test_reshape(self):
+        a = np.random.random((2, 2, 3, 4))
+        i1 = ZLayer.Input(shape = (2, 3, 4))
+        s = ZLayer.Reshape((-1, 2, 12))(i1)
+        m = ZModel.Model(i1, s)
+        # predict should not generate exception
+        y = m.predict(a, distributed=False)
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/pyzoo/test/zoo/pipeline/api/keras/test_layer.py
+++ b/pyzoo/test/zoo/pipeline/api/keras/test_layer.py
@@ -192,7 +192,7 @@ class TestLayer(ZooTestCase):
         a = np.random.random((2, 2, 3, 4))
         i1 = ZLayer.Input(shape=(2, 3, 4))
         s = ZLayer.Reshape((-1, 2, 12))(i1)
-        m = ZModel.Model(i1, s)
+        m = ZModel(i1, s)
         # predict should not generate exception
         y = m.predict(a, distributed=False)
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/Reshape.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/Reshape.scala
@@ -75,8 +75,8 @@ class Reshape[T: ClassTag](
     if (infer) {
       val nElements = nonBatchInput.product
       val resizeElements = - targetShape.product
-      require(nElements > resizeElements && nElements % resizeElements == 0,
-        "Total size after reshape must be unchanged")
+      require(nElements % resizeElements == 0, s"Total size after reshape must be unchanged." +
+          s" inputShape: $inputShape, targetShape: ${targetShape.mkString(", ")}")
       targetShape(inferIndex) = nElements / resizeElements
     }
     else {


### PR DESCRIPTION
nonBatchInput could contain -1 in it and breaks the require constraint. The following code (same as in unit test) fails with the original code

```
from zoo.pipeline.api.keras.layers import *
from zoo.pipeline.api.keras.models import Model
from zoo.common.nncontext import *
import numpy as np

sparkConf = create_spark_conf().setMaster("local[1]").setAppName("testNNClassifer")
sc = init_nncontext(sparkConf)

a = np.random.random((2, 2, 3, 4))
i1 = Input(shape = (2, 3, 4))
s = Reshape((-1, 2, 12))(i1)
m = Model(i1, s)
y = m.predict(a, distributed=False)
print(y)
```





