### PR TITLE
Add TextSet and update TextClassification examples

### DIFF
--- a/pyzoo/test/zoo/feature/text/test_text_set.py
+++ b/pyzoo/test/zoo/feature/text/test_text_set.py
@@ -1,0 +1,163 @@
+#
+# Copyright 2018 Analytics Zoo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from zoo.feature.common import ChainedPreprocessing
+from zoo.feature.text import *
+from zoo.common.nncontext import *
+from zoo.pipeline.api.keras.models import Sequential
+from zoo.pipeline.api.keras.layers import Embedding, Convolution1D, Flatten, Dense
+
+
+class TestTextSet:
+
+    def setup_method(self, method):
+        """ setup any state tied to the execution of the given method in a
+        class.  setup_method is invoked for every test method of a class.
+        """
+        self.sc = init_nncontext(init_spark_conf().setMaster("local[1]")
+                                 .setAppName("test text set"))
+        text1 = "Hello my friend, please annotate my text"
+        text2 = "hello world, this is some sentence for my test"
+        text3 = "another text for test"
+        self.texts = [text1, text2, text3]
+        self.labels = [0., 1, 1]
+        resource_path = os.path.join(os.path.split(__file__)[0], "../../resources")
+        self.path = os.path.join(resource_path, "news20")
+
+    def teardown_method(self, method):
+        """ teardown any state that was previously setup with a setup_method
+        call.
+        """
+        self.sc.stop()
+
+    @staticmethod
+    def _build_model(sequence_length):
+        model = Sequential()
+        model.add(Embedding(20, 10, input_length=sequence_length))
+        model.add(Convolution1D(4, 3))
+        model.add(Flatten())
+        model.add(Dense(5, activation="softmax"))
+        return model
+
+    def test_textset_without_label(self):
+        local_set = LocalTextSet(self.texts)
+        assert local_set.get_labels() == [-1, -1, -1]
+        distributed_set = DistributedTextSet(self.sc.parallelize(self.texts))
+        assert distributed_set.get_labels().collect() == [-1, -1, -1]
+
+    def test_textset_convertion(self):
+        local_set = LocalTextSet(self.texts, self.labels)
+        local1 = local_set.to_local()
+        distributed1 = local_set.to_distributed(self.sc)
+        assert local1.is_local()
+        assert distributed1.is_distributed()
+        assert local1.get_texts() == distributed1.get_texts().collect()
+
+        texts_rdd = self.sc.parallelize(self.texts)
+        labels_rdd = self.sc.parallelize(self.labels)
+        distributed_set = DistributedTextSet(texts_rdd, labels_rdd)
+        local2 = distributed_set.to_local()
+        distributed2 = distributed_set.to_distributed()
+        assert local2.is_local()
+        assert distributed2.is_distributed()
+        assert local2.get_texts() == distributed2.get_texts().collect()
+
+    def test_local_textset_integration(self):
+        local_set = LocalTextSet(self.texts, self.labels)
+        assert local_set.is_local()
+        assert not local_set.is_distributed()
+        assert local_set.get_texts() == self.texts
+        assert local_set.get_labels() == self.labels
+        tokenized = ChainedPreprocessing([Tokenizer(), Normalizer(), SequenceShaper(10)])(local_set)
+        word_index = tokenized.generate_word_index_map(max_words_num=10)
+        transformed = ChainedPreprocessing([WordIndexer(word_index),
+                                            TextFeatureToSample()])(tokenized)
+        assert transformed.is_local()
+        word_index = transformed.get_word_index()
+        assert len(word_index) == 10
+        assert word_index["my"] == 1
+        samples = transformed.get_samples()
+        assert len(samples) == 3
+        for sample in samples:
+            assert sample.feature.shape[0] == 10
+
+        model = TestTextSet._build_model(10)
+        model.compile("adagrad", "sparse_categorical_crossentropy", ['accuracy'])
+        model.fit(transformed, batch_size=2, nb_epoch=2, validation_data=transformed)
+        res_set = model.predict(transformed, batch_per_thread=2)
+        predicts = res_set.get_predicts()
+        for predict in predicts:
+            assert len(predict) == 1
+            assert predict[0].shape == (5, )
+        acc = model.evaluate(transformed, batch_size=2)
+
+    def test_distributed_textset_integration(self):
+        texts_rdd = self.sc.parallelize(self.texts)
+        labels_rdd = self.sc.parallelize(self.labels)
+        distributed_set = DistributedTextSet(texts_rdd, labels_rdd)
+        assert distributed_set.is_distributed()
+        assert not distributed_set.is_local()
+        assert distributed_set.get_texts().collect() == self.texts
+        assert distributed_set.get_labels().collect() == self.labels
+
+        sets = distributed_set.random_split([0.5, 0.5])
+        train_texts = sets[0].get_texts().collect()
+        test_texts = sets[1].get_texts().collect()
+        assert set(train_texts + test_texts) == set(self.texts)
+
+        tokenized = Tokenizer()(distributed_set)
+        transformed = tokenized.normalize().shape_sequence(5)\
+            .word2idx().generate_sample()
+        word_index = transformed.get_word_index()
+        assert len(word_index) == 10
+        samples = transformed.get_samples().collect()
+        assert len(samples) == 3
+        for sample in samples:
+            assert sample.feature.shape[0] == 5
+
+        model = TestTextSet._build_model(5)
+        model.compile("sgd", "sparse_categorical_crossentropy", metrics=['accuracy'])
+        model.fit(transformed, batch_size=2, nb_epoch=2)
+        res_set = model.predict(transformed, batch_per_thread=2)
+        predicts = res_set.get_predicts().collect()
+        for predict in predicts:
+            assert len(predict) == 1
+            assert predict[0].shape == (5, )
+        acc = model.evaluate(transformed, batch_size=2)
+
+    def test_read_local(self):
+        local_set = TextSet.read(self.path)
+        assert local_set.is_local()
+        assert not local_set.get_word_index()  # should be None
+        assert len(local_set.get_texts()) == 3
+        assert local_set.get_labels() == [0, 0, 1]
+        assert local_set.get_samples() == [None, None, None]
+        assert local_set.get_predicts() == [None, None, None]
+
+    def test_read_distributed(self):
+        distributed_set = TextSet.read(self.path, self.sc, 4)
+        assert distributed_set.is_distributed()
+        assert not distributed_set.get_word_index()
+        assert len(distributed_set.get_texts().collect()) == 3
+        assert sorted(distributed_set.get_labels().collect()) == [0, 0, 1]
+        assert distributed_set.get_samples().collect() == [None, None, None]
+        assert distributed_set.get_predicts().collect() == [None, None, None]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/pyzoo/test/zoo/resources/news20/alt.atheism/51158
+++ b/pyzoo/test/zoo/resources/news20/alt.atheism/51158
@@ -1,0 +1,15 @@
+Subject: So what is Maddi?
+From: madhaus@netcom.com (Maddi Hausmann)
+
+As I was created in the image of Gaea, therefore I must
+be the pinnacle of creation, She which Creates, She which
+Births, She which Continues.
+
+Or, to cut all the religious crap, I'm a woman, thanks.
+And it's sexism that started me on the road to atheism.
+
+-- 
+Maddi Hausmann                       madhaus@netcom.com
+Centigram Communications Corp        San Jose California  408/428-3553
+
+Kids, please don't try this at home.  Remember, I post professionally.

--- a/pyzoo/test/zoo/resources/news20/alt.atheism/51186
+++ b/pyzoo/test/zoo/resources/news20/alt.atheism/51186
@@ -1,0 +1,18 @@
+From: livesey@solntze.wpd.sgi.com (Jon Livesey)
+Subject: Re: An Anecdote about Islam
+
+In article <114127@bu.edu>, jaeger@buphy.bu.edu (Gregg Jaeger) writes:
+|> 
+|> I don't understand the point of this petty sarcasm. It is a basic 
+|> principle of Islam that if one is born muslim or one says "I testify
+|> that there is no god but God and Mohammad is a prophet of God" that,
+|> so long as one does not explicitly reject Islam by word then one _must_
+|> be considered muslim by all muslims. So the phenomenon you're attempting
+|> to make into a general rule or psychology is a direct odds with basic
+|> Islamic principles. If you want to attack Islam you could do better than
+|> than to argue against something that Islam explicitly contradicts.
+
+Then Mr Mozumder is incorrect when he says that when committing
+bad acts, people temporarily become atheists?
+
+jon.

--- a/pyzoo/test/zoo/resources/news20/rec.autos/101556
+++ b/pyzoo/test/zoo/resources/news20/rec.autos/101556
@@ -1,0 +1,15 @@
+From: reb@hprnd.rose.hp.com (Ralph Bean)
+Subject: Re: saturn pricing blatherings
+
+Mihir Pramod Shah (mps1@cec1.wustl.edu) wrote:
+: Robert J. Wade writes:
+: > until...and more Saturn retailers are built(like 2 in the same city), 
+:                        		     ^^^^^^^^^^^^^^^^^^^^^^^
+: ...most medium and large cities have...a small handful of Saturn dealers now
+
+Sacramento has two Saturn dealerships.
+
+: Mihir Shah
+
+Ralph Bean
+hprnd.rose.hp.com

--- a/pyzoo/zoo/examples/run-example-tests.sh
+++ b/pyzoo/zoo/examples/run-example-tests.sh
@@ -53,15 +53,16 @@ fi
 
 ${SPARK_HOME}/bin/spark-submit \
     --master ${MASTER} \
-    --driver-memory 20g \
-    --executor-memory 20g \
+    --driver-memory 2g \
+    --executor-memory 2g \
     --py-files ${ANALYTICS_ZOO_PYZIP},${ANALYTICS_ZOO_ROOT}/pyzoo/zoo/examples/textclassification/text_classification.py \
     --jars ${ANALYTICS_ZOO_JAR} \
     --conf spark.driver.extraClassPath=${ANALYTICS_ZOO_JAR} \
     --conf spark.executor.extraClassPath=${ANALYTICS_ZOO_JAR} \
     ${ANALYTICS_ZOO_ROOT}/pyzoo/zoo/examples/textclassification/text_classification.py \
     --nb_epoch 2 \
-    --data_path analytics-zoo-data/data
+    --data_path analytics-zoo-data/data/20news-18828 \
+    --embedding_path analytics-zoo-data/data/glove.6B
 
 
 now=$(date "+%s")
@@ -116,7 +117,6 @@ ${SPARK_HOME}/bin/spark-submit \
     analytics-zoo-models/analytics-zoo_ssd-mobilenet-300x300_PASCAL_0.1.0.model hdfs://172.168.2.181:9000/kaggle/train_100 /tmp
 now=$(date "+%s")
 time4=$((now-start))
-
 
 
 echo "#1 textclassification time used:$time1 seconds"

--- a/pyzoo/zoo/examples/textclassification/README.md
+++ b/pyzoo/zoo/examples/textclassification/README.md
@@ -18,9 +18,9 @@ The data used in this example are:
 - [20 Newsgroup dataset](http://qwone.com/~jason/20Newsgroups/20news-18828.tar.gz) which contains 20 categories and with 18828 texts in total.
 - [GloVe word embeddings](http://nlp.stanford.edu/data/glove.6B.zip): embeddings of 400k words pre-trained on a 2014 dump of English Wikipedia.
 
-You need to download and extract the data by yourself beforehand.
+You need to prepare the data by yourself beforehand.
 
-The following scripts we prepare will serve to download and extract the data for you:
+The following scripts we provide will serve to download and extract the data for you:
 ```bash
 bash ${ANALYTICS_ZOO_HOME}/bin/data/news20/get_news20.sh dir
 bash ${ANALYTICS_ZOO_HOME}/bin/data/glove/get_glove.sh dir
@@ -34,7 +34,7 @@ Remarks:
 You can easily use the following commands to run this example:
 ```bash
 export SPARK_DRIVER_MEMORY=2g
-news20_path=the directory containing the News20 data
+news20_path=the directory containing News20 dataset
 glove_path=the directory containing GloVe embeddings
 
 python text_classification.py --data_path ${news20_path} --embedding_path ${glove_path}
@@ -51,7 +51,7 @@ Run the following command for Spark local mode (`MASTER=local[*]`) or cluster mo
 export SPARK_HOME=the root directory of Spark
 export ANALYTICS_ZOO_HOME=the folder where you extract the downloaded Analytics Zoo zip package
 MASTER=...
-news20_path=the directory containing the News20 data
+news20_path=the directory containing News20 dataset
 glove_path=the directory containing GloVe embeddings
 
 ${ANALYTICS_ZOO_HOME}/bin/spark-submit-with-zoo.sh \

--- a/pyzoo/zoo/examples/textclassification/README.md
+++ b/pyzoo/zoo/examples/textclassification/README.md
@@ -66,8 +66,8 @@ See [here](https://analytics-zoo.github.io/master/#PythonUserGuide/run/#run-with
 
 
 ## Options
-* `--data_path` This option is __required__. The path where the News20 dataset locate.
-* `--embedding_path` This option is __required__. The path where the GloVe embeddings locate.
+* `--data_path` This option is __required__. The path where News20 dataset locate.
+* `--embedding_path` This option is __required__. The path where GloVe embeddings locate.
 * `--class_num` The number of classes to do classification. Default is 20 for News20 dataset.
 * `--partition_num` The number of partitions to cut the dataset into. Default is 4.
 * `--token_length` The size of each word vector. GloVe supports token_length 50, 100, 200 and 300. Default is 200.

--- a/pyzoo/zoo/examples/textclassification/README.md
+++ b/pyzoo/zoo/examples/textclassification/README.md
@@ -15,17 +15,17 @@ Follow the instructions [here](https://analytics-zoo.github.io/master/#PythonUse
 
 ## Data Preparation
 The data used in this example are:
-- [20 Newsgroup dataset](http://qwone.com/~jason/20Newsgroups/20news-18828.tar.gz) which contains 20 categories and with 19997 texts in total.
+- [20 Newsgroup dataset](http://qwone.com/~jason/20Newsgroups/20news-18828.tar.gz) which contains 20 categories and with 18828 texts in total.
 - [GloVe word embeddings](http://nlp.stanford.edu/data/glove.6B.zip): embeddings of 400k words pre-trained on a 2014 dump of English Wikipedia.
 
 Executing this example will automatically download and extract the data for you during the first run if no data has been detected in the target path.
 
-You can also choose to prepare the data by yourself beforehand. The following scripts we prepare will serve to download and extract the data:
+You can also choose to prepare the data by yourself beforehand. The following scripts we prepare will serve to download and extract the data for you:
 ```bash
 bash ${ANALYTICS_ZOO_HOME}/bin/data/news20/get_news20.sh dir
 bash ${ANALYTICS_ZOO_HOME}/bin/data/glove/get_glove.sh dir
 ```
-where `ANALYTICS_ZOO_HOME` is the folder where you extract the downloaded package and `dir` is the directory you wish to locate the downloaded data. If `dir` is not specified, the data will be downloaded to the current working directory. 20 Newsgroup dataset and GloVe word embeddings are supposed to be placed under the same directory.
+where `ANALYTICS_ZOO_HOME` is the folder where you extract the downloaded package and `dir` is the directory you wish to locate the downloaded data. If `dir` is not specified, the data will be downloaded to the current working directory. 20 Newsgroup dataset and GloVe word embeddings are supposed to be placed under the same directory specified in `--data_path`.
 
 The data folder structure after extraction should look like the following:
 ```
@@ -67,18 +67,18 @@ See [here](https://analytics-zoo.github.io/master/#PythonUserGuide/run/#run-with
 
 
 ## Options
-* `--data_path` The path where the training and word2Vec data locate. Default is `/tmp/text_data`. Make sure that you have write permission to the specified path if you want the program to automatically download the data for you.
+* `--data_path` The path where the News20 and GloVe data locate. Default is `/tmp/text_data`. Make sure that you have write permission to the specified path if you want the program to automatically download the data for you.
 * `--partition_num` The number of partitions to cut the dataset into. Default is 4.
 * `--token_length` The size of each word vector. GloVe supports token_length 50, 100, 200 and 300. Default is 200.
 * `--sequence_length` The length of a sequence. Default is 500.
-* `--max_words_num` The maximum number of words. Default is 5000.
+* `--max_words_num` The maximum number of words sorted by frequencies to be taken into consideration. Default is 5000.
 * `--encoder` The encoder for the input sequence. String, 'cnn' or 'lstm' or 'gru'. Default is 'cnn'.
 * `--encoder_output_dim` The output dimension of the encoder. Default is 256.
 * `--training_split` The split portion of the data for training. Default is 0.8.
 * `-b` `--batch_size` The number of samples per gradient update. Default is 128.
 * `--nb_epoch` The number of iterations to train the model. Default is 20.
 * `-l` `--learning_rate` The learning rate for the TextClassifier model. Default is 0.01.
-* `--log_dir` The path to store training and validation summary. Default is `/tmp/.bigdl`.
+* `--log_dir` The path to store training and validation summary. Default is `/tmp/.analytics-zoo`.
 * `--model` Specify this option only if you want to load an existing TextClassifier model and in this case its path should be provided.
 
 

--- a/pyzoo/zoo/examples/textclassification/README.md
+++ b/pyzoo/zoo/examples/textclassification/README.md
@@ -18,29 +18,26 @@ The data used in this example are:
 - [20 Newsgroup dataset](http://qwone.com/~jason/20Newsgroups/20news-18828.tar.gz) which contains 20 categories and with 18828 texts in total.
 - [GloVe word embeddings](http://nlp.stanford.edu/data/glove.6B.zip): embeddings of 400k words pre-trained on a 2014 dump of English Wikipedia.
 
-Executing this example will automatically download and extract the data for you during the first run if no data has been detected in the target path.
+You need to download and extract the data by yourself beforehand.
 
-You can also choose to prepare the data by yourself beforehand. The following scripts we prepare will serve to download and extract the data for you:
+The following scripts we prepare will serve to download and extract the data for you:
 ```bash
 bash ${ANALYTICS_ZOO_HOME}/bin/data/news20/get_news20.sh dir
 bash ${ANALYTICS_ZOO_HOME}/bin/data/glove/get_glove.sh dir
 ```
-where `ANALYTICS_ZOO_HOME` is the folder where you extract the downloaded package and `dir` is the directory you wish to locate the downloaded data. If `dir` is not specified, the data will be downloaded to the current working directory. 20 Newsgroup dataset and GloVe word embeddings are supposed to be placed under the same directory specified in `--data_path`.
-
-The data folder structure after extraction should look like the following:
-```
-/tmp/text_data$ tree .
-    .
-    ├── 20news-18828
-    └── glove.6B
-```
+Remarks:
+- `ANALYTICS_ZOO_HOME` is the folder where you extract the downloaded package and `dir` is the directory you wish to locate the corresponding downloaded data.
+- If `dir` is not specified, the data will be downloaded to the current working directory.
 
 
 ## Run after pip install
 You can easily use the following commands to run this example:
 ```bash
 export SPARK_DRIVER_MEMORY=2g
-python text_classification.py --data_path /tmp/data
+news20_path=the directory containing the News20 data
+glove_path=the directory containing GloVe embeddings
+
+python text_classification.py --data_path ${news20_path} --embedding_path ${glove_path}
 ```
 See [here](#options) for more configurable options for this example.
 
@@ -54,12 +51,14 @@ Run the following command for Spark local mode (`MASTER=local[*]`) or cluster mo
 export SPARK_HOME=the root directory of Spark
 export ANALYTICS_ZOO_HOME=the folder where you extract the downloaded Analytics Zoo zip package
 MASTER=...
+news20_path=the directory containing the News20 data
+glove_path=the directory containing GloVe embeddings
 
 ${ANALYTICS_ZOO_HOME}/bin/spark-submit-with-zoo.sh \
     --master ${MASTER} \
     --driver-memory 2g \
     --executor-memory 2g \
-    text_classification.py --data_path /tmp/text_data
+    text_classification.py --data_path ${news20_path} --embedding_path ${glove_path}
 ```
 See [here](#options) for more configurable options for this example.
 
@@ -67,7 +66,9 @@ See [here](https://analytics-zoo.github.io/master/#PythonUserGuide/run/#run-with
 
 
 ## Options
-* `--data_path` The path where the News20 and GloVe data locate. Default is `/tmp/text_data`. Make sure that you have write permission to the specified path if you want the program to automatically download the data for you.
+* `--data_path` This option is __required__. The path where the News20 dataset locate.
+* `--embedding_path` This option is __required__. The path where the GloVe embeddings locate.
+* `--class_num` The number of classes to do classification. Default is 20 for News20 dataset.
 * `--partition_num` The number of partitions to cut the dataset into. Default is 4.
 * `--token_length` The size of each word vector. GloVe supports token_length 50, 100, 200 and 300. Default is 200.
 * `--sequence_length` The length of a sequence. Default is 500.

--- a/pyzoo/zoo/examples/textclassification/text_classification.py
+++ b/pyzoo/zoo/examples/textclassification/text_classification.py
@@ -14,45 +14,20 @@
 # limitations under the License.
 #
 
-import re
 import datetime as dt
 from optparse import OptionParser
 
 from bigdl.optim.optimizer import *
 from zoo.common.nncontext import init_nncontext
-from zoo.examples.textclassification.news20 import get_news20
+from zoo.feature.text import TextSet
 from zoo.models.textclassification import TextClassifier
-from zoo.pipeline.api.keras.objectives import SparseCategoricalCrossEntropy
-from zoo.pipeline.api.keras.metrics import Accuracy
-
-
-def text_to_words(review_text):
-    letters_only = re.sub("[^a-zA-Z]", " ", review_text)
-    words = letters_only.lower().split()
-    return words
-
-
-def analyze_texts(data_rdd):
-    def index(w_c_i):
-        ((word, frequency), i) = w_c_i
-        return word, (i + 1, frequency)
-    return data_rdd.flatMap(lambda text_label: text_to_words(text_label[0])) \
-        .map(lambda word: (word, 1)).reduceByKey(lambda a, b: a + b) \
-        .sortBy(lambda word_frequency: - word_frequency[1]).zipWithIndex() \
-        .map(lambda word_frequency_i: index(word_frequency_i)).collect()
-
-
-def pad(l, fill_value, width):
-    if len(l) >= width:
-        return l[0: width]
-    else:
-        l.extend([fill_value] * (width - len(l)))
-        return l
 
 
 if __name__ == "__main__":
     parser = OptionParser()
-    parser.add_option("--data_path", dest="data_path", default="/tmp/text_data")
+    parser.add_option("--data_path", dest="data_path")
+    parser.add_option("--embedding_path", dest="embedding_path")
+    parser.add_option("--class_num", dest="class_num", default="20")
     parser.add_option("--partition_num", dest="partition_num", default="4")
     parser.add_option("--token_length", dest="token_length", default="200")
     parser.add_option("--sequence_length", dest="sequence_length", default="500")
@@ -63,81 +38,46 @@ if __name__ == "__main__":
     parser.add_option("-b", "--batch_size", dest="batch_size", default="128")
     parser.add_option("--nb_epoch", dest="nb_epoch", default="20")
     parser.add_option("-l", "--learning_rate", dest="learning_rate", default="0.01")
-    parser.add_option("--log_dir", dest="log_dir", default="/tmp/.zoo")
+    parser.add_option("--log_dir", dest="log_dir", default="/tmp/.analytics-zoo")
     parser.add_option("--model", dest="model")
 
     (options, args) = parser.parse_args(sys.argv)
-    data_path = options.data_path
-    token_length = int(options.token_length)
-    sequence_len = int(options.sequence_length)
-    max_words_num = int(options.max_words_num)
-    training_split = float(options.training_split)
-    batch_size = int(options.batch_size)
-
     sc = init_nncontext("Text Classification Example")
 
-    print('Processing text dataset...')
-    texts, class_num = get_news20(base_dir=data_path)
-    text_data_rdd = sc.parallelize(texts, options.partition_num)
-
-    word_meta = analyze_texts(text_data_rdd)
-    # Remove the top 10 words roughly. You might want to fine tune this.
-    word_meta = dict(word_meta[10: max_words_num])
-    word_mata_broadcast = sc.broadcast(word_meta)
-
-    indexed_rdd = text_data_rdd\
-        .map(lambda text_label:
-             ([word_mata_broadcast.value[w][0] for w in text_to_words(text_label[0]) if
-               w in word_mata_broadcast.value], text_label[1]))\
-        .map(lambda tokens_label:
-             (pad(tokens_label[0], 0, sequence_len), tokens_label[1]))
-    sample_rdd = indexed_rdd.map(
-        lambda features_label:
-            Sample.from_ndarray(np.array(features_label[0]), features_label[1]))
-    train_rdd, val_rdd = sample_rdd.randomSplit([training_split, 1 - training_split])
+    text_set = TextSet.read(path=options.data_path).to_distributed(sc, int(options.partition_num))
+    print("Processing text dataset...")
+    transformed = text_set.tokenize().normalize().shape_sequence(len=int(options.sequence_length))\
+        .word2idx(remove_topN=10, max_words_num=int(options.max_words_num)).generate_sample()
+    train_set, val_set = transformed.random_split(
+        [float(options.training_split), 1 - float(options.training_split)])
 
     if options.model:
         model = TextClassifier.load_model(options.model)
     else:
+        token_length = int(options.token_length)
         if not (token_length == 50 or token_length == 100
                 or token_length == 200 or token_length == 300):
             raise ValueError('token_length for GloVe can only be 50, 100, 200, 300, but got '
                              + str(token_length))
-        embedding_file = data_path + "/glove.6B/glove.6B." + str(token_length) + "d.txt"
-        word_index = {w: i_f[0] for w, i_f in word_meta.items()}
-        model = TextClassifier(class_num, embedding_file, word_index, sequence_len,
+        embedding_file = options.embedding_path + "/glove.6B." + str(token_length) + "d.txt"
+        word_index = transformed.get_word_index()
+        model = TextClassifier(int(options.class_num), embedding_file,
+                               word_index, int(options.sequence_length),
                                options.encoder, int(options.encoder_output_dim))
 
-    optimizer = Optimizer(
-        model=model,
-        training_rdd=train_rdd,
-        criterion=SparseCategoricalCrossEntropy(),
-        end_trigger=MaxEpoch(int(options.nb_epoch)),
-        batch_size=batch_size,
-        optim_method=Adagrad(learningrate=float(options.learning_rate), learningrate_decay=0.001))
-    optimizer.set_validation(
-        batch_size=batch_size,
-        val_rdd=val_rdd,
-        trigger=EveryEpoch(),
-        val_method=[Accuracy()])
-
-    log_dir = options.log_dir
-    app_name = 'adam-' + dt.datetime.now().strftime("%Y%m%d-%H%M%S")
-    train_summary = TrainSummary(log_dir=log_dir, app_name=app_name)
-    train_summary.set_summary_trigger("Parameters", SeveralIteration(50))
-    val_summary = ValidationSummary(log_dir=log_dir, app_name=app_name)
-    optimizer.set_train_summary(train_summary)
-    optimizer.set_val_summary(val_summary)
-
-    optimizer.optimize()
-
-    # Predict for probability distributions
-    results = model.predict(val_rdd)
-    results.take(5)
-    # Predict for labels
-    result_classes = model.predict_classes(val_rdd)
-    print("First five class predictions (label starts from 0):")
-    for res in result_classes.take(5):
-        print(res)
+    model.compile(optimizer=Adagrad(learningrate=float(options.learning_rate),
+                                    learningrate_decay=0.001),
+                  loss="sparse_categorical_crossentropy",
+                  metrics=['accuracy'])
+    app_name = 'textclassification-' + dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+    model.set_tensorboard(options.log_dir, app_name)
+    model.fit(train_set, batch_size=int(options.batch_size),
+              nb_epoch=int(options.nb_epoch), validation_data=val_set)
+    predict_set = model.predict(val_set, batch_per_thread=int(options.partition_num))
+    # Get the first five prediction probability distributions
+    predicts = predict_set.get_predicts().take(5)
+    print("Probability distributions of the first five texts in the validation set:")
+    for predict in predicts:
+        print(predict)
 
     sc.stop()

--- a/pyzoo/zoo/feature/common.py
+++ b/pyzoo/zoo/feature/common.py
@@ -33,15 +33,20 @@ class Preprocessing(JavaValue):
 
     def __call__(self, input):
         """
-        transform ImageSet
+        Transform ImageSet or TextSet.
         """
         # move the import here to break circular import
         if "zoo.feature.image.imageset.ImageSet" not in sys.modules:
             from zoo.feature.image import ImageSet
+        if "zoo.feature.text.text_set.TextSet" not in sys.modules:
+            from zoo.feature.text import TextSet
         # if type(input) is ImageSet:
         if isinstance(input, ImageSet):
             jset = callBigDlFunc(self.bigdl_type, "transformImageSet", self.value, input)
             return ImageSet(jvalue=jset)
+        elif isinstance(input, TextSet):
+            jset = callBigDlFunc(self.bigdl_type, "transformTextSet", self.value, input)
+            return TextSet(jvalue=jset)
 
 
 class ChainedPreprocessing(Preprocessing):

--- a/pyzoo/zoo/feature/text/__init__.py
+++ b/pyzoo/zoo/feature/text/__init__.py
@@ -14,5 +14,6 @@
 # limitations under the License.
 #
 
-from .text import *
+from .text_feature import *
+from .text_set import *
 from .transformer import *

--- a/pyzoo/zoo/feature/text/text_feature.py
+++ b/pyzoo/zoo/feature/text/text_feature.py
@@ -24,38 +24,77 @@ if sys.version >= '3':
 
 
 class TextFeature(JavaValue):
-
+    """
+    Each TextFeature keeps information of a single text record.
+    It can include various status of a text,
+    e.g. original text content, category label, tokens, index representation
+    of tokens, BigDL Sample representation, prediction result and so on.
+    """
     def __init__(self, text=None, label=None, jvalue=None, bigdl_type="float"):
-        self.bigdl_type = bigdl_type
-        if jvalue:
-            self.value = jvalue
-        else:
+        if text is not None:
             assert isinstance(text, six.string_types), "text of a TextFeature should be a string"
-            if label is not None:
-                self.value = callBigDlFunc(bigdl_type, JavaValue.jvm_class_constructor(self),
-                                           text, int(label))
-            else:
-                self.value = callBigDlFunc(bigdl_type, JavaValue.jvm_class_constructor(self),
-                                           text)
+        if label is not None:
+            super(TextFeature, self).__init__(jvalue, bigdl_type, text, int(label))
+        else:
+            super(TextFeature, self).__init__(jvalue, bigdl_type, text)
 
     def get_text(self):
+        """
+        Get the text content of the TextFeature.
+
+        :return: String
+        """
         return callBigDlFunc(self.bigdl_type, "textFeatureGetText", self.value)
 
     def get_label(self):
+        """
+        Get the label of the TextFeature.
+        If no label is stored, -1 will be returned.
+
+        :return: Int
+        """
         return callBigDlFunc(self.bigdl_type, "textFeatureGetLabel", self.value)
 
     def has_label(self):
+        """
+        Whether the TextFeature contains label.
+
+        :return: Boolean
+        """
         return callBigDlFunc(self.bigdl_type, "textFeatureHasLabel", self.value)
 
     def set_label(self, label):
+        """
+        Set the label for the TextFeature.
+
+        :param label: Int
+        :return: The TextFeature with label.
+        """
         self.value = callBigDlFunc(self.bigdl_type, "textFeatureSetLabel", self.value, int(label))
         return self
 
     def get_tokens(self):
+        """
+        Get the tokens of the TextFeature.
+        If text hasn't been segmented, None will be returned.
+
+        :return: List of String
+        """
         return callBigDlFunc(self.bigdl_type, "textFeatureGetTokens", self.value)
 
     def get_sample(self):
+        """
+        Get the Sample representation of the TextFeature.
+        If the TextFeature hasn't been transformed to Sample, None will be returned.
+
+        :return: BigDL Sample
+        """
         return callBigDlFunc(self.bigdl_type, "textFeatureGetSample", self.value)
 
     def keys(self):
+        """
+        Get the keys that the TextFeature contains.
+
+        :return: List of String
+        """
         return callBigDlFunc(self.bigdl_type, "textFeatureGetKeys", self.value)

--- a/pyzoo/zoo/feature/text/text_set.py
+++ b/pyzoo/zoo/feature/text/text_set.py
@@ -1,0 +1,284 @@
+#
+# Copyright 2018 Analytics Zoo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import six
+from bigdl.util.common import JavaValue, callBigDlFunc
+from pyspark import RDD
+
+
+class TextSet(JavaValue):
+    """
+    TextSet wraps a set of texts with status.
+    """
+    def __init__(self, jvalue, bigdl_type="float", *args):
+        super(TextSet, self).__init__(jvalue, bigdl_type, *args)
+
+    def is_local(self):
+        """
+        Whether it is a LocalTextSet.
+
+        :return: Boolean
+        """
+        return callBigDlFunc(self.bigdl_type, "textSetIsLocal", self.value)
+
+    def is_distributed(self):
+        """
+        Whether it is a DistributedTextSet.
+
+        :return: Boolean
+        """
+        return callBigDlFunc(self.bigdl_type, "textSetIsDistributed", self.value)
+
+    def to_distributed(self, sc=None, partition_num=4):
+        """
+        Convert to a DistributedTextSet.
+
+        Need to specify SparkContext to convert a LocalTextSet to a DistributedTextSet.
+        In this case, you may also want to specify partition_num, the default of which is 4.
+
+        :return: DistributedTextSet
+        """
+        if self.is_distributed():
+            jvalue = self.value
+        else:
+            assert sc, "sc cannot be null to transform a LocalTextSet to a DistributedTextSet"
+            jvalue = callBigDlFunc(self.bigdl_type, "textSetToDistributed", self.value,
+                                   sc, partition_num)
+        return DistributedTextSet(jvalue=jvalue)
+
+    def to_local(self):
+        """
+        Convert to a LocalTextSet.
+
+        :return: LocalTextSet
+        """
+        if self.is_local():
+            jvalue = self.value
+        else:
+            jvalue = callBigDlFunc(self.bigdl_type, "textSetToLocal", self.value)
+        return LocalTextSet(jvalue=jvalue)
+
+    def get_word_index(self):
+        """
+        Get the word index dictionary of the TextSet.
+        If the TextSet hasn't been transformed from word to index, None will be returned.
+
+        :return: Dictionary {word: id}
+        """
+        return callBigDlFunc(self.bigdl_type, "textSetGetWordIndex", self.value)
+
+    def generate_word_index_map(self, remove_topN=0, max_words_num=-1):
+        """
+        Generate word_index map based on sorted word frequencies in descending order.
+        Return the result dictionary, which can also be retrieved by 'get_word_index()'.
+        If the TextSet hasn't been tokenized, None will be returned.
+        See word2idx for more details.
+
+        :return: Dictionary {word: id}
+        """
+        return callBigDlFunc(self.bigdl_type, "textSetGenerateWordIndexMap", self.value,
+                             remove_topN, max_words_num)
+
+    def get_texts(self):
+        """
+        Get the text contents of a TextSet.
+
+        :return: List of String for LocalTextSet.
+                 RDD of String for DistributedTextSet.
+        """
+        return callBigDlFunc(self.bigdl_type, "textSetGetTexts", self.value)
+
+    def get_labels(self):
+        """
+        Get the labels of a TextSet (if any).
+        If a text doesn't have a label, its corresponding position will be -1.
+
+        :return: List of int for LocalTextSet.
+                 RDD of int for DistributedTextSet.
+        """
+        return callBigDlFunc(self.bigdl_type, "textSetGetLabels", self.value)
+
+    def get_predicts(self):
+        """
+        Get the prediction results of a TextSet (if any).
+        If a text hasn't been predicted by a model, its corresponding position will be None.
+
+        :return: List of list of numpy array for LocalTextSet.
+                 RDD of list of numpy array for DistributedTextSet.
+        """
+        predicts = callBigDlFunc(self.bigdl_type, "textSetGetPredicts", self.value)
+        if isinstance(predicts, RDD):
+            return predicts.map(lambda predict: _process_predict_result(predict))
+        else:
+            return [_process_predict_result(predict) for predict in predicts]
+
+    def get_samples(self):
+        """
+        Get the BigDL Sample representations of a TextSet (if any).
+        If a text hasn't been transformed to Sample, its corresponding position will be None.
+
+        :return: List of Sample for LocalTextSet.
+                 RDD of Sample for DistributedTextSet.
+        """
+        return callBigDlFunc(self.bigdl_type, "textSetGetSamples", self.value)
+
+    def random_split(self, weights):
+        """
+        Randomly split into list of TextSet with provided weights.
+        Only available for DistributedTextSet for now.
+
+        :param weights: List of float indicating the split portions.
+        """
+        jvalues = callBigDlFunc(self.bigdl_type, "textSetRandomSplit", self.value, weights)
+        return [TextSet(jvalue=jvalue) for jvalue in list(jvalues)]
+
+    def tokenize(self):
+        """
+        Do tokenization on original text.
+        See Tokenizer for more details.
+
+        :return: TextSet after tokenization.
+        """
+        jvalue = callBigDlFunc(self.bigdl_type, "textSetTokenize", self.value)
+        return TextSet(jvalue=jvalue)
+
+    def normalize(self):
+        """
+        Do normalization on tokens.
+        See Normalizer for more details.
+
+        :return: TextSet after normalization.
+        """
+        jvalue = callBigDlFunc(self.bigdl_type, "textSetNormalize", self.value)
+        return TextSet(jvalue=jvalue)
+
+    def shape_sequence(self, len, mode="pre"):
+        """
+        Shape the sequence of tokens to a fixed length. Padding element will be "##".
+        See SequenceShaper for more details.
+
+        :return: TextSet after sequence shaping.
+        """
+        jvalue = callBigDlFunc(self.bigdl_type, "textSetShapeSequence", self.value, len, mode)
+        return TextSet(jvalue=jvalue)
+
+    def word2idx(self, remove_topN=0, max_words_num=-1):
+        """
+        Map word tokens to indices.
+        Index will start from 1 and corresponds to the occurrence frequency of each word sorted
+        in descending order.
+        See WordIndexer for more details.
+
+        :param remove_topN: Int. Remove the topN words with highest frequencies in the case
+                            where those are treated as stopwords.
+                            Default is 0, namely remove nothing.
+        :param max_words_num: Int. The maximum number of words to be taken into consideration.
+                              Default is -1, namely all words will be considered.
+        :return: TextSet after word2idx.
+        """
+        jvalue = callBigDlFunc(self.bigdl_type, "textSetWord2idx", self.value,
+                               remove_topN, max_words_num)
+        return TextSet(jvalue=jvalue)
+
+    def generate_sample(self):
+        """
+        Generate BigDL Sample.
+        See TextFeatureToSample for more details.
+
+        :return: TextSet with Samples.
+        """
+        jvalue = callBigDlFunc(self.bigdl_type, "textSetGenerateSample", self.value)
+        return TextSet(jvalue=jvalue)
+
+    def transform(self, transformer, bigdl_type="float"):
+        self.value = callBigDlFunc(bigdl_type, "transformTextSet", transformer, self.value)
+        return self
+
+    @classmethod
+    def read(cls, path, sc=None, min_partitions=1, bigdl_type="float"):
+        """
+        Read text files as TextSet.
+        If sc is defined, read texts as DistributedTextSet from local file system or HDFS.
+        If sc is None, read texts as LocalTextSet from local file system.
+
+        :param path: String. Folder path to texts.
+               The folder structure is expected to be the following:
+                   path
+                     |dir1 - text1, text2, ...
+                     |dir2 - text1, text2, ...
+                     |dir3 - text1, text2, ...
+               Under the target path, there ought to be N subdirectories (dir1 to dirN). Each
+               subdirectory represents a category and contains all texts that belong to such
+               category. Each category will be a given a label according to its position in the
+               ascending order sorted among all subdirectories.
+               All texts will be given a label according to the subdirectory where it is located.
+               Labels start from 0.
+        :param sc: An instance of SparkContext if any. Default is None.
+        :param min_partitions: A suggestion value of the minimal partition number.
+                               Int. Default is 1. Only need to specify this when sc is not None.
+        :return: TextSet.
+        """
+        jvalue = callBigDlFunc(bigdl_type, "readTextSet", path, sc, min_partitions)
+        return TextSet(jvalue=jvalue)
+
+
+class LocalTextSet(TextSet):
+    """
+    LocalTextSet is comprised of lists.
+    """
+    def __init__(self, texts=None, labels=None, jvalue=None, bigdl_type="float"):
+        """
+        Create a LocalTextSet using texts and labels.
+
+        # Arguments:
+        texts: List of String. Each element is the content of a text.
+        labels: List of int or None if texts don't have labels.
+        """
+        if texts is not None:
+            assert all(isinstance(text, six.string_types) for text in texts),\
+                "texts for LocalTextSet should be list of string"
+        if labels is not None:
+            labels = [int(label) for label in labels]
+        super(LocalTextSet, self).__init__(jvalue, bigdl_type, texts, labels)
+
+
+class DistributedTextSet(TextSet):
+    """
+    DistributedTextSet is comprised of RDDs.
+    """
+    def __init__(self, texts=None, labels=None, jvalue=None, bigdl_type="float"):
+        """
+        Create a DistributedTextSet using texts and labels.
+
+        # Arguments:
+        texts: RDD of String. Each element is the content of a text.
+        labels: RDD of int or None if texts don't have labels.
+        """
+        if texts is not None:
+            assert isinstance(texts, RDD), "texts for DistributedTextSet should be RDD of String"
+        if labels is not None:
+            assert isinstance(labels, RDD), "labels for DistributedTextSet should be RDD of int"
+            labels = labels.map(lambda x: int(x))
+        super(DistributedTextSet, self).__init__(jvalue, bigdl_type, texts, labels)
+
+
+def _process_predict_result(predict):
+    # 'predict' is a list of JTensors or None
+    # convert to a list of ndarray
+    if predict is not None:
+        return [res.to_ndarray() for res in predict]
+    else:
+        return None

--- a/pyzoo/zoo/feature/text/text_set.py
+++ b/pyzoo/zoo/feature/text/text_set.py
@@ -84,7 +84,7 @@ class TextSet(JavaValue):
         """
         Generate word_index map based on sorted word frequencies in descending order.
         Return the result dictionary, which can also be retrieved by 'get_word_index()'.
-        If the TextSet hasn't been tokenized, None will be returned.
+        Make sure you call this after tokenize. Otherwise you will get an error.
         See word2idx for more details.
 
         :return: Dictionary {word: id}

--- a/pyzoo/zoo/feature/text/transformer.py
+++ b/pyzoo/zoo/feature/text/transformer.py
@@ -78,7 +78,7 @@ class SequenceShaper(TextTransformer):
                 If 'post', the sequence will be truncated from the end.
     pad_element: String. The element to be padded to the sequence if the original length is
                  smaller than the target length. Default is "##".
-                 Make sure that the padding element is meaninglessin your corpus.
+                 Make sure that the padding element is meaningless in your corpus.
     >>> sequence_shaper = SequenceShaper(len=6, trunc_mode="post", pad_element="xxxx")
     creating: createSequenceShaper
     """

--- a/pyzoo/zoo/models/textclassification/text_classifier.py
+++ b/pyzoo/zoo/models/textclassification/text_classifier.py
@@ -113,3 +113,21 @@ class TextClassifier(ZooModel):
         model = ZooModel._do_load(jmodel, bigdl_type)
         model.__class__ = TextClassifier
         return model
+
+    def compile(self, optimizer, loss, metrics=None):
+        self.model.compile(optimizer, loss, metrics)
+
+    def set_tensorboard(self, log_dir, app_name):
+        self.model.set_tensorboard(log_dir, app_name)
+
+    def set_checkpoint(self, path, over_write=True):
+        self.model.set_checkpoint(path, over_write)
+
+    def fit(self, x, y=None, batch_size=32, nb_epoch=10, validation_data=None, distributed=True):
+        self.model.fit(x, y, batch_size, nb_epoch, validation_data, distributed)
+
+    def evaluate(self, x, y=None, batch_size=32):
+        return self.model.evaluate(x, y, batch_size)
+
+    def predict(self, x, batch_per_thread=4, distributed=True):
+        return self.model.predict(x, batch_per_thread, distributed)

--- a/pyzoo/zoo/pipeline/api/keras/engine/topology.py
+++ b/pyzoo/zoo/pipeline/api/keras/engine/topology.py
@@ -16,6 +16,7 @@
 
 import zoo.pipeline.api.autograd as autograd
 from zoo.feature.image import ImageSet
+from zoo.feature.text import TextSet
 from zoo.pipeline.api.keras.base import ZooKerasLayer
 from zoo.pipeline.api.keras.utils import *
 from bigdl.nn.layer import Layer
@@ -121,15 +122,16 @@ class KerasNet(ZooKerasLayer):
 
     def fit(self, x, y=None, batch_size=32, nb_epoch=10, validation_data=None, distributed=True):
         """
-        Train a model for a fixed number of epochs on a dataset.
+        Train a model for a fixed number of epochs on a DataSet.
 
         # Arguments
-        x: Input data. A Numpy array or RDD of Sample or ImageSet.
-        y: Labels. A Numpy array. Default is None if x is already RDD of Sample or Image DataSet.
+        x: Input data. A Numpy array or RDD of Sample, ImageSet or TextSet.
+        y: Labels. A Numpy array. Default is None if x is already Sample RDD or ImageSet or TextSet.
         batch_size: Number of samples per gradient update. Default is 32.
-        nb_epoch: Number of iterations to train.
-        validation_data: Tuple (x_val, y_val) where x_val and y_val are both Numpy arrays. Or
-                         RDD of Sample. Or ImageSet. Default is None if no validation is involved.
+        nb_epoch: Number of epochs to train.
+        validation_data: Tuple (x_val, y_val) where x_val and y_val are both Numpy arrays.
+                         Can also be RDD of Sample or ImageSet or TextSet.
+                         Default is None if no validation is involved.
         distributed: Boolean. Whether to train the model in distributed mode or local mode.
                      Default is True. In local mode, x and y must both be Numpy arrays.
         """
@@ -138,7 +140,8 @@ class KerasNet(ZooKerasLayer):
                 training_data = to_sample_rdd(x, y)
                 if validation_data:
                     validation_data = to_sample_rdd(*validation_data)
-            elif (isinstance(x, RDD) or isinstance(x, ImageSet)) and not y:
+            elif (isinstance(x, RDD) or isinstance(x, ImageSet) or isinstance(x, TextSet))\
+                    and not y:
                 training_data = x
             else:
                 raise TypeError("Unsupported training data type: %s" % type(x))
@@ -168,13 +171,14 @@ class KerasNet(ZooKerasLayer):
         Evaluate a model on a given dataset in distributed mode.
 
         # Arguments
-        x: Evaluation data. A Numpy array or RDD of Sample or ImageSet.
-        y: Labels. A Numpy array. Default is None if x is already RDD of Sample.
+        x: Evaluation data. A Numpy array or RDD of Sample or ImageSet or TextSet.
+        y: Labels. A Numpy array.
+           Default is None if x is already Sample RDD or ImageSet or TextSet.
         batch_size: Number of samples per batch. Default is 32.
         """
         if isinstance(x, np.ndarray) and isinstance(y, np.ndarray):
             data = to_sample_rdd(x, y)
-        elif (isinstance(x, RDD) or isinstance(x, ImageSet)) and not y:
+        elif (isinstance(x, RDD) or isinstance(x, ImageSet) or isinstance(x, TextSet)) and not y:
             data = x
         else:
             raise TypeError("Unsupported evaluation data type: %s" % type(x))
@@ -203,7 +207,7 @@ class KerasNet(ZooKerasLayer):
     def convert_output(output):
         if type(output) is JTensor:
             return output.to_ndarray()
-        elif(len(output) == 1):
+        elif len(output) == 1:
             return KerasNet.convert_output(output[0])
         else:
             return [KerasNet.convert_output(x) for x in output]
@@ -221,12 +225,12 @@ class KerasNet(ZooKerasLayer):
         distributed: Boolean. Whether to do prediction in distributed mode or local mode.
                      Default is True. In local mode, x must be a Numpy array.
         """
-        if isinstance(x, ImageSet):
+        if isinstance(x, ImageSet) or isinstance(x, TextSet):
             results = callBigDlFunc(self.bigdl_type, "zooPredict",
                                     self.value,
                                     x,
                                     batch_per_thread)
-            return ImageSet(results)
+            return ImageSet(results) if isinstance(x, ImageSet) else TextSet(results)
         if distributed:
             if isinstance(x, np.ndarray):
                 data_rdd = to_sample_rdd(x, np.zeros([x.shape[0]]))

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/textclassification/README.md
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/textclassification/README.md
@@ -16,9 +16,9 @@ The data used in this example are:
 - [20 Newsgroup dataset](http://qwone.com/~jason/20Newsgroups/20news-18828.tar.gz) which contains 20 categories and with 18828 texts in total.
 - [GloVe word embeddings](http://nlp.stanford.edu/data/glove.6B.zip): embeddings of 400k words pre-trained on a 2014 dump of English Wikipedia.
 
-You need to download and extract the data by yourself beforehand.
+You need to prepare the data by yourself beforehand.
 
-The following scripts we prepare will serve to download and extract the data for you:
+The following scripts we provide will serve to download and extract the data for you:
 ```bash
 bash ${ANALYTICS_ZOO_HOME}/bin/data/news20/get_news20.sh dir
 bash ${ANALYTICS_ZOO_HOME}/bin/data/glove/get_glove.sh dir
@@ -35,7 +35,7 @@ Run the following command for Spark local mode (`MASTER=local[*]`) or cluster mo
 export SPARK_HOME=the root directory of Spark
 export ANALYTICS_ZOO_HOME=the folder where you extract the downloaded Analytics Zoo zip package
 MASTER=...
-news20Path=the directory containing the News20 data
+news20Path=the directory containing News20 dataset
 glovePath=the directory containing GloVe embeddings
 
 ${ANALYTICS_ZOO_HOME}/bin/spark-shell-with-zoo.sh \

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/textclassification/README.md
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/textclassification/README.md
@@ -16,20 +16,16 @@ The data used in this example are:
 - [20 Newsgroup dataset](http://qwone.com/~jason/20Newsgroups/20news-18828.tar.gz) which contains 20 categories and with 18828 texts in total.
 - [GloVe word embeddings](http://nlp.stanford.edu/data/glove.6B.zip): embeddings of 400k words pre-trained on a 2014 dump of English Wikipedia.
 
-You need to prepare the data by yourself beforehand. The following scripts we prepare will serve to download and extract the data for you:
+You need to download and extract the data by yourself beforehand.
+
+The following scripts we prepare will serve to download and extract the data for you:
 ```bash
 bash ${ANALYTICS_ZOO_HOME}/bin/data/news20/get_news20.sh dir
 bash ${ANALYTICS_ZOO_HOME}/bin/data/glove/get_glove.sh dir
 ```
-where `ANALYTICS_ZOO_HOME` is the folder where you extract the downloaded package and `dir` is the directory you wish to locate the downloaded data. If `dir` is not specified, the data will be downloaded to the current working directory. 20 Newsgroup dataset and GloVe word embeddings are supposed to be placed under the same directory `baseDir`.
-
-The data folder structure after extraction should look like the following:
-```
-baseDir$ tree .
-    .
-    ├── 20news-18828
-    └── glove.6B
-```
+Remarks:
+- `ANALYTICS_ZOO_HOME` is the folder where you extract the downloaded package and `dir` is the directory you wish to locate the corresponding downloaded data.
+- If `dir` is not specified, the data will be downloaded to the current working directory.
 
 
 ## Run this example
@@ -39,20 +35,24 @@ Run the following command for Spark local mode (`MASTER=local[*]`) or cluster mo
 export SPARK_HOME=the root directory of Spark
 export ANALYTICS_ZOO_HOME=the folder where you extract the downloaded Analytics Zoo zip package
 MASTER=...
-BASE_DIR=the base directory containing the News20 and GloVe data
+news20Path=the directory containing the News20 data
+glovePath=the directory containing GloVe embeddings
 
 ${ANALYTICS_ZOO_HOME}/bin/spark-shell-with-zoo.sh \
     --master ${MASTER} \
     --driver-memory 2g \
     --executor-memory 2g \
     --class com.intel.analytics.zoo.examples.textclassification.TextClassification \
-    --baseDir ${BASE_DIR}
+    --dataPath ${news20Path} \
+    --embeddingPath ${glovePath}
 ```
 See [here](#options) for more configurable options for this example.
 
 
 ## Options
-* `--baseDir` This option is __required__. The path where the News20 and GloVe data locate.
+* `--dataPath` This option is __required__. The path where the News20 dataset locate.
+* `--embeddingPath` This option is __required__. The path where the GloVe embeddings locate.
+* `--classNum` The number of classes to do classification. Default is 20 for News20 dataset.
 * `--partitionNum` The number of partitions to cut the dataset into. Datault is 4.
 * `--tokenLength` The size of each word vector. GloVe supports tokenLength 50, 100, 200 and 300. Default is 200.
 * `--sequenceLength` The length of a sequence. Default is 500.

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/textclassification/README.md
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/textclassification/README.md
@@ -13,15 +13,15 @@ You can download Analytics Zoo prebuilt release and nightly build package from [
 
 ## Data Preparation
 The data used in this example are:
-- [20 Newsgroup dataset](http://qwone.com/~jason/20Newsgroups/20news-18828.tar.gz) which contains 20 categories and with 19997 texts in total.
+- [20 Newsgroup dataset](http://qwone.com/~jason/20Newsgroups/20news-18828.tar.gz) which contains 20 categories and with 18828 texts in total.
 - [GloVe word embeddings](http://nlp.stanford.edu/data/glove.6B.zip): embeddings of 400k words pre-trained on a 2014 dump of English Wikipedia.
 
-You need to prepare the data by yourself beforehand. The following scripts we prepare will serve to download and extract the data:
+You need to prepare the data by yourself beforehand. The following scripts we prepare will serve to download and extract the data for you:
 ```bash
 bash ${ANALYTICS_ZOO_HOME}/bin/data/news20/get_news20.sh dir
 bash ${ANALYTICS_ZOO_HOME}/bin/data/glove/get_glove.sh dir
 ```
-where `ANALYTICS_ZOO_HOME` is the folder where you extract the downloaded package and `dir` is the directory you wish to locate the downloaded data. If `dir` is not specified, the data will be downloaded to the current working directory. 20 Newsgroup dataset and GloVe word embeddings are supposed to be placed under the same directory.
+where `ANALYTICS_ZOO_HOME` is the folder where you extract the downloaded package and `dir` is the directory you wish to locate the downloaded data. If `dir` is not specified, the data will be downloaded to the current working directory. 20 Newsgroup dataset and GloVe word embeddings are supposed to be placed under the same directory `baseDir`.
 
 The data folder structure after extraction should look like the following:
 ```
@@ -39,7 +39,7 @@ Run the following command for Spark local mode (`MASTER=local[*]`) or cluster mo
 export SPARK_HOME=the root directory of Spark
 export ANALYTICS_ZOO_HOME=the folder where you extract the downloaded Analytics Zoo zip package
 MASTER=...
-BASE_DIR=the base directory containing the training and word2Vec data
+BASE_DIR=the base directory containing the News20 and GloVe data
 
 ${ANALYTICS_ZOO_HOME}/bin/spark-shell-with-zoo.sh \
     --master ${MASTER} \
@@ -52,11 +52,11 @@ See [here](#options) for more configurable options for this example.
 
 
 ## Options
-* `--baseDir` This option is __required__. The path where the training and word2Vec data locate.
+* `--baseDir` This option is __required__. The path where the News20 and GloVe data locate.
 * `--partitionNum` The number of partitions to cut the dataset into. Datault is 4.
 * `--tokenLength` The size of each word vector. GloVe supports tokenLength 50, 100, 200 and 300. Default is 200.
 * `--sequenceLength` The length of a sequence. Default is 500.
-* `--maxWordsNum` The maximum number of words. Default is 5000.
+* `--maxWordsNum` The maximum number of words sorted by frequencies to be taken into consideration. Default is 5000.
 * `--encoder` The encoder for the input sequence. String, 'cnn' or 'lstm' or 'gru'. Default is 'cnn'.
 * `--encoderOutputDim` The output dimension of the encoder. Default is 256.
 * `--trainingSplit` The split portion of the data for training. Default is 0.8.

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/textclassification/README.md
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/textclassification/README.md
@@ -50,8 +50,8 @@ See [here](#options) for more configurable options for this example.
 
 
 ## Options
-* `--dataPath` This option is __required__. The path where the News20 dataset locate.
-* `--embeddingPath` This option is __required__. The path where the GloVe embeddings locate.
+* `--dataPath` This option is __required__. The path where News20 dataset locate.
+* `--embeddingPath` This option is __required__. The path where GloVe embeddings locate.
 * `--classNum` The number of classes to do classification. Default is 20 for News20 dataset.
 * `--partitionNum` The number of partitions to cut the dataset into. Datault is 4.
 * `--tokenLength` The size of each word vector. GloVe supports tokenLength 50, 100, 200 and 300. Default is 200.

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/textclassification/TextClassification.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/textclassification/TextClassification.scala
@@ -51,7 +51,7 @@ object TextClassification {
         .text("The directory for GloVe embeddings")
         .action((x, c) => c.copy(embeddingPath = x))
       opt[Int]("classNum")
-        .text("The number of classes to be do classification")
+        .text("The number of classes to do classification")
         .action((x, c) => c.copy(classNum = x))
       opt[Int]("partitionNum")
         .text("The number of partitions to cut the dataset into")

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/textclassification/TextClassification.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/textclassification/TextClassification.scala
@@ -16,96 +16,43 @@
 
 package com.intel.analytics.zoo.examples.textclassification
 
-import java.io.File
-import java.util
-
-import com.intel.analytics.bigdl.dataset.Sample
-import com.intel.analytics.bigdl.example.utils.SimpleTokenizer._
-import com.intel.analytics.bigdl.example.utils.{SimpleTokenizer, WordMeta}
 import com.intel.analytics.bigdl.optim._
-import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric.NumericFloat
-import com.intel.analytics.bigdl.utils.LoggerFilter
 import com.intel.analytics.zoo.common.NNContext
+import com.intel.analytics.zoo.feature.text.TextSet
 import com.intel.analytics.zoo.models.textclassification.TextClassifier
 import com.intel.analytics.zoo.pipeline.api.keras.metrics.Accuracy
 import com.intel.analytics.zoo.pipeline.api.keras.objectives.SparseCategoricalCrossEntropy
-import com.intel.analytics.zoo.pipeline.api.keras.layers.WordEmbedding
 import org.apache.log4j.{Level => Level4j, Logger => Logger4j}
-import org.apache.spark.SparkConf
-import org.apache.spark.rdd.RDD
-import org.slf4j.{Logger, LoggerFactory}
 import scopt.OptionParser
 
-import scala.collection.mutable.ArrayBuffer
-import scala.io.Source
 
-case class TextClassificationParams(baseDir: String = "./",
-                                    tokenLength: Int = 200,
-                                    sequenceLength: Int = 500,
-                                    encoder: String = "cnn",
-                                    encoderOutputDim: Int = 256,
-                                    maxWordsNum: Int = 5000,
-                                    trainingSplit: Double = 0.8,
-                                    batchSize: Int = 128,
-                                    nbEpoch: Int = 20,
-                                    learningRate: Double = 0.01,
-                                    partitionNum: Int = 4,
-                                    model: Option[String] = None)
+case class TextClassificationParams(
+   dataPath: String = "./", embeddingPath: String = "./",
+   classNum: Int = 20, tokenLength: Int = 200,
+   sequenceLength: Int = 500, encoder: String = "cnn",
+   encoderOutputDim: Int = 256, maxWordsNum: Int = 5000,
+   trainingSplit: Double = 0.8, batchSize: Int = 128,
+   nbEpoch: Int = 20, learningRate: Double = 0.01,
+   partitionNum: Int = 4, model: Option[String] = None)
+
 
 object TextClassification {
-  val log: Logger = LoggerFactory.getLogger(this.getClass)
-  LoggerFilter.redirectSparkInfoLogs()
   Logger4j.getLogger("com.intel.analytics.bigdl.optim").setLevel(Level4j.INFO)
-
-  var classNum: Int = -1
-
-  // Load text, label pairs from file
-  def loadRawData(dir: String): ArrayBuffer[(String, Float)] = {
-    val texts = ArrayBuffer[String]()
-    val labels = ArrayBuffer[Float]()
-    // Category is a string name and label is it's one-based index
-    val categoryToLabel = new util.HashMap[String, Int]()
-    val categoryPathList = new File(dir).listFiles().filter(_.isDirectory).toList.sorted
-
-    categoryPathList.foreach { categoryPath =>
-      val label_id = categoryToLabel.size()
-      categoryToLabel.put(categoryPath.getName, label_id)
-      val textFiles = categoryPath.listFiles()
-        .filter(_.isFile).filter(_.getName.forall(Character.isDigit(_))).sorted
-      textFiles.foreach { file =>
-        val source = Source.fromFile(file, "ISO-8859-1")
-        val text = try source.getLines().toList.mkString("\n") finally source.close()
-        texts.append(text)
-        labels.append(label_id)
-      }
-    }
-    this.classNum = labels.toSet.size
-    log.info(s"Found ${texts.length} texts.")
-    log.info(s"Found $classNum classes")
-    texts.zip(labels)
-  }
-
-  // Turn texts into tokens
-  def analyzeTexts(dataRdd: RDD[(String, Float)], maxWordsNum: Int)
-  : Map[String, WordMeta] = {
-    // Remove the top 10 words roughly. You might want to fine tune this.
-    val frequencies = dataRdd.flatMap{case (text: String, label: Float) =>
-      SimpleTokenizer.toTokens(text)
-    }.map(word => (word, 1)).reduceByKey(_ + _)
-      .sortBy(- _._2).collect().slice(10, maxWordsNum)
-
-    val indexes = Range(1, frequencies.length)
-    frequencies.zip(indexes).map{item =>
-      (item._1._1, WordMeta(item._1._2, item._2))}.toMap
-  }
 
   def main(args: Array[String]): Unit = {
     val parser = new OptionParser[TextClassificationParams]("TextClassification Example") {
-      opt[String]("baseDir")
+      opt[String]("dataPath")
         .required()
-        .text("The base directory containing the training and word2Vec data")
-        .action((x, c) => c.copy(baseDir = x))
+        .text("The directory containing the training data")
+        .action((x, c) => c.copy(dataPath = x))
+      opt[String]("embeddingPath")
+        .required()
+        .text("The directory for GloVe embeddings")
+        .action((x, c) => c.copy(embeddingPath = x))
+      opt[Int]("classNum")
+        .text("The number of classes to be do classification")
+        .action((x, c) => c.copy(classNum = x))
       opt[Int]("partitionNum")
         .text("The number of partitions to cut the dataset into")
         .action((x, c) => c.copy(partitionNum = x))
@@ -113,10 +60,10 @@ object TextClassification {
         .text("The size of each word vector, 50 or 100 or 200 or 300 for GloVe")
         .action((x, c) => c.copy(tokenLength = x))
       opt[Int]("sequenceLength")
-        .text("The length of a sequence")
+        .text("The length of each sequence")
         .action((x, c) => c.copy(sequenceLength = x))
       opt[Int]("maxWordsNum")
-        .text("The maximum number of words")
+        .text("The maximum number of words to be taken into consideration")
         .action((x, c) => c.copy(maxWordsNum = x))
       opt[String]("encoder")
         .text("The encoder for the input sequence, cnn or lstm or gru")
@@ -131,7 +78,7 @@ object TextClassification {
         .text("The number of samples per gradient update")
         .action((x, c) => c.copy(batchSize = x))
       opt[Int]("nbEpoch")
-        .text("The number of iterations to train the model")
+        .text("The number of epochs to train the model")
         .action((x, c) => c.copy(nbEpoch = x))
       opt[Double]('l', "learningRate")
         .text("The learning rate for the TextClassifier model")
@@ -142,38 +89,15 @@ object TextClassification {
     }
 
     parser.parse(args, TextClassificationParams()).map { param =>
-      val conf = new SparkConf()
-        .setAppName("Text Classification Example")
-        .set("spark.task.maxFailures", "1")
-      val sc = NNContext.initNNContext(conf)
+      val sc = NNContext.initNNContext("Text Classification Example")
 
-      val sequenceLength = param.sequenceLength
-      val trainingSplit = param.trainingSplit
-      val textDataDir = s"${param.baseDir}/20news-18828/"
-      require(new File(textDataDir).exists(), "Text data directory is not found in baseDir, " +
-        "you can run $ANALYTICS_ZOO_HOME/bin/data/news20/get_news20.sh to " +
-        "download 20 Newsgroup dataset")
-      val gloveDir = s"${param.baseDir}/glove.6B/"
-      require(new File(gloveDir).exists(),
-        "GloVe word embeddings directory is not found in baseDir, " +
-        "you can run $ANALYTICS_ZOO_HOME/bin/data/glove/get_glove.sh to download")
-
-      // For large dataset, you might want to get such RDD[(String, Float)] from HDFS
-      val dataRdd = sc.parallelize(loadRawData(textDataDir), param.partitionNum)
-      val word2Meta = analyzeTexts(dataRdd, param.maxWordsNum)
-      val word2MetaBC = sc.broadcast(word2Meta)
-
-      val indexedRdd = dataRdd
-        .map {case (text, label) => (toTokens(text, word2MetaBC.value), label)}
-        .map {case (tokens, label) => (shaping(tokens, sequenceLength), label)}
-      val sampleRDD = indexedRdd.map {case (input: Array[Float], label: Float) =>
-        Sample(
-          featureTensor = Tensor(input, Array(sequenceLength)),
-          label = label)
-      }
-
-      val Array(trainingRDD, valRDD) = sampleRDD.randomSplit(
-        Array(trainingSplit, 1 - trainingSplit))
+      val textSet = TextSet.read(param.dataPath)
+        .toDistributed(sc, param.partitionNum)
+      println("Processing text dataset...")
+      val transformed = textSet.tokenize().normalize().shapeSequence(param.sequenceLength)
+        .word2idx(removeTopN = 10, maxWordsNum = param.maxWordsNum).generateSample()
+      val Array(trainTextSet, valTextSet) = transformed.randomSplit(
+        Array(param.trainingSplit, 1 - param.trainingSplit))
 
       val model = if (param.model.isDefined) {
         TextClassifier.loadModel(param.model.get)
@@ -182,34 +106,23 @@ object TextClassification {
         val tokenLength = param.tokenLength
         require(tokenLength == 50 || tokenLength == 100 || tokenLength == 200 || tokenLength == 300,
         s"tokenLength for GloVe can only be 50, 100, 200, 300, but got $tokenLength")
-        val wordIndex = word2Meta.map(x => x._1 -> x._2.index)
-        val gloveFile = gloveDir + "glove.6B." + tokenLength.toString + "d.txt"
-        TextClassifier(classNum, gloveFile, wordIndex, sequenceLength,
+        val wordIndex = transformed.getWordIndex
+        val gloveFile = param.embeddingPath + "/glove.6B." + tokenLength.toString + "d.txt"
+        TextClassifier(param.classNum, gloveFile, wordIndex, param.sequenceLength,
           param.encoder, param.encoderOutputDim)
       }
 
-      val optimizer = Optimizer(
-        model = model,
-        sampleRDD = trainingRDD,
-        criterion = SparseCategoricalCrossEntropy[Float](),
-        batchSize = param.batchSize
-      )
+      model.compile(
+        optimizer = new Adagrad(learningRate = param.learningRate,
+          learningRateDecay = 0.001),
+        loss = SparseCategoricalCrossEntropy[Float](),
+        metrics = List(new Accuracy()))
+      model.fit(trainTextSet, batchSize = param.batchSize,
+        nbEpoch = param.nbEpoch, validationData = valTextSet)
 
-      optimizer
-        .setOptimMethod(new Adagrad(learningRate = param.learningRate,
-          learningRateDecay = 0.001))
-        .setValidation(Trigger.everyEpoch, valRDD, Array(new Accuracy), param.batchSize)
-        .setEndWhen(Trigger.maxEpoch(param.nbEpoch))
-        .optimize()
-
-      // Predict for probability distributions
-      val results = model.predict(valRDD)
-      results.take(5)
-      // Predict for labels
-      val resultClasses = model.predictClasses(valRDD)
-      println("First five class predictions (label starts from 0):")
-      resultClasses.take(5).foreach(println)
-
+      val predictSet = model.predict(valTextSet, batchPerThread = param.partitionNum)
+      println("Probability distributions of the first five texts in the validation set:")
+      predictSet.toDistributed().rdd.take(5).map(_.getPredict.toTensor).foreach(println)
       sc.stop()
     }
   }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/common/Preprocessing.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/common/Preprocessing.scala
@@ -16,8 +16,9 @@
 package com.intel.analytics.zoo.feature.common
 
 import com.intel.analytics.bigdl.dataset.Transformer
-import com.intel.analytics.bigdl.transform.vision.image.{FeatureTransformer, ImageFeature}
+import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
 import com.intel.analytics.zoo.feature.image.ImageSet
+import com.intel.analytics.zoo.feature.text.{TextFeature, TextSet}
 import org.apache.commons.lang3.SerializationUtils
 
 /**
@@ -47,6 +48,15 @@ trait Preprocessing[A, B] extends Transformer[A, B] {
     } else {
       throw new IllegalArgumentException("We expect " +
         "Preprocessing[ImageFeature, ImageFeature] here")
+    }
+  }
+
+  def apply(textSet: TextSet): TextSet = {
+    this match {
+      case textTransformer: Preprocessing[TextFeature, TextFeature] =>
+        textSet.transform(textTransformer)
+      case _ => throw new IllegalArgumentException("We expect " +
+        "Preprocessing[TextFeature, TextFeature] here")
     }
   }
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageSet.scala
@@ -17,7 +17,7 @@
 package com.intel.analytics.zoo.feature.image
 
 import com.intel.analytics.bigdl.DataSet
-import com.intel.analytics.bigdl.dataset.DataSet
+import com.intel.analytics.bigdl.dataset.{DataSet, Sample}
 import com.intel.analytics.bigdl.transform.vision.image.{DistributedImageFrame, ImageFeature, ImageFrame, LocalImageFrame}
 import com.intel.analytics.zoo.common.Utils
 import com.intel.analytics.zoo.feature.common.Preprocessing
@@ -25,6 +25,8 @@ import org.apache.commons.io.FileUtils
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.opencv.imgcodecs.Imgcodecs
+
+import scala.reflect.ClassTag
 
 /**
  * ImageSet wraps a set of ImageFeature
@@ -72,9 +74,9 @@ abstract class ImageSet {
   def toImageFrame(): ImageFrame
 
   /**
-   * Convert ImageSet to DataSet of ImageFeature.
+   * Convert ImageSet to DataSet of Sample.
    */
-  def toDataSet(): DataSet[ImageFeature]
+  def toDataSet[T: ClassTag]: DataSet[Sample[T]]
 }
 
 class LocalImageSet(var array: Array[ImageFeature]) extends ImageSet {
@@ -91,8 +93,8 @@ class LocalImageSet(var array: Array[ImageFeature]) extends ImageSet {
     ImageFrame.array(array)
   }
 
-  override def toDataSet(): DataSet[ImageFeature] = {
-    DataSet.array(array)
+  override def toDataSet[T: ClassTag]: DataSet[Sample[T]] = {
+    DataSet.array(array.map(_[Sample[T]](ImageFeature.sample)))
   }
 }
 
@@ -110,8 +112,8 @@ class DistributedImageSet(var rdd: RDD[ImageFeature]) extends ImageSet {
     ImageFrame.rdd(rdd)
   }
 
-  override def toDataSet(): DataSet[ImageFeature] = {
-    DataSet.rdd[ImageFeature](rdd)
+  override def toDataSet[T: ClassTag]: DataSet[Sample[T]] = {
+    DataSet.rdd(rdd.map(_[Sample[T]](ImageFeature.sample)))
   }
 }
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextFeature.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextFeature.scala
@@ -17,6 +17,7 @@
 package com.intel.analytics.zoo.feature.text
 
 import com.intel.analytics.bigdl.dataset.Sample
+import com.intel.analytics.bigdl.nn.abstractnn.Activity
 import org.apache.log4j.Logger
 
 import scala.collection.{Set, mutable}
@@ -25,8 +26,8 @@ import scala.reflect.ClassTag
 /**
  * Each TextFeature keeps information of a single text record.
  * It can include various status of a text,
- * e.g. original text content, category label, words after tokenization,
- * index representation of tokens, BigDL Sample representation and so on.
+ * e.g. original text content, category label, tokens, index representation
+ * of tokens, BigDL Sample representation, prediction result and so on.
  * It uses a HashMap to store all these data.
  * Each key is a string that can be used to identify the corresponding value.
  */
@@ -106,7 +107,13 @@ class TextFeature extends Serializable {
    * Get the Sample representation of the TextFeature.
    * If the TextFeature hasn't been transformed to Sample, null will be returned.
    */
-  def getSample[T: ClassTag]: Sample[T] = apply[Sample[T]](TextFeature.sample)
+  def getSample: Sample[Float] = apply[Sample[Float]](TextFeature.sample)
+
+  /**
+   * Get the prediction probability distribution of the TextFeature.
+   * If the TextFeature hasn't been predicted by a model, null will be returned.
+   */
+  def getPredict: Activity = apply[Activity](TextFeature.predict)
 }
 
 object TextFeature {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextSet.scala
@@ -1,0 +1,359 @@
+/*
+ * Copyright 2018 Analytics Zoo Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.zoo.feature.text
+
+import java.io.File
+import java.util
+
+import com.intel.analytics.bigdl.DataSet
+import com.intel.analytics.bigdl.dataset.{DataSet, Sample}
+import com.intel.analytics.zoo.feature.common.Preprocessing
+import com.intel.analytics.zoo.feature.text.TruncMode.TruncMode
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.util.StringUtils
+import org.apache.log4j.Logger
+import org.apache.spark.{SparkContext, SparkException}
+import org.apache.spark.rdd.RDD
+
+import scala.collection.mutable.ArrayBuffer
+import scala.io.Source
+
+/**
+ * TextSet wraps a set of TextFeature.
+ */
+abstract class TextSet {
+  /**
+   * Transform from one TextSet to another.
+   */
+  def transform(transformer: Preprocessing[TextFeature, TextFeature]): TextSet
+
+  // scalastyle:off methodName
+  // scalastyle:off noSpaceBeforeLeftBracket
+  def -> (transformer: Preprocessing[TextFeature, TextFeature]): TextSet = {
+    this.transform(transformer)
+  }
+
+  /**
+   * Whether it is a LocalTextSet.
+   */
+  def isLocal: Boolean
+
+  /**
+   * Whether it is a DistributedTextSet.
+   */
+  def isDistributed: Boolean
+
+  /**
+   * Convert to a LocalTextSet.
+   */
+  def toLocal(): LocalTextSet
+
+  /**
+   * Convert to a DistributedTextSet.
+   *
+   * Need to specify SparkContext to convert a LocalTextSet to a DistributedTextSet.
+   * In this case, you may also want to specify partitionNum, the default of which is 4.
+   */
+  def toDistributed(sc: SparkContext = null, partitionNum: Int = 4): DistributedTextSet
+
+  /**
+   * Convert TextSet to DataSet of Sample.
+   */
+  def toDataSet: DataSet[Sample[Float]]
+
+  /**
+   * Randomly split into array of TextSet with provided weights.
+   * Only available for DistributedTextSet for now.
+   *
+   * @param weights Array of Double indicating the split portions.
+   */
+  def randomSplit(weights: Array[Double]): Array[TextSet]
+
+  /**
+   * Do tokenization on original text.
+   * See Tokenizer for more details.
+   */
+  def tokenize(): TextSet = {
+    transform(Tokenizer())
+  }
+
+  /**
+   * Do normalization on tokens.
+   * See Normalizer for more details.
+   */
+  def normalize(): TextSet = {
+    transform(Normalizer())
+  }
+
+  /**
+   * Shape the sequence of tokens to a fixed length. Padding element will be "##".
+   * See SequenceShaper for more details.
+   */
+  def shapeSequence(
+     len: Int,
+     truncMode: TruncMode = TruncMode.pre): TextSet = {
+    transform(SequenceShaper(len, truncMode))
+  }
+
+  /**
+   * Map word tokens to indices.
+   * Index will start from 1 and corresponds to the occurrence frequency of each word sorted
+   * in descending order.
+   * See WordIndexer for more details.
+   * After word2idx, you can get the wordIndex map by calling 'getWordIndex'.
+   *
+   * @param removeTopN Integer. Remove the topN words with highest frequencies in the case
+   *                   where those are treated as stopwords. Default is 0, namely remove nothing.
+   * @param maxWordsNum Integer. The maximum number of words to be taken into consideration.
+   *                    Default is -1, namely all words will be considered.
+   */
+  def word2idx(removeTopN: Int = 0, maxWordsNum: Int = -1): TextSet = {
+    if (wordIndex != null) {
+      TextSet.logger.warn("wordIndex already exists. Using the existing wordIndex")
+    } else {
+      generateWordIndexMap(removeTopN, maxWordsNum)
+    }
+    transform(WordIndexer(wordIndex))
+  }
+
+  /**
+   * Generate BigDL Sample.
+   * See TextFeatureToSample for more details.
+   */
+  def generateSample(): TextSet = {
+    transform(TextFeatureToSample())
+  }
+
+  /**
+   * Generate wordIndex map based on sorted word frequencies in descending order.
+   * Return the result map, which will also be stored in 'wordIndex'.
+   * See word2idx for more details.
+   */
+  // If the TextSet hasn't been tokenized, this will do nothing and return null.
+  // If map=null is further passed to WordIndexer, then an exception will be thrown there.
+  def generateWordIndexMap(removeTopN: Int = 0, maxWordsNum: Int = 5000): Map[String, Int]
+
+  private var wordIndex: Map[String, Int] = _
+
+  /**
+   * Get the word index map of this TextSet.
+   * If the TextSet hasn't been transformed from word to index, null will be returned.
+   */
+  def getWordIndex: Map[String, Int] = wordIndex
+
+  def setWordIndex(map: Map[String, Int]): this.type = {
+    wordIndex = map
+    this
+  }
+}
+
+
+object TextSet {
+
+  val logger: Logger = Logger.getLogger(getClass)
+
+  /**
+   * Create a LocalTextSet from array of TextFeature.
+   */
+  def array(data: Array[TextFeature]): LocalTextSet = {
+    new LocalTextSet(data)
+  }
+
+  /**
+   * Create a DistributedTextSet from RDD of TextFeature.
+   */
+  def rdd(data: RDD[TextFeature]): DistributedTextSet = {
+    new DistributedTextSet(data)
+  }
+
+  /**
+   * Read text files as TextSet.
+   * If sc is defined, read texts as DistributedTextSet from local file system or HDFS.
+   * If sc is null, read texts as LocalTextSet from local file system.
+   *
+   * @param path String. Folder path to texts. The folder structure is expected to be the following:
+   *             path
+   *                ├── dir1 - text1, text2, ...
+   *                ├── dir2 - text1, text2, ...
+   *                └── dir3 - text1, text2, ...
+   *             Under the target path, there ought to be N subdirectories (dir1 to dirN). Each
+   *             subdirectory represents a category and contains all texts that belong to such
+   *             category. Each category will be a given a label according to its position in the
+   *             ascending order sorted among all subdirectories.
+   *             All texts will be given a label according to the subdirectory where it is located.
+   *             Labels start from 0.
+   * @param sc An instance of SparkContext if any. Default is null.
+   * @param minPartitions A suggestion value of the minimal partition number.
+   *                      Integer. Default is 1. Only need to specify this when sc is not null.
+   * @return TextSet.
+   */
+  def read(path: String, sc: SparkContext = null, minPartitions: Int = 1): TextSet = {
+    val textSet = if (sc != null) {
+      // URI needs for the FileSystem to accept HDFS
+      val uri = StringUtils.stringToURI(Array(path))(0)
+      val fs = FileSystem.get(uri, new Configuration())
+      val categories = fs.listStatus(new Path(path)).map(_.getPath.getName).sorted
+      logger.info(s"Found ${categories.length} classes.")
+      // Labels of categories start from 0.
+      val indices = categories.indices
+      val categoryToLabel = categories.zip(indices).toMap
+      val textRDD = sc.wholeTextFiles(path + "/*", minPartitions).map{case (p, text) =>
+        val parts = p.split("/")
+        val category = parts(parts.length - 2)
+        TextFeature(text, label = categoryToLabel(category))
+      }
+      TextSet.rdd(textRDD)
+    }
+    else {
+      val texts = ArrayBuffer[String]()
+      val labels = ArrayBuffer[Int]()
+      val categoryToLabel = new util.HashMap[String, Int]()
+      val categoryPath = new File(path)
+      require(categoryPath.exists(), s"$path doesn't exist. Please check your input path")
+      val categoryPathList = categoryPath.listFiles().filter(_.isDirectory).toList.sorted
+      categoryPathList.foreach { categoryPath =>
+        val label = categoryToLabel.size()
+        categoryToLabel.put(categoryPath.getName, label)
+        val textFiles = categoryPath.listFiles()
+          .filter(_.isFile).filter(_.getName.forall(Character.isDigit(_))).sorted
+        textFiles.foreach { file =>
+          val source = Source.fromFile(file, "ISO-8859-1")
+          val text = try source.getLines().toList.mkString("\n") finally source.close()
+          texts.append(text)
+          labels.append(label)
+        }
+      }
+      logger.info(s"Found ${texts.length} texts.")
+      logger.info(s"Found ${categoryToLabel.size()} classes")
+      val textArr = texts.zip(labels).map{case (text, label) =>
+        TextFeature(text, label)
+      }.toArray
+      TextSet.array(textArr)
+    }
+    textSet
+  }
+
+  /**
+   * Zip word with its corresponding index. Index starts from 1.
+   * @param frequencies Array of words, each with its occurrence frequency in descending order.
+   * @return WordIndex map.
+   */
+  def wordIndexFromFrequencies(frequencies: Array[(String, Int)]): Map[String, Int] = {
+    val indexes = Range(1, frequencies.length + 1)
+    frequencies.zip(indexes).map{item =>
+      (item._1._1, item._2)}.toMap
+  }
+}
+
+
+class LocalTextSet(var array: Array[TextFeature]) extends TextSet {
+
+  override def transform(transformer: Preprocessing[TextFeature, TextFeature]): TextSet = {
+    array = transformer.apply(array.toIterator).toArray
+    this
+  }
+
+  override def isLocal: Boolean = true
+
+  override def isDistributed: Boolean = false
+
+  override def toLocal(): LocalTextSet = {
+    this
+  }
+
+  override def toDistributed(sc: SparkContext, partitionNum: Int = 4): DistributedTextSet = {
+    new DistributedTextSet(sc.parallelize(array, partitionNum))
+  }
+
+  override def toDataSet: DataSet[Sample[Float]] = {
+    DataSet.array(array.map(_[Sample[Float]](TextFeature.sample)))
+  }
+
+  override def randomSplit(weights: Array[Double]): Array[TextSet] = {
+    throw new UnsupportedOperationException("LocalTextSet doesn't support randomSplit for now")
+  }
+
+  override def generateWordIndexMap(
+    removeTopN: Int = 0, maxWordsNum: Int = -1): Map[String, Int] = {
+    try {
+      var frequencies = array.flatMap(_.getTokens).filter(_ != "##")  // "##" is the padElement.
+        .groupBy(identity).mapValues(_.length).toArray.sortBy(- _._2).drop(removeTopN)
+      if (maxWordsNum > 0) {
+        frequencies = frequencies.take(maxWordsNum)
+      }
+      val wordIndex = TextSet.wordIndexFromFrequencies(frequencies)
+      setWordIndex(wordIndex)
+      wordIndex
+    } catch {
+      case npe: NullPointerException =>
+        npe.printStackTrace()
+        TextSet.logger.warn("TextSet hasn't been tokenized yet, please call tokenize() first")
+        null
+      case e: Exception => throw e
+    }
+  }
+}
+
+
+class DistributedTextSet(var rdd: RDD[TextFeature]) extends TextSet {
+
+  override def transform(transformer: Preprocessing[TextFeature, TextFeature]): TextSet = {
+    rdd = transformer(rdd)
+    this
+  }
+
+  override def isLocal: Boolean = false
+
+  override def isDistributed: Boolean = true
+
+  override def toLocal(): LocalTextSet = {
+    new LocalTextSet(rdd.collect())
+  }
+
+  override def toDistributed(sc: SparkContext = null, partitionNum: Int = 4): DistributedTextSet = {
+    this
+  }
+
+  override def toDataSet: DataSet[Sample[Float]] = {
+    DataSet.rdd(rdd.map(_[Sample[Float]](TextFeature.sample)))
+  }
+
+  override def randomSplit(weights: Array[Double]): Array[TextSet] = {
+    rdd.randomSplit(weights).map(TextSet.rdd)
+  }
+
+  override def generateWordIndexMap(
+    removeTopN: Int = 0, maxWordsNum: Int = -1): Map[String, Int] = {
+    try {
+      var frequencies = rdd.flatMap(_.getTokens).filter(_ != "##")  // "##" is the padElement.
+        .map(word => (word, 1)).reduceByKey(_ + _).sortBy(- _._2).collect().drop(removeTopN)
+      if (maxWordsNum > 0) {
+        frequencies = frequencies.take(maxWordsNum)
+      }
+      val wordIndex = TextSet.wordIndexFromFrequencies(frequencies)
+      setWordIndex(wordIndex)
+      wordIndex
+    } catch {
+      // Most likely that the reason is the TextSet hasn't been tokenized yet.
+      case s: SparkException =>
+        s.printStackTrace()
+        null
+      case e: Exception => throw e
+    }
+  }
+}

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/WordIndexer.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/WordIndexer.scala
@@ -16,6 +16,8 @@
 
 package com.intel.analytics.zoo.feature.text
 
+import org.apache.log4j.Logger
+
 /**
  * Given a wordIndex map, transform tokens to corresponding indices.
  * Input key: TextFeature.tokens
@@ -30,6 +32,12 @@ package com.intel.analytics.zoo.feature.text
 class WordIndexer(
    val map: Map[String, Int],
    val replaceElement: Int = 0) extends TextTransformer {
+
+  require(map != null, "map for WordIndexer can't be null")
+
+  if (map.values.exists(_ == replaceElement)) {
+    WordIndexer.logger.warn(s"replaceElement $replaceElement exists in the wordIndex map")
+  }
 
   override def transform(feature: TextFeature): TextFeature = {
     require(feature.contains(TextFeature.tokens), "TextFeature doesn't contain tokens yet, " +
@@ -49,6 +57,8 @@ class WordIndexer(
 }
 
 object WordIndexer {
+  val logger: Logger = Logger.getLogger(getClass)
+
   def apply(
      wordIndex: Map[String, Int],
      replaceElement: Int = 0): WordIndexer = {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/textclassification/TextClassifier.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/textclassification/TextClassifier.scala
@@ -16,12 +16,15 @@
 
 package com.intel.analytics.zoo.models.textclassification
 
+import com.intel.analytics.bigdl.Criterion
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
+import com.intel.analytics.bigdl.optim.{OptimMethod, ValidationMethod, ValidationResult}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.zoo.feature.text.TextSet
 import com.intel.analytics.zoo.models.common.ZooModel
 import com.intel.analytics.zoo.pipeline.api.keras.layers._
-import com.intel.analytics.zoo.pipeline.api.keras.models.Sequential
+import com.intel.analytics.zoo.pipeline.api.keras.models.{KerasNet, Sequential}
 
 import scala.reflect.ClassTag
 
@@ -63,6 +66,34 @@ class TextClassifier[T: ClassTag] private(
     model.add(Activation("relu"))
     model.add(Dense(classNum, activation = "softmax"))
     model
+  }
+
+  def compile(
+      optimizer: OptimMethod[T],
+      loss: Criterion[T],
+      metrics: List[ValidationMethod[T]] = null)(implicit ev: TensorNumeric[T]): Unit = {
+    model.asInstanceOf[KerasNet[T]].compile(optimizer, loss, metrics)
+  }
+
+  def fit(
+      x: TextSet,
+      batchSize: Int,
+      nbEpoch: Int,
+      validationData: TextSet = null)(implicit ev: TensorNumeric[T]): Unit = {
+    model.asInstanceOf[KerasNet[T]].fit(x, batchSize, nbEpoch, validationData)
+  }
+
+  def evaluate(
+      x: TextSet,
+      batchSize: Int)
+    (implicit ev: TensorNumeric[T]): Array[(ValidationResult, ValidationMethod[T])] = {
+    model.asInstanceOf[KerasNet[T]].evaluate(x, batchSize)
+  }
+
+  def predict(
+      x: TextSet,
+      batchPerThread: Int): TextSet = {
+    model.asInstanceOf[KerasNet[T]].predict(x, batchPerThread)
   }
 }
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/Embedding.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/Embedding.scala
@@ -61,8 +61,8 @@ object Embedding {
       outputDim: Int,
       init: String = "uniform",
       wRegularizer: Regularizer[T] = null,
-      inputShape: Shape = null)(implicit ev: TensorNumeric[T]): Embedding[T] = {
+      inputLength: Int)(implicit ev: TensorNumeric[T]): Embedding[T] = {
     new Embedding[T](inputDim, outputDim, KerasUtils.getInitMethod(init),
-      wRegularizer, inputShape)
+      wRegularizer, Shape(inputLength))
   }
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/python/PythonZooKeras.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/python/PythonZooKeras.scala
@@ -46,6 +46,7 @@ import com.intel.analytics.zoo.pipeline.api.net._
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.rdd.RDD
 import com.intel.analytics.bigdl.dataset.{Sample => JSample}
+import com.intel.analytics.zoo.feature.text.TextSet
 
 import scala.collection.mutable.ArrayBuffer
 import scala.io.Source
@@ -112,6 +113,15 @@ class PythonZooKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonB
       batchSize: Int,
       nbEpoch: Int,
       validationData: ImageSet): Unit = {
+    module.fit(x, batchSize, nbEpoch, validationData)
+  }
+
+  def zooFit(
+      module: KerasNet[T],
+      x: TextSet,
+      batchSize: Int,
+      nbEpoch: Int,
+      validationData: TextSet): Unit = {
     module.fit(x, batchSize, nbEpoch, validationData)
   }
 
@@ -200,16 +210,27 @@ class PythonZooKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonB
     module.predict(x, batchPerThread)
   }
 
+  def zooPredict(
+      module: KerasNet[T],
+      x: TextSet,
+      batchPerThread: Int): TextSet = {
+    module.predict(x, batchPerThread)
+  }
+
+  private def processEvaluateResult(
+    resultArray: Array[(ValidationResult, ValidationMethod[T])]): JList[EvaluatedResult] = {
+    resultArray.map { result =>
+      EvaluatedResult(result._1.result()._1, result._1.result()._2,
+        result._2.toString())
+    }.toList.asJava
+  }
+
   def zooEvaluate(
       module: KerasNet[T],
       x: JavaRDD[Sample],
       batchSize: Int = 32): JList[EvaluatedResult] = {
     val resultArray = module.evaluate(toJSample(x), batchSize)
-    val testResultArray = resultArray.map { result =>
-      EvaluatedResult(result._1.result()._1, result._1.result()._2,
-        result._2.toString())
-    }
-    testResultArray.toList.asJava
+    processEvaluateResult(resultArray)
   }
 
   def zooEvaluate(
@@ -217,11 +238,15 @@ class PythonZooKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonB
       x: ImageSet,
       batchSize: Int): JList[EvaluatedResult] = {
     val resultArray = module.evaluate(x, batchSize)
-    val testResultArray = resultArray.map { result =>
-      EvaluatedResult(result._1.result()._1, result._1.result()._2,
-        result._2.toString())
-    }
-    testResultArray.toList.asJava
+    processEvaluateResult(resultArray)
+  }
+
+  def zooEvaluate(
+      module: KerasNet[T],
+      x: TextSet,
+      batchSize: Int): JList[EvaluatedResult] = {
+    val resultArray = module.evaluate(x, batchSize)
+    processEvaluateResult(resultArray)
   }
 
   def zooSetTensorBoard(
@@ -349,7 +374,7 @@ class PythonZooKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonB
       init: String = "uniform",
       wRegularizer: Regularizer[T] = null,
       inputShape: JList[Int] = null): Embedding[T] = {
-    Embedding[T](inputDim, outputDim, init, wRegularizer, toScalaShape(inputShape))
+    Embedding[T](inputDim, outputDim, init, wRegularizer, inputShape.get(0))
   }
 
   def createZooKerasBatchNormalization(

--- a/zoo/src/test/integration-test.robot
+++ b/zoo/src/test/integration-test.robot
@@ -67,7 +67,7 @@ Run Spark Test
    [Arguments]                      ${submit}                   ${spark_master}
    DownLoad Input
    Log To Console                   begin text classification
-   Run Shell                        ${submit} --master ${spark_master} --driver-memory 5g --executor-memory 5g --total-executor-cores 32 --executor-cores 8 --class com.intel.analytics.zoo.examples.textclassification.TextClassification ${jar_path} --batchSize 128 --baseDir /tmp/text_data --partitionNum 32 --nbEpoch 2
+   Run Shell                        ${submit} --master ${spark_master} --driver-memory 2g --executor-memory 2g --total-executor-cores 32 --executor-cores 8 --class com.intel.analytics.zoo.examples.textclassification.TextClassification ${jar_path} --batchSize 128 --dataPath /tmp/text_data/20news-18828 --embeddingPath /tmp/text_data/glove.6B --partitionNum 32 --nbEpoch 2
    Log To Console                   begin image classification
    Run Shell                        ${submit} --master ${spark_master} --driver-memory 5g --executor-memory 5g --total-executor-cores 32 --executor-cores 8 --class com.intel.analytics.zoo.examples.imageclassification.Predict ${jar_path} -f ${public_hdfs_master}:9000/kaggle/train_100 --topN 1 --model /tmp/imageclassification/analytics-zoo_squeezenet-quantize_imagenet_0.1.0.model --partition 32
    Log To Console                   begin object detection

--- a/zoo/src/test/resources/news20/alt.atheism/51158
+++ b/zoo/src/test/resources/news20/alt.atheism/51158
@@ -1,0 +1,15 @@
+Subject: So what is Maddi?
+From: madhaus@netcom.com (Maddi Hausmann)
+
+As I was created in the image of Gaea, therefore I must
+be the pinnacle of creation, She which Creates, She which
+Births, She which Continues.
+
+Or, to cut all the religious crap, I'm a woman, thanks.
+And it's sexism that started me on the road to atheism.
+
+-- 
+Maddi Hausmann                       madhaus@netcom.com
+Centigram Communications Corp        San Jose California  408/428-3553
+
+Kids, please don't try this at home.  Remember, I post professionally.

--- a/zoo/src/test/resources/news20/alt.atheism/51186
+++ b/zoo/src/test/resources/news20/alt.atheism/51186
@@ -1,0 +1,18 @@
+From: livesey@solntze.wpd.sgi.com (Jon Livesey)
+Subject: Re: An Anecdote about Islam
+
+In article <114127@bu.edu>, jaeger@buphy.bu.edu (Gregg Jaeger) writes:
+|> 
+|> I don't understand the point of this petty sarcasm. It is a basic 
+|> principle of Islam that if one is born muslim or one says "I testify
+|> that there is no god but God and Mohammad is a prophet of God" that,
+|> so long as one does not explicitly reject Islam by word then one _must_
+|> be considered muslim by all muslims. So the phenomenon you're attempting
+|> to make into a general rule or psychology is a direct odds with basic
+|> Islamic principles. If you want to attack Islam you could do better than
+|> than to argue against something that Islam explicitly contradicts.
+
+Then Mr Mozumder is incorrect when he says that when committing
+bad acts, people temporarily become atheists?
+
+jon.

--- a/zoo/src/test/resources/news20/rec.autos/101556
+++ b/zoo/src/test/resources/news20/rec.autos/101556
@@ -1,0 +1,15 @@
+From: reb@hprnd.rose.hp.com (Ralph Bean)
+Subject: Re: saturn pricing blatherings
+
+Mihir Pramod Shah (mps1@cec1.wustl.edu) wrote:
+: Robert J. Wade writes:
+: > until...and more Saturn retailers are built(like 2 in the same city), 
+:                        		     ^^^^^^^^^^^^^^^^^^^^^^^
+: ...most medium and large cities have...a small handful of Saturn dealers now
+
+Sacramento has two Saturn dealerships.
+
+: Mihir Shah
+
+Ralph Bean
+hprnd.rose.hp.com

--- a/zoo/src/test/resources/news20/sci.space/60209
+++ b/zoo/src/test/resources/news20/sci.space/60209
@@ -1,0 +1,34 @@
+From: enf021@cck.coventry.ac.uk (Achurist)
+Subject: Re: Abyss: breathing fluids
+
+In article <93089.204431GRV101@psuvm.psu.edu> Callec Dradja <GRV101@psuvm.psu.edu> writes:
+>I am a bit nervous about posting this beacause it is begining to
+>stray fron the topic of space but then again that doesn't seem to
+>stop alot of other people. :-)
+>
+>With all of this talk about breathing at high pressures, I began
+>to think about the movie Abyss. If you remember, in that movie one
+>of the characters dove to great depths by wearing a suit that used
+>a fluid that carries oxegen as opposed to some sort of gas. Now I
+>have heard that mice can breath this fluid but for some reason, humans
+>are unable to. Does anyone know more details about this?
+>
+>Gregson Vaux
+>
+
+I believe the reason is that the lung diaphram gets too tired to pump
+the liquid in and out and simply stops breathing after 2-3 minutes.
+So if your in the vehicle ready to go they better not put you on 
+hold, or else!! That's about it. Remember a liquid is several more times
+as dense as a gas by its very nature. ~10 I think, depending on the gas
+and liquid comparision of course!
+
+Acurist
+
+
+
+
+
+
+
+

--- a/zoo/src/test/resources/news20/sci.space/60249
+++ b/zoo/src/test/resources/news20/sci.space/60249
@@ -1,0 +1,31 @@
+From: dpage@ra.csc.ti.com (Doug Page)
+Subject: Re: Sr-71 in propoganda films?
+
+In article <1993Apr5.220610.1532@sequent.com>, bigfoot@sequent.com (Gregory Smith) writes:
+|> mccall@mksol.dseg.ti.com (fred j mccall 575-3539) writes:
+|> 
+|> >In <1phv98$jbk@access.digex.net> prb@access.digex.com (Pat) writes:
+|> 
+|> 
+|> >>THe SR-71 stopped being a real secret by the mid 70's.
+|> >>I had a friend in high school who had a poster with it's picture.
+|> 
+|> >It was known well before that.  I built a model of it sometime in the
+|> >mid 60's, billed as YF-12A/SR-71.  The model was based on YF-12A specs
+|> >and had a big radar in the nose and 8 AAMs in closed bays on the
+|> >underside of the fuselage.  The description, even then, read "speeds
+|> >in excess of Mach 3 at altitudes exceeding 80,000 feet."
+|> 
+|> L.B.J. publically announced the existance of the Blackbird program
+|> in 1964.
+
+
+He's also the one who dubbed it the SR-71 - it was the RS-71 until LBJ
+mippselled (sic) it.
+
+FWIW,
+
+Doug Page
+
+***  The opinions are mine (maybe), and don't necessarily represent those  ***
+***  of my employer.                                                       ***

--- a/zoo/src/test/scala/com/intel/analytics/zoo/feature/text/TextFeatureSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/feature/text/TextFeatureSpec.scala
@@ -31,7 +31,8 @@ class TextFeatureSpec extends FlatSpec with Matchers {
     require(feature.getLabel == 0)
     require(feature.keys() == HashSet("label", "text"))
     require(feature.getTokens == null)
-    require(feature.getSample[Float] == null)
+    require(feature.getSample == null)
+    require(feature.getPredict == null)
   }
 
   "TextFeature without label" should "work properly" in {

--- a/zoo/src/test/scala/com/intel/analytics/zoo/feature/text/TextFeatureToSampleSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/feature/text/TextFeatureToSampleSpec.scala
@@ -16,7 +16,6 @@
 
 package com.intel.analytics.zoo.feature.text
 
-import com.intel.analytics.bigdl.dataset.Sample
 import org.scalatest.{FlatSpec, Matchers}
 
 class TextFeatureToSampleSpec extends FlatSpec with Matchers {
@@ -31,7 +30,7 @@ class TextFeatureToSampleSpec extends FlatSpec with Matchers {
   "TextFeatureToSample with label" should "work properly" in {
     val toSample = TextFeatureToSample()
     val transformed = toSample.transform(genFeature().setLabel(1))
-    val sample = transformed[Sample[Float]](TextFeature.sample)
+    val sample = transformed.getSample
     require(sample.getData().sameElements(Array(1.0f, 2.0f,
       3.0f, 4.0f, 5.0f, 2.0f, 6.0f, 1.0f)))
   }
@@ -39,7 +38,7 @@ class TextFeatureToSampleSpec extends FlatSpec with Matchers {
   "TextFeatureToSample without label" should "work properly" in {
     val toSample = TextFeatureToSample()
     val transformed = toSample.transform(genFeature())
-    val sample = transformed[Sample[Float]](TextFeature.sample)
+    val sample = transformed.getSample
     require(sample.getData().sameElements(Array(1.0f, 2.0f,
       3.0f, 4.0f, 5.0f, 2.0f, 6.0f)))
   }

--- a/zoo/src/test/scala/com/intel/analytics/zoo/feature/text/TextSetSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/feature/text/TextSetSpec.scala
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2018 Analytics Zoo Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.zoo.feature.text
+
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric.NumericFloat
+import com.intel.analytics.zoo.common.NNContext
+import com.intel.analytics.zoo.pipeline.api.keras.layers.{Convolution1D, Dense, Embedding, Flatten}
+import com.intel.analytics.zoo.pipeline.api.keras.models.Sequential
+import org.apache.spark.{SparkConf, SparkContext}
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+
+import scala.collection.immutable.HashSet
+
+class TextSetSpec extends FlatSpec with Matchers with BeforeAndAfter {
+  val text1 = "Hello my friend, please annotate my text"
+  val text2 = "hello world, this is some sentence for my test"
+  val path: String = getClass.getClassLoader.getResource("news20").getPath
+  var sc : SparkContext = _
+
+  before {
+    val conf = new SparkConf().setAppName("Test TextSet").setMaster("local[1]")
+    sc = NNContext.initNNContext(conf)
+  }
+
+  after {
+    if (sc != null) {
+      sc.stop()
+    }
+  }
+
+  private def genFeatures(): Array[TextFeature] = {
+    val feature1 = TextFeature(text1, label = 0)
+    val feature2 = TextFeature(text2, label = 1)
+    Array(feature1, feature2)
+  }
+
+  def buildModel(): Sequential[Float] = {
+    val model = Sequential()
+    model.add(Embedding(300, 20, inputLength = 30))
+    model.add(Convolution1D(8, 4))
+    model.add(Flatten())
+    model.add(Dense(3, activation = "softmax"))
+    model
+  }
+
+  "DistributedTextSet Transformation" should "work properly" in {
+    val distributed = TextSet.rdd(sc.parallelize(genFeatures()))
+    require(distributed.isDistributed)
+    val shaped = distributed -> Tokenizer() -> Normalizer() -> SequenceShaper(len = 5)
+    val transformed = shaped.word2idx().generateSample()
+    require(transformed.isDistributed)
+
+    val wordIndex = transformed.getWordIndex
+    require(wordIndex.toArray.length == 9)
+    require(wordIndex.keySet == HashSet("friend", "please", "annotate", "my", "text",
+      "some", "sentence", "for", "test"))
+    require(wordIndex("my") == 1)
+
+    val features = transformed.toDistributed().rdd.collect()
+    require(features.length == 2)
+    require(features(0).keys() == HashSet("label", "text", "tokens", "indexedTokens", "sample"))
+    require(features(0)[Array[Float]]("indexedTokens").length == 5)
+  }
+
+  "LocalTextSet Transformation" should "work properly" in {
+    val local = TextSet.array(genFeatures())
+    require(local.isLocal)
+    val transformed = local.tokenize().normalize().shapeSequence(len = 10)
+      .word2idx(removeTopN = 1).generateSample()
+    require(transformed.isLocal)
+
+    val wordIndex = transformed.getWordIndex
+    require(wordIndex.toArray.length == 12)
+    require(wordIndex.keySet.contains("hello"))
+    require(!wordIndex.keySet.contains("Hello"))
+    require(!wordIndex.keySet.contains("##"))
+
+    val features = transformed.toLocal().array
+    require(features.length == 2)
+    require(features(0).keys() == HashSet("label", "text", "tokens", "indexedTokens", "sample"))
+    require(features(0)[Array[Float]]("indexedTokens").length == 10)
+  }
+
+  "TextSet read with sc, fit, predict and evaluate" should "work properly" in {
+    val textSet = TextSet.read(path, sc)
+    require(textSet.isDistributed)
+    require(textSet.toDistributed().rdd.count() == 5)
+    require(textSet.toDistributed().rdd.collect().head.keys() == HashSet("label", "text"))
+    val transformed = textSet.tokenize().normalize()
+      .shapeSequence(len = 30).word2idx().generateSample()
+    val model = buildModel()
+    model.compile("sgd", "sparse_categorical_crossentropy", List("accuracy"))
+    model.fit(transformed, batchSize = 4, nbEpoch = 2, validationData = transformed)
+    require(! transformed.toDistributed().rdd.first().contains("predict"))
+    val predictSet = model.predict(transformed, batchPerThread = 1)
+    require(predictSet.toDistributed().rdd.first().contains("predict"))
+    val accuracy = model.evaluate(transformed, batchSize = 4)
+  }
+
+  "TextSet read without sc, fit, predict and evaluate" should "work properly" in {
+    val textSet = TextSet.read(path)
+    require(textSet.isLocal)
+    require(textSet.toLocal().array.length == 5)
+    require(textSet.toLocal().array.head.keys() == HashSet("label", "text"))
+    val tokenized = textSet -> Tokenizer() -> Normalizer() -> SequenceShaper(len = 30)
+    val wordIndex = tokenized.generateWordIndexMap()
+    val transformed = tokenized -> WordIndexer(wordIndex) -> TextFeatureToSample()
+    require(transformed.getWordIndex == wordIndex)
+    val model = buildModel()
+    model.compile("sgd", "sparse_categorical_crossentropy", List("accuracy"))
+    model.fit(transformed, batchSize = 4, nbEpoch = 2, validationData = transformed)
+    require(! transformed.toLocal().array.head.contains("predict"))
+    val predictSet = model.predict(transformed, batchPerThread = 1)
+    require(predictSet.toLocal().array.head.contains("predict"))
+    val accuracy = model.evaluate(transformed, batchSize = 4)
+  }
+}

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/EmbeddingSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/EmbeddingSpec.scala
@@ -26,7 +26,7 @@ class EmbeddingSpec extends KerasBaseSpec {
   // Compared results with Keras on Python side
   "Embedding" should "work properly" in {
     val seq = Sequential[Float]()
-    val layer = Embedding[Float](1000, 32, inputShape = Shape(4))
+    val layer = Embedding[Float](1000, 32, inputLength = 4)
     seq.add(layer)
     seq.getOutputShape().toSingle().toArray should be (Array(-1, 4, 32))
     val input = Tensor[Float](2, 4)
@@ -46,7 +46,7 @@ class EmbeddingSpec extends KerasBaseSpec {
 
 class EmbeddingSerialTest extends ModuleSerializationTest {
   override def test(): Unit = {
-    val layer = Embedding[Float](1000, 32, inputShape = Shape(4))
+    val layer = Embedding[Float](1000, 32, inputLength = 4)
     layer.build(Shape(2, 4))
     val input = Tensor[Float](2, 4)
     input(Array(1, 1)) = 1

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/models/TopologySpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/models/TopologySpec.scala
@@ -92,7 +92,7 @@ class TopologySpec extends FlatSpec with Matchers with BeforeAndAfter {
 
   "model.summary() for Sequential" should "work properly" in {
     val model = Sequential[Float]()
-    model.add(Embedding[Float](20000, 128, inputShape = Shape(100)).setName("embedding1"))
+    model.add(Embedding[Float](20000, 128, inputLength = 100).setName("embedding1"))
     model.add(Dropout[Float](0.25))
     model.add(Convolution1D[Float](nbFilter = 64, filterLength = 5, borderMode = "valid",
       activation = "relu", subsampleLength = 1).setName("conv1"))


### PR DESCRIPTION
The second PR separated from #601 with modifications.
- Add TextSet.
- Update TextClassification examples using TextSet and Transformers.
- Fit, predict and evaluate on TextSet.
- Add some missing doc for Python TextFeature.

Some remarks:
- Directly reading using sc is slower in the preprocessing step (collecting word frequencies) than reading without sc and transforming to DistributedTextSet afterwards.
- Will add predictor in a separate PR.