### PR TITLE
Fix Accuracy for binary classification

### DIFF
--- a/pyzoo/zoo/pipeline/api/keras/metrics.py
+++ b/pyzoo/zoo/pipeline/api/keras/metrics.py
@@ -40,7 +40,7 @@ class AUC(JavaValue):
 class Accuracy(ZooKerasCreator, JavaValue):
     """
     Measures top1 accuracy for multi-class classification
-    or accuracy for binary classification..
+    or accuracy for binary classification.
 
     # Arguments
     zero_based_label: Boolean. Whether target labels start from 0. Default is True.

--- a/pyzoo/zoo/pipeline/api/keras/metrics.py
+++ b/pyzoo/zoo/pipeline/api/keras/metrics.py
@@ -39,11 +39,14 @@ class AUC(JavaValue):
 
 class Accuracy(ZooKerasCreator, JavaValue):
     """
-    Measures top1 accuracy for classification problems.
+    Measures top1 accuracy for multi-class classification
+    or accuracy for binary classification..
 
     # Arguments
     zero_based_label: Boolean. Whether target labels start from 0. Default is True.
                       If False, labels start from 1.
+                      Note that this only takes effect for multi-class classification.
+                      For binary classification, labels ought to be 0 or 1.
 
     >>> acc = Accuracy()
     creating: createZooKerasAccuracy
@@ -55,7 +58,7 @@ class Accuracy(ZooKerasCreator, JavaValue):
 
 class Top5Accuracy(ZooKerasCreator, JavaValue):
     """
-    Measures top5 accuracy for classification problems.
+    Measures top5 accuracy for multi-class classification.
 
     # Arguments
     zero_based_label: Boolean. Whether target labels start from 0. Default is True.

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/metrics/Accuracy.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/metrics/Accuracy.scala
@@ -23,10 +23,13 @@ import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import scala.reflect.ClassTag
 
 /**
- * Measures top1 accuracy for classification problems.
+ * Measures top1 accuracy for multi-class classification
+ * or accuracy for binary classification.
  *
  * @param zeroBasedLabel Boolean. Whether target labels start from 0. Default is true.
  *                       If false, labels start from 1.
+ *                       Note that this only takes effect for multi-class classification.
+ *                       For binary classification, labels ought to be 0 or 1.
  */
 class Accuracy[T: ClassTag](
     val zeroBasedLabel: Boolean = true)(implicit ev: TensorNumeric[T])
@@ -34,7 +37,10 @@ class Accuracy[T: ClassTag](
 
   override def apply(output: Activity, target: Activity):
   ValidationResult = {
-    if (zeroBasedLabel) {
+    val _output = output.toTensor[T]
+    val binaryClassification = (_output.dim() == 2 && _output.size(2) == 1) ||
+      (_output.dim() == 1 && _output.size(1) == 1)
+    if (zeroBasedLabel && ! binaryClassification) {
       super.apply(output, target.toTensor[T].clone().add(ev.fromType(1.0f)))
     }
     else {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/metrics/Accuracy.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/metrics/Accuracy.scala
@@ -50,7 +50,7 @@ class Accuracy[T: ClassTag](
 }
 
 /**
- * Measures top5 accuracy for classification problems.
+ * Measures top5 accuracy for multi-class classification.
  *
  * @param zeroBasedLabel Boolean. Whether target labels start from 0. Default is true.
  *                       If false, labels start from 1.

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/metrics/AccuracySpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/metrics/AccuracySpec.scala
@@ -51,6 +51,28 @@ class AccuracySpec extends FlatSpec with Matchers {
     result should be(test)
   }
 
+  "top1 accuracy for binary classification" should "ignore zero-based label" in {
+    val output = Tensor(Storage(Array[Double](0.3, 0.2, 0.6, 0.8)), 1, Array(4, 1))
+
+    val target = Tensor(Storage(Array[Double](0, 1, 1, 1)))
+
+    val validation = new Accuracy[Double]()
+    val result = validation(output, target)
+    val test = new AccuracyResult(3, 4)
+    result should be(test)
+  }
+
+  "top1 accuracy for binary classification" should "be correct on 1d tensor" in {
+    val output = Tensor(Storage(Array[Double](0.3)), 1, Array(1))
+
+    val target = Tensor(Storage(Array[Double](0)))
+
+    val validation = new Accuracy[Double](zeroBasedLabel = false)
+    val result = validation(output, target)
+    val test = new AccuracyResult(1, 1)
+    result should be(test)
+  }
+
   "top1 accuracy using 1-based label" should "be correct on 1d tensor" in {
     val output = Tensor(Storage(Array[Double](
       0, 0, 0, 1

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/metrics/AccuracySpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/metrics/AccuracySpec.scala
@@ -51,22 +51,18 @@ class AccuracySpec extends FlatSpec with Matchers {
     result should be(test)
   }
 
-  "top1 accuracy for binary classification" should "ignore zero-based label" in {
+  "accuracy for binary classification" should "ignore zero-based label" in {
     val output = Tensor(Storage(Array[Double](0.3, 0.2, 0.6, 0.8)), 1, Array(4, 1))
-
     val target = Tensor(Storage(Array[Double](0, 1, 1, 1)))
-
     val validation = new Accuracy[Double]()
     val result = validation(output, target)
     val test = new AccuracyResult(3, 4)
     result should be(test)
   }
 
-  "top1 accuracy for binary classification" should "be correct on 1d tensor" in {
+  "accuracy for binary classification" should "be correct on 1d tensor" in {
     val output = Tensor(Storage(Array[Double](0.3)), 1, Array(1))
-
     val target = Tensor(Storage(Array[Double](0)))
-
     val validation = new Accuracy[Double](zeroBasedLabel = false)
     val result = validation(output, target)
     val test = new AccuracyResult(1, 1)


### PR DESCRIPTION
A bug for zero-based label Accuracy.
In the case of binary classification, zero-based label shouldn't take effect.
Only to add 1 if it is a multiclass problem.