### PR TITLE
Remove pip install version in python guide

### DIFF
--- a/docs/docs/PythonUserGuide/install.md
+++ b/docs/docs/PythonUserGuide/install.md
@@ -6,12 +6,12 @@ For Python users, Analytics Zoo can be installed either [from pip](#install-from
 ## **Install from pip**
 You can use the following command to install the latest release version of __analytics-zoo__ via pip easily:
 
-* Note that you might need to add `sudo` if you don't have the permission for installation.
-
 ```bash
 pip install analytics-zoo     # for Python 2.7
 pip3 install analytics-zoo    # for Python 3.5 and Python 3.6
 ```
+
+* Note that you might need to add `sudo` if you don't have the permission for installation.
 
 **Important:**
 

--- a/docs/docs/PythonUserGuide/install.md
+++ b/docs/docs/PythonUserGuide/install.md
@@ -4,17 +4,13 @@ For Python users, Analytics Zoo can be installed either [from pip](#install-from
 
 ---
 ## **Install from pip**
-
-Analytics Zoo can be installed via pip easily using the following command.
-
-***Install analytics-zoo-0.3.0.dev0***
+You can use the following command to install the latest release version of __analytics-zoo__ via pip easily:
 
 * Note that you might need to add `sudo` if you don't have the permission for installation.
 
 ```bash
-pip install --upgrade pip
-pip install analytics-zoo==0.3.0.dev0     # for Python 2.7
-pip3 install analytics-zoo==0.3.0.dev0    # for Python 3.5 and Python 3.6
+pip install analytics-zoo     # for Python 2.7
+pip3 install analytics-zoo    # for Python 3.5 and Python 3.6
 ```
 
 **Important:**
@@ -29,11 +25,11 @@ sc = init_nncontext()
 
 **Remarks:**
 
-1. We've tested this package with pip 9.0.1.
+1. We've tested this package with pip 9.0.1. `pip install --upgrade pip` if necessary.
 2. Pip install supports __Mac__ and __Linux__ platforms.
 3. Pip install only supports __local__ mode. Cluster mode might be supported in the future. For those who want to use Analytics Zoo in cluster mode, please try to [install without pip](#install-without-pip).
 4. You need to install Java __>= JDK8__ before running Analytics Zoo, which is required by `pyspark`.
-5. `pyspark`(2.2), `bigdl==0.6.0` and its dependencies will be automatically installed if they haven't been detected in the current Python environment.
+5. `pyspark`, `bigdl==0.6.0` and their dependencies will automatically be installed if they haven't been detected in the current Python environment.
 
 
 ---


### PR DESCRIPTION
In the case that README links to the python install page of master branch, it is not reasonable if we specify `==0.3.0.dev0` (an unreleased version)