### PR TITLE
Imageset.read with resize keep the same channel with original image

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/BufferedImageResize.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/BufferedImageResize.scala
@@ -37,8 +37,8 @@ class BufferedImageResize(resizeH: Int, resizeW: Int) extends ImageProcessing {
           img.getScaledInstance(resizeW, resizeH, java.awt.Image.SCALE_SMOOTH)
 
         val imageBuff: BufferedImage =
-          new BufferedImage(resizeW, resizeH, BufferedImage.TYPE_3BYTE_BGR)
-        imageBuff.getGraphics.drawImage(scaledImage, 0, 0, new Color(0, 0, 0), null)
+                  new BufferedImage(resizeW, resizeH, img.getType)
+        imageBuff.getGraphics().drawImage(scaledImage, 0, 0, null)
 
         val output = new ByteArrayOutputStream()
         val uri = imf[String](ImageFeature.uri)

--- a/zoo/src/test/scala/com/intel/analytics/zoo/feature/FeatureSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/feature/FeatureSpec.scala
@@ -15,7 +15,6 @@
  */
 package com.intel.analytics.zoo.feature
 
-import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
 import com.intel.analytics.zoo.common.{NNContext, Utils}
 import com.intel.analytics.zoo.feature.common.{BigDLAdapter, Preprocessing}
 import com.intel.analytics.zoo.feature.image.{ImageBytesToMat, ImageResize, ImageSet}
@@ -27,6 +26,7 @@ import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 class FeatureSpec extends FlatSpec with Matchers with BeforeAndAfter {
   val resource = getClass.getClassLoader.getResource("imagenet/n04370456/")
+  val gray = getClass.getClassLoader.getResource("gray")
   var sc : SparkContext = _
 
   before {
@@ -50,6 +50,13 @@ class FeatureSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val imf = image.toLocal().array.head
     require(imf.getHeight() == 200)
     require(imf.getWidth() == 200)
+    require(imf.getChannel() == 3)
+
+    val imageGray = ImageSet.read(gray.getFile, resizeH = 200, resizeW = 200)
+    val imfGray = imageGray.toLocal().array.head
+    require(imfGray.getHeight() == 200)
+    require(imfGray.getWidth() == 200)
+    require(imfGray.getChannel() == 1)
   }
 
   "Distribute ImageSet" should "work with resize" in {
@@ -57,6 +64,13 @@ class FeatureSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val imf = image.toDistributed().rdd.collect().head
     require(imf.getHeight() == 200)
     require(imf.getWidth() == 200)
+    require(imf.getChannel() == 3)
+
+    val imageGray = ImageSet.read(gray.getFile, sc, resizeH = 200, resizeW = 200)
+    val imfGray = imageGray.toDistributed().rdd.collect().head
+    require(imfGray.getHeight() == 200)
+    require(imfGray.getWidth() == 200)
+    require(imfGray.getChannel() == 1)
   }
 
   "Local ImageSet" should "work with bytes" in {


### PR DESCRIPTION
Bug fix for https://github.com/intel-analytics/zoo/issues/379