### PR TITLE
Fix RegistryMap key not found bug

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/NetUtils.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/NetUtils.scala
@@ -370,23 +370,28 @@ private[zoo] class RegistryMap[T]() {
   private def getRegistrySize = registry.size
 
   def getOrCreate(id: String)(create: => T): (T, Boolean) = {
-    if (registry.contains(id)) {
-      logger.debug(s"$id already exists, read from registry. " +
-        s"Current registry size: $getRegistrySize")
-      (registry(id), false)
-    } else {
-      this.synchronized {
-        if (registry.contains(id)) {
+
+    val result: Option[T] = registry.get(id)
+    result match {
+      case Some(value) =>
+        logger.debug(s"$id already exists, read from registry. " +
+          s"Current registry size: $getRegistrySize")
+        return (value, false)
+    }
+
+    registry.synchronized {
+      val result: Option[T] = registry.get(id)
+      result match {
+        case Some(value) =>
           logger.debug(s"$id already exists, read from registry. " +
             s"Current registry size: $getRegistrySize")
-          (registry(id), false)
-        } else {
+          (value, false)
+        case _ =>
           logger.debug(s"$id does not exist, created it and added to registry. " +
             s"Current registry size: $getRegistrySize")
           val res = create
           registry.put(id, res)
           (res, true)
-        }
       }
     }
   }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/NetUtils.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/NetUtils.scala
@@ -377,6 +377,7 @@ private[zoo] class RegistryMap[T]() {
         logger.debug(s"$id already exists, read from registry. " +
           s"Current registry size: $getRegistrySize")
         return (value, false)
+      case _ =>
     }
 
     registry.synchronized {


### PR DESCRIPTION
if we fist test if the key is in the map then retrieve the key, there is a chance that the key got garbage collected right after the test, thus result in a KeyNotFound exception.