### PR TITLE
fix a error caused by force yes

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,7 @@ ENV JAVA_HOME                           /opt/jdk
 ENV PATH                                ${JAVA_HOME}/bin:${PATH}
 
 RUN apt-get update && \
-    apt-get install -y vim curl nano wget unzip maven git
+    apt-get install -y --force-yes vim curl nano wget unzip maven git
 #java
 RUN wget http://ftp.osuosl.org/pub/funtoo/distfiles/oracle-java/jdk-8u152-linux-x64.tar.gz && \
     gunzip jdk-8u152-linux-x64.tar.gz && \
@@ -50,10 +50,10 @@ RUN wget http://ftp.osuosl.org/pub/funtoo/distfiles/oracle-java/jdk-8u152-linux-
     rm jdk-8u152-linux-x64.tar && \
     ln -s /opt/jdk1.8.0_152 /opt/jdk
 #python
-RUN apt-get install -y software-properties-common python-software-properties python-pkg-resources && \
+RUN apt-get install -y --force-yes software-properties-common python-software-properties python-pkg-resources && \
     add-apt-repository -y ppa:jonathonf/python-2.7 && \
     apt-get update && \
-    apt-get install -y build-essential python python-setuptools python-dev && \
+    apt-get install -y --force-yes build-essential python python-setuptools python-dev && \
     wget https://bootstrap.pypa.io/get-pip.py && \
     python2 get-pip.py && \
     pip2 install --upgrade setuptools && \


### PR DESCRIPTION
fix a error:
http://10.239.47.211:18888/job/ZOO-NB-Deploy-Docker/21/console

[91mE: There are problems and -y was used without --force-yes
[0mThe command '/bin/sh -c apt-get install -y software-properties-common python-software-properties python-pkg-resources &&     add-apt-repository -y ppa:jonathonf/python-2.7 &&     apt-get update &&     apt-get install -y build-essential python python-setuptools python-dev &&     wget https://bootstrap.pypa.io/get-pip.py &&     python2 get-pip.py &&     pip2 install --upgrade setuptools &&     pip2 install numpy scipy pandas scikit-learn matplotlib seaborn jupyter wordcloud moviepy requests opencv-python tensorflow &&     python2 -m pip install ipykernel &&     python2 -m ipykernel install --user' returned a non-zero code: 100

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-analytics/analytics-zoo/618)
<!-- Reviewable:end -->
