### PR TITLE
Update README for yarn guide and fix website style

### DIFF
--- a/docs/docs/PythonUserGuide/install.md
+++ b/docs/docs/PythonUserGuide/install.md
@@ -76,7 +76,9 @@ apt-get install -y zip
 easy_install pip
 ```
 * Create the virtualenv package for dependencies.
-    * Under $ANALYTICS_ZOO_HOME (the dist directory under the Analytics Zoo project), you can find ```bin/python_package.sh```. Run this script to create the dependency virtual environment according to the dependencies listed in `requirements.txt`. You can add your own dependencies into this file if you wish. The current requirements only contain those needed for running Analytics Zoo Python examples and models.
+    * `export ANALYTICS_ZOO_HOME=the folder where you extract the downloaded Analytics Zoo zip package`
+    
+    * Run ```$ANALYTICS_ZOO_HOME/bin/python_package.sh``` to create the dependency virtual environment according to the dependencies listed in `requirements.txt`. You can add your own dependencies into this file if you wish. The current requirements only contain those needed for running Analytics Zoo Python examples and models.
 
     * After running this script, there will be `venv.zip` and `venv` directory generated in current directory. You can use them to submit your Python jobs. Please refer to [here](run.md#run-with-virtual-environment-on-yarn) for the commands to submit an Analytics Zoo Python job with the created virtual environment in Yarn cluster.
 

--- a/docs/docs/PythonUserGuide/install.md
+++ b/docs/docs/PythonUserGuide/install.md
@@ -76,9 +76,9 @@ apt-get install -y zip
 easy_install pip
 ```
 * Create the virtualenv package for dependencies.
-    * `export ANALYTICS_ZOO_HOME=the folder where you extract the downloaded Analytics Zoo zip package`
+    * ```export ANALYTICS_ZOO_HOME=the folder where you extract the downloaded Analytics Zoo zip package```
     
-    * Run ```$ANALYTICS_ZOO_HOME/bin/python_package.sh``` to create the dependency virtual environment according to the dependencies listed in `requirements.txt`. You can add your own dependencies into this file if you wish. The current requirements only contain those needed for running Analytics Zoo Python examples and models.
+    * Run ```${ANALYTICS_ZOO_HOME}/bin/python_package.sh``` to create the dependency virtual environment according to the dependencies listed in `requirements.txt`. You can add your own dependencies into this file if you wish. The current requirements only contain those needed for running Analytics Zoo Python examples and models.
 
     * After running this script, there will be `venv.zip` and `venv` directory generated in current directory. You can use them to submit your Python jobs. Please refer to [here](run.md#run-with-virtual-environment-on-yarn) for the commands to submit an Analytics Zoo Python job with the created virtual environment in Yarn cluster.
 

--- a/docs/docs/PythonUserGuide/run.md
+++ b/docs/docs/PythonUserGuide/run.md
@@ -136,12 +136,12 @@ you can run Python programs using Analytics Zoo using the following command.
 Here we use Analytics Zoo [Object Detection Python example](https://github.com/intel-analytics/analytics-zoo/tree/master/pyzoo/zoo/examples/objectdetection) for illustration.
 
 * Yarn cluster mode
-```
-    export SPARK_HOME=the root directory of Spark
-    export ANALYTICS_ZOO_HOME=the folder where you extract the downloaded Analytics Zoo zip package
-    export VENV_HOME=the parent directory of venv.zip and venv folder
-    
-    PYSPARK_PYTHON=${VENV_HOME}/venv.zip/venv/bin/python ${ANALYTICS_ZOO_HOME}/bin/spark-submit-with-zoo.sh \
+```bash
+export SPARK_HOME=the root directory of Spark
+export ANALYTICS_ZOO_HOME=the folder where you extract the downloaded Analytics Zoo zip package
+export VENV_HOME=the parent directory of venv.zip and venv folder
+
+PYSPARK_PYTHON=${VENV_HOME}/venv.zip/venv/bin/python ${ANALYTICS_ZOO_HOME}/bin/spark-submit-with-zoo.sh \
     --conf spark.yarn.appMasterEnv.PYSPARK_PYTHON=venv.zip/venv/bin/python \
     --master yarn-cluster \
     --executor-memory 10g \
@@ -153,12 +153,12 @@ Here we use Analytics Zoo [Object Detection Python example](https://github.com/i
 ```
 
 * Yarn client mode
-```
-    export SPARK_HOME=the root directory of Spark
-    export ANALYTICS_ZOO_HOME=the folder where you extract the downloaded Analytics Zoo zip package
-    export VENV_HOME=the parent directory of venv.zip and venv folder
-    
-    PYSPARK_DRIVER_PYTHON=${VENV_HOME}/venv/bin/python PYSPARK_PYTHON=venv.zip/venv/bin/python ${ANALYTICS_ZOO_HOME}/bin/spark-submit-with-zoo.sh \
+```bash
+export SPARK_HOME=the root directory of Spark
+export ANALYTICS_ZOO_HOME=the folder where you extract the downloaded Analytics Zoo zip package
+export VENV_HOME=the parent directory of venv.zip and venv folder
+
+PYSPARK_DRIVER_PYTHON=${VENV_HOME}/venv/bin/python PYSPARK_PYTHON=venv.zip/venv/bin/python ${ANALYTICS_ZOO_HOME}/bin/spark-submit-with-zoo.sh \
     --master yarn \
     --deploy-mode client \
     --executor-memory 10g \

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,7 +6,7 @@ Before using scripts, two environment variables should be set.
 * If you download Analytics Zoo from the [Release Page](../docs/docs/release-download.md):
 ```bash
 export SPARK_HOME=the root directory of Spark
-export ANALYTICS_ZOO_HOME=the path where you extract the analytics-zoo package
+export ANALYTICS_ZOO_HOME=the folder where you extract the downloaded Analytics Zoo zip package
 ```
 
 * If you build Analytics Zoo by yourself:
@@ -40,7 +40,7 @@ analytics-zoo
 After setting the necessary environment variables above, you can run those scripts. One example is shown as following.
 ```bash
 ./spark-submit-with-zoo.sh \
-    --master your_master_of_spark \
+    --master your_master_of_spark \
     --driver-cores cores_number_of_driver  \
     --driver-memory memory_size_of_driver  \
     --total-executor-cores total_cores_number_of_executor  \
@@ -50,69 +50,4 @@ After setting the necessary environment variables above, you can run those scrip
 ```
 Note that not all the parameters are required. You only need to set the necessary ones.
 
-* For YARN cluster:
-
-  You can run Analytics Zoo programs on YARN clusters without changes to the cluster (e.g., no need to pre-install the Python dependencies). You can first package all the required Python dependencies into a virtual environment on the local node (where you will run the spark-submit command), and then directly use `spark-submit-with-zoo.sh` to run the Zoo Python program on the YARN cluster (using that virtual environment). 
-     
-   Please follow the steps below: 
-     
-   1. Make sure you already install such libraries(python-setuptools, python-dev, gcc, make, zip, pip) for creating virtual environment. If not, please install them first. For example, on Ubuntu, run these commands to install:
-    ```
-            apt-get update
-            apt-get install -y python-setuptools python-dev
-            apt-get install -y gcc make
-            apt-get install -y zip
-            easy_install pip
-    ```	
-   2. Create dependency virtualenv package
-        - Run ```python_package.sh``` to create dependency virtual environment according to dependency descriptions in requirements.txt. You can add your own dependencies in requirements.txt. The current requirements.txt only contains dependencies for Analytics Zoo python examples and models.
-        - After running this script, there will be venv.zip and venv directory generated in current directory. Use them to submit your python jobs.            
-   3. Submit job with virtualenv package
-        - YARN cluster mode.
-            
-        Before submit job, set the environment first:
-        ```
-                export PYSPARK_PYTHON=./venv.zip/venv/bin/python
-                export VENV_HOME=your virtual environment directory
-        ```
-        Then run ```spark-submit-with-zoo.sh``` as below:
-        ```
-                spark-submit-with-zoo.sh \
-                --master yarn-cluster \
-                --conf spark.yarn.appMasterEnv.PYSPARK_PYTHON=./venv.zip/venv/bin/python \
-                --archives ${VENV_HOME}/venv.zip \
-                --executor-memory 10g \
-                --driver-memory 10g \
-                --executor-cores 8 \
-                --num-executors 2 \
-                your python script and parameters
-        ```
-        - YARN client mode.
-                        
-        Before submit job, set the environment first:
-        ```
-                export VENV_HOME=your virtual environment directory
-                export PYSPARK_DRIVER_PYTHON=${VENV_HOME}/venv/bin/python
-                export PYSPARK_PYTHON=./venv.zip/venv/bin/python
-        ```
-        Then run ```spark-submit-with-zoo.sh``` as below:
-        ```
-                spark-submit-with-zoo.sh \
-                --master yarn \
-                --deploy-mode client \
-                --executor-memory 10g \
-                --driver-memory 10g \
-                --executor-cores 16 \
-                --num-executors 2 \
-                --archives ${VENV_HOME}/venv.zip \
-                your python script and parameters
-        ```    
-           
-        __FAQ__
-        
-        In case you encounter the following errors when you create the environment package using the above command:
-        
-        1. virtualenv ImportError: No module named urllib3
-            - Using python in anaconda to create virtualenv may cause this problem. Try using python default in your system instead of installing virtualenv in anaconda.
-        2. AttributeError: 'module' object has no attribute 'sslwrap'
-            - Try upgrading `gevent` with `pip install --upgrade gevent`.
+See [here](https://analytics-zoo.github.io/master/#PythonUserGuide/install/#for-yarn-cluster) for yarn cluster instructions.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -39,7 +39,7 @@ analytics-zoo
 ## Run Scripts
 After setting the necessary environment variables above, you can run those scripts. One example is shown as following.
 ```bash
-./spark-submit-with-zoo.sh \
+spark-submit-with-zoo.sh \
     --master your_master_of_spark \
     --driver-cores cores_number_of_driver  \
     --driver-memory memory_size_of_driver  \
@@ -50,4 +50,4 @@ After setting the necessary environment variables above, you can run those scrip
 ```
 Note that not all the parameters are required. You only need to set the necessary ones.
 
-See [here](https://analytics-zoo.github.io/master/#PythonUserGuide/install/#for-yarn-cluster) for yarn cluster instructions.
+See [here](https://analytics-zoo.github.io/master/#PythonUserGuide/install/#for-yarn-cluster) for instructions if you want to run on yarn cluster.


### PR DESCRIPTION
- In README under scripts, directly link to website doc so that we don't need to maintain the same instructions in two places.
- Style of website generated fixed.