### PR TITLE
Add get_uri to Python Imageset API.

### DIFF
--- a/pyzoo/test/zoo/feature/image/test_image_set.py
+++ b/pyzoo/test/zoo/feature/image/test_image_set.py
@@ -56,6 +56,14 @@ class Test_Image_Set():
         image_set = ImageSet.read(self.image_path)
         image_set.get_label()
 
+    def test_get_uri_local(self):
+        image_set = ImageSet.read(self.image_path)
+        image_set.get_uri()
+
+    def test_get_uri_distributed(self):
+        image_set = ImageSet.read(self.image_path, self.sc)
+        image_set.get_uri().collect()
+
     def test_is_local(self):
         image_set = ImageSet.read(self.image_path)
         assert image_set.is_local() is True

--- a/pyzoo/zoo/feature/image/imageset.py
+++ b/pyzoo/zoo/feature/image/imageset.py
@@ -93,6 +93,13 @@ class ImageSet(JavaValue):
         """
         return self.image_set.get_predict(key)
 
+    def get_uri(self):
+        """
+        get image URIs from ImageSet
+        :return list (or RDD for DistributedImageSet) of URI String
+        """
+        return self.image_set.get_uri()
+
     def to_image_frame(self, bigdl_type="float"):
         return callBigDlFunc(bigdl_type, "imageSetToImageFrame", self.value)
 
@@ -139,6 +146,14 @@ class LocalImageSet(ImageSet):
                         (predict[0], list(map(lambda x: x.to_ndarray(), predict[1]))) if predict[1]
                         else (predict[0], None), predicts))
 
+    def get_uri(self):
+        """
+        get image URIs from ImageSet
+        :return list of URI String
+        """
+        uris = callBigDlFunc(self.bigdl_type, "localImageSetToUri", self.value)
+        return uris
+
 
 class DistributedImageSet(ImageSet):
     """
@@ -184,3 +199,11 @@ class DistributedImageSet(ImageSet):
                             (predict[0],
                              list(map(lambda x: x.to_ndarray(), predict[1]))) if predict[1]
                             else (predict[0], None))
+
+    def get_uri(self):
+        """
+        get image URIs from ImageSet
+        :return RDD of URI String
+        """
+        uris = callBigDlFunc(self.bigdl_type, "distributedImageSetToUri", self.value)
+        return uris

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/python/PythonImageFeature.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/python/PythonImageFeature.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.zoo.feature.python
 
-import java.util.{List => JList, Map => JMap}
+import java.util.{List => JList}
 
 import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
 import com.intel.analytics.bigdl.python.api.{JTensor, PythonBigDL}

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/python/PythonImageFeature.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/python/PythonImageFeature.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.zoo.feature.python
 
-import java.util.{List => JList}
+import java.util.{List => JList, Map => JMap}
 
 import com.intel.analytics.bigdl.nn.abstractnn.DataFormat
 import com.intel.analytics.bigdl.python.api.{JTensor, PythonBigDL}
@@ -72,6 +72,12 @@ class PythonImageFeature[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pyt
     imageSet.array.map(x => imageSetToPredict(x, key)).toList.asJava
   }
 
+  def localImageSetToUri(imageSet: LocalImageSet): JList[String] = {
+    imageSet.array.map { imf =>
+      imf.uri()
+    }.toList.asJava
+  }
+
   def distributedImageSetToImageTensorRdd(imageSet: DistributedImageSet,
     floatKey: String = ImageFeature.floats, toChw: Boolean = true): JavaRDD[JTensor] = {
     imageSet.rdd.map(imageFeatureToImageTensor(_, floatKey, toChw)).toJavaRDD()
@@ -84,6 +90,12 @@ class PythonImageFeature[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pyt
   def distributedImageSetToPredict(imageSet: DistributedImageSet, key: String)
   : JavaRDD[JList[Any]] = {
     imageSet.rdd.map(x => imageSetToPredict(x, key))
+  }
+
+  def distributedImageSetToUri(imageSet: DistributedImageSet): JavaRDD[String] = {
+    imageSet.rdd.map { imf =>
+      imf.uri()
+    }.toJavaRDD()
   }
 
   private def imageSetToPredict(imf: ImageFeature, key: String): JList[Any] = {


### PR DESCRIPTION
Enable users to map the image, label, predict to URI, this will further allow setting labels to Images.