### PR TITLE
Fix pip install release issue in setup.py

### DIFF
--- a/pyzoo/setup.py
+++ b/pyzoo/setup.py
@@ -42,7 +42,7 @@ try:
     with open('zoo/__init__.py', 'r') as f:
         for line in f.readlines():
             if '__version__' in line:
-                VERSION = line.split(" ")[2]
+                VERSION = line.strip().replace("\"", "").split(" ")[2]
 except IOError:
     print("Failed to load Analytics Zoo version file for packaging. \
       You must be in Analytics Zoo's pyzoo dir.")

--- a/pyzoo/setup.py
+++ b/pyzoo/setup.py
@@ -39,13 +39,14 @@ def get_analytics_zoo_packages():
 packages = get_analytics_zoo_packages()
 
 try:
-    exec(open('zoo/__init__.py').read())
+    with open('zoo/__init__.py', 'r') as f:
+        for line in f.readlines():
+            if '__version__' in line:
+                VERSION = line.split(" ")[2]
 except IOError:
     print("Failed to load Analytics Zoo version file for packaging. \
       You must be in Analytics Zoo's pyzoo dir.")
     sys.exit(-1)
-
-VERSION = __version__
 
 building_error_msg = """
 If you are packing python API from zoo source, you must build Analytics Zoo first


### PR DESCRIPTION
http://10.239.47.211:18888/view/ZOO-NB/job/ZOO-NB-Deploy-PYTHON/238/console

Previously get the version need to execute the python file, which will throw the exception that bigdl hasn't been installed.
Now just read the lines and get the version.