### PR TITLE
replace bytes with mat in nnframes

### DIFF
--- a/pyzoo/test/zoo/pipeline/nnframes/test_nn_image_reader.py
+++ b/pyzoo/test/zoo/pipeline/nnframes/test_nn_image_reader.py
@@ -53,7 +53,7 @@ class TestNNImageReader():
         assert first_row[2] == 500
         assert first_row[3] == 3
         assert first_row[4] == 16
-        assert len(first_row[5]) == 95959
+        assert len(first_row[5]) == 563500
 
     def test_read_image_withOriginColumn(self):
         image_path = os.path.join(self.resource_path, "pascal/000025.jpg")

--- a/pyzoo/test/zoo/pipeline/nnframes/test_nn_image_reader.py
+++ b/pyzoo/test/zoo/pipeline/nnframes/test_nn_image_reader.py
@@ -53,7 +53,7 @@ class TestNNImageReader():
         assert first_row[2] == 500
         assert first_row[3] == 3
         assert first_row[4] == 16
-        assert len(first_row[5]) == 563500
+        assert len(first_row[5]) == 562500
 
     def test_read_image_withOriginColumn(self):
         image_path = os.path.join(self.resource_path, "pascal/000025.jpg")

--- a/pyzoo/zoo/pipeline/nnframes/nn_image_reader.py
+++ b/pyzoo/zoo/pipeline/nnframes/nn_image_reader.py
@@ -39,7 +39,12 @@ class NNImageReader:
         :param resizeH height after resize, by default is -1 which will not resize the image
         :param resizeW width after resize, by default is -1 which will not resize the image
         :param image_codec specifying the color type of a loaded image, same as in OpenCV.imread.
-               By default is Imgcodecs.CV_LOAD_IMAGE_UNCHANGED(-1)
+               By default is Imgcodecs.CV_LOAD_IMAGE_UNCHANGED(-1).
+               >0 Return a 3-channel color image. Note In the current implementation the
+                  alpha channel, if any, is stripped from the output image. Use negative value
+                  if you need the alpha channel.
+               =0 Return a grayscale image.
+               <0 Return the loaded image as is (with alpha channel if any).
         :return DataFrame with a single column "image"; Each record in the column represents
                 one image record: Row (uri, height, width, channels, CvType, bytes).
         """

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNImageReader.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNImageReader.scala
@@ -101,7 +101,7 @@ object NNImageSchema {
       case CvType.CV_8UC3 | CvType.CV_8UC1 | CvType.CV_8UC4 =>
         val bytesData = row.getAs[Array[Byte]](5)
         val mat = new Mat(h, w, storageType)
-        mat.put(0,0, bytesData)
+        mat.put(0, 0, bytesData)
         val opencvMat = new OpenCVMat(mat)
         imf(ImageFeature.mat) = opencvMat
         imf(ImageFeature.originalSize) = opencvMat.shape()

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNImageReader.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNImageReader.scala
@@ -17,13 +17,14 @@
 package com.intel.analytics.zoo.pipeline.nnframes
 
 import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
-import com.intel.analytics.bigdl.transform.vision.image.{BytesToMat, ImageFeature, ImageFrame}
+import com.intel.analytics.bigdl.transform.vision.image.opencv.OpenCVMat
+import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
 import com.intel.analytics.zoo.feature.image.ImageSet
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
-import org.opencv.core.CvType
+import org.opencv.core.{CvType, Mat}
 import org.opencv.imgcodecs.Imgcodecs
 
 import scala.language.existentials
@@ -43,7 +44,7 @@ object NNImageSchema {
       StructField("nChannels", IntegerType, false) ::
       // OpenCV-compatible type: CV_8UC3, CV_8UC1 in most cases
       StructField("mode", IntegerType, false) ::
-      // Bytes in image file
+      // Bytes in row-wise BGR
       StructField("data", BinaryType, false) :: Nil)
 
   /**
@@ -70,18 +71,14 @@ object NNImageSchema {
           s" $other in ${imf.uri()}. Only 1, 3 and 4 are supported.")
       }
       (cvType, floatData)
-    } else if (imf.contains(ImageFeature.bytes)) {
-      val bytesData = imf.bytes()
-      val cvType = imf.getChannel() match {
-        case 1 => CvType.CV_8UC1
-        case 3 => CvType.CV_8UC3
-        case 4 => CvType.CV_8UC4
-        case other => throw new IllegalArgumentException(s"Unsupported number of channels:" +
-          s" $other in ${imf.uri()}. Only 1, 3 and 4 are supported.")
-      }
+    } else if (imf.contains(ImageFeature.mat)) {
+      val mat = imf.opencvMat()
+      val cvType = mat.`type`()
+      val bytesData = new Array[Byte]((mat.total() * mat.elemSize()).toInt)
+      mat.get(0, 0, bytesData)
       (cvType, bytesData)
     } else {
-      throw new IllegalArgumentException(s"ImageFeature should have imageTensor or bytes.")
+      throw new IllegalArgumentException(s"ImageFeature should have imageTensor or mat.")
     }
 
     Row(
@@ -102,8 +99,12 @@ object NNImageSchema {
     val storageType = row.getInt(4)
     storageType match {
       case CvType.CV_8UC3 | CvType.CV_8UC1 | CvType.CV_8UC4 =>
-        imf.update(ImageFeature.bytes, row.getAs[Array[Byte]](5))
-        BytesToMat().transform(imf)
+        val bytesData = row.getAs[Array[Byte]](5)
+        val mat = new Mat(h, w, storageType)
+        mat.put(0,0, bytesData)
+        val opencvMat = new OpenCVMat(mat)
+        imf(ImageFeature.mat) = opencvMat
+        imf(ImageFeature.originalSize) = opencvMat.shape()
       case CvType.CV_32FC3 | CvType.CV_32FC1 | CvType.CV_32FC4 =>
         val data = row.getSeq[Float](5).toArray
         val size = Array(h, w, c)
@@ -162,7 +163,12 @@ object NNImageReader {
    * @param resizeH height after resize, by default is -1 which will not resize the image
    * @param resizeW width after resize, by default is -1 which will not resize the image
    * @param imageCodec specifying the color type of a loaded image, same as in OpenCV.imread.
-   *              By default is Imgcodecs.CV_LOAD_IMAGE_UNCHANGED
+   *              By default is Imgcodecs.CV_LOAD_IMAGE_UNCHANGED.
+   *              >0 Return a 3-channel color image. Note In the current implementation the
+   *                 alpha channel, if any, is stripped from the output image. Use negative value
+   *                  if you need the alpha channel.
+   *              =0 Return a grayscale image.
+   *              <0 Return the loaded image as is (with alpha channel if any).
    * @return DataFrame with a single column "image" of images;
    *         see DLImageSchema.byteSchema for the details
    */

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/nnframes/NNImageReaderSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/nnframes/NNImageReaderSpec.scala
@@ -58,7 +58,7 @@ class NNImageReaderSpec extends FlatSpec with Matchers with BeforeAndAfter {
     assert(r.getInt(2) == 500)
     assert(r.getInt(3) == 3)
     assert(r.getInt(4) == CvType.CV_8UC3)
-    assert(r.getAs[Array[Byte]](5).length == 95959)
+    assert(r.getAs[Array[Byte]](5).length == 562500)
   }
 
   "NNImageReader" should "has correct result for imageNet" in {
@@ -103,6 +103,17 @@ class NNImageReaderSpec extends FlatSpec with Matchers with BeforeAndAfter {
     assert(imageDF.count() == 6)
   }
 
+  "read png image" should "work with image_codec" in {
+    val resource = getClass.getClassLoader.getResource("png/zoo.png")
+    val df = NNImageReader.readImages(resource.getFile, sc, imageCodec = 1)
+    assert(df.count() == 1)
+    val r = df.head().getAs[Row](0)
+    assert(r.getString(0).endsWith("png/zoo.png"))
+    // should only have 3 channels with image_codec
+    assert(r.getInt(3) == 3)
+    assert(r.getInt(4) == CvType.CV_8UC3)
+  }
+
   "read gray scale image" should "work" in {
     val resource = getClass.getClassLoader.getResource("gray/gray.bmp")
     val df = NNImageReader.readImages(resource.getFile, sc)
@@ -113,6 +124,30 @@ class NNImageReaderSpec extends FlatSpec with Matchers with BeforeAndAfter {
     assert(r.getInt(2) == 50)
     assert(r.getInt(3) == 1)
     assert(r.getInt(4) == CvType.CV_8UC1)
+  }
+
+  "read gray scale image with resize" should "work" in {
+    val resource = getClass.getClassLoader.getResource("gray/gray.bmp")
+    val df = NNImageReader.readImages(resource.getFile, sc, -1, 300, 300)
+    assert(df.count() == 1)
+    val r = df.head().getAs[Row](0)
+    assert(r.getString(0).endsWith("gray.bmp"))
+    assert(r.getInt(1) == 300)
+    assert(r.getInt(2) == 300)
+    assert(r.getInt(3) == 1)
+    assert(r.getInt(4) == CvType.CV_8UC1)
+  }
+
+  "read gray scale image with image_codec" should "work" in {
+    val resource = getClass.getClassLoader.getResource("gray/gray.bmp")
+    val df = NNImageReader.readImages(resource.getFile, sc, imageCodec = 1)
+    assert(df.count() == 1)
+    val r = df.head().getAs[Row](0)
+    assert(r.getString(0).endsWith("gray.bmp"))
+    assert(r.getInt(1) == 50)
+    assert(r.getInt(2) == 50)
+    assert(r.getInt(3) == 3)
+    assert(r.getInt(4) == CvType.CV_8UC3)
   }
 
   "NNImageReader" should "support withOriginColumn" in {


### PR DESCRIPTION
Since ImageSet.read already creates Mat from image bytes, NNImageReader now can just save the converted mat in DataFrame, and original files bytes are no longer useful and is removed from generated imageFeature.