### PR TITLE
Fix TextClassifier methods and add setEvaluateStatus

### DIFF
--- a/pyzoo/test/zoo/feature/text/test_text_set.py
+++ b/pyzoo/test/zoo/feature/text/test_text_set.py
@@ -17,10 +17,12 @@
 import pytest
 import shutil
 
+from bigdl.optim.optimizer import SGD
 from zoo.feature.common import ChainedPreprocessing
 from zoo.feature.text import *
 from zoo.common.nncontext import *
 from zoo.models.textclassification import TextClassifier
+from zoo.pipeline.api.keras.objectives import SparseCategoricalCrossEntropy
 
 
 class TestTextSet:
@@ -142,14 +144,13 @@ class TestTextSet:
             assert sample.feature.shape[0] == 5
 
         model = TextClassifier(5, self.glove_path, word_index, 5, encoder="lstm")
-        model.compile("sgd", "sparse_categorical_crossentropy", metrics=['accuracy'])
+        model.compile(SGD(), SparseCategoricalCrossEntropy())
         model.fit(transformed, batch_size=2, nb_epoch=2)
         res_set = model.predict(transformed, batch_per_thread=2)
         predicts = res_set.get_predicts().collect()
         for predict in predicts:
             assert len(predict) == 1
             assert predict[0].shape == (5, )
-        acc = model.evaluate(transformed, batch_size=2)
 
         tmp_path = create_tmp_path() + ".bigdl"
         model.save_model(tmp_path, over_write=True)

--- a/pyzoo/test/zoo/models/textclassification/test_textclassifier.py
+++ b/pyzoo/test/zoo/models/textclassification/test_textclassifier.py
@@ -34,6 +34,11 @@ class TestTextClassifier(ZooTestCase):
         model.summary()
         input_data = np.random.randint(20, size=(4, 500))
         self.assert_forward_backward(model, input_data)
+        model.set_evaluate_status()
+        # Forward twice will get the same output
+        output1 = model.forward(input_data)
+        output2 = model.forward(input_data)
+        assert np.allclose(output1, output2)
 
     def test_save_load(self):
         model = TextClassifier(20, glove_path, sequence_length=100)

--- a/pyzoo/test/zoo/pipeline/api/keras/test_simple_integration.py
+++ b/pyzoo/test/zoo/pipeline/api/keras/test_simple_integration.py
@@ -223,6 +223,12 @@ class TestSimpleIntegration(ZooTestCase):
         assert word_index["for"] == 11
         assert word_index["as"] == 20
 
+    def test_set_evaluate_status(self):
+        model = Sequential().add(Dropout(0.2, input_shape=(4, ))).set_evaluate_status()
+        input_data = np.random.random([3, 4])
+        output = model.forward(input_data)
+        assert np.allclose(input_data, output)
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/pyzoo/test/zoo/pipeline/utils/test_utils.py
+++ b/pyzoo/test/zoo/pipeline/utils/test_utils.py
@@ -145,7 +145,7 @@ class ZooTestCase(TestCase):
         """
         model_class = model.__class__
         tmp_path = create_tmp_path() + ".bigdl"
-        model.save_model(tmp_path)
+        model.save_model(tmp_path, over_write=True)
         loaded_model = model_class.load_model(tmp_path)
         assert isinstance(loaded_model, model_class)
         self.compare_output_and_grad_input(model, loaded_model, input_data, rtol, atol)

--- a/pyzoo/zoo/models/common/zoo_model.py
+++ b/pyzoo/zoo/models/common/zoo_model.py
@@ -76,6 +76,14 @@ class ZooModel(ZooModelCreator, Container):
         callBigDlFunc(self.bigdl_type, "zooModelSummary",
                       self.value)
 
+    def set_evaluate_status(self):
+        """
+        Set the model to be in evaluate status, i.e. remove the effect of Dropout, etc.
+        """
+        callBigDlFunc(self.bigdl_type, "zooModelSetEvaluateStatus",
+                      self.value)
+        return self
+
     @staticmethod
     def _do_load(jmodel, bigdl_type="float"):
         model = Layer(jvalue=jmodel, bigdl_type=bigdl_type)

--- a/pyzoo/zoo/models/textclassification/text_classifier.py
+++ b/pyzoo/zoo/models/textclassification/text_classifier.py
@@ -143,6 +143,7 @@ class TextClassifier(ZooModel):
     def set_evaluate_status(self):
         callBigDlFunc(self.bigdl_type, "textClassifierSetEvaluateStatus",
                       self.value)
+        return self
 
     def fit(self, x, batch_size=32, nb_epoch=10, validation_data=None):
         """

--- a/pyzoo/zoo/models/textclassification/text_classifier.py
+++ b/pyzoo/zoo/models/textclassification/text_classifier.py
@@ -115,19 +115,47 @@ class TextClassifier(ZooModel):
         return model
 
     def compile(self, optimizer, loss, metrics=None):
-        self.model.compile(optimizer, loss, metrics)
+        if isinstance(optimizer, six.string_types):
+            optimizer = to_bigdl_optim_method(optimizer)
+        if isinstance(loss, six.string_types):
+            loss = to_bigdl_criterion(loss)
+        if metrics and all(isinstance(metric, six.string_types) for metric in metrics):
+            metrics = to_bigdl_metrics(metrics)
+        callBigDlFunc(self.bigdl_type, "textClassifierCompile",
+                      self.value,
+                      optimizer,
+                      loss,
+                      metrics)
 
     def set_tensorboard(self, log_dir, app_name):
-        self.model.set_tensorboard(log_dir, app_name)
+        callBigDlFunc(self.bigdl_type, "textClassifierSetTensorBoard",
+                      self.value,
+                      log_dir,
+                      app_name)
 
     def set_checkpoint(self, path, over_write=True):
-        self.model.set_checkpoint(path, over_write)
+        callBigDlFunc(self.bigdl_type, "textClassifierSetCheckpoint",
+                      self.value,
+                      path,
+                      over_write)
 
-    def fit(self, x, y=None, batch_size=32, nb_epoch=10, validation_data=None, distributed=True):
-        self.model.fit(x, y, batch_size, nb_epoch, validation_data, distributed)
+    def fit(self, x, batch_size=32, nb_epoch=10, validation_data=None):
+        callBigDlFunc(self.bigdl_type, "textClassifierFit",
+                      self.value,
+                      x,
+                      batch_size,
+                      nb_epoch,
+                      validation_data)
 
-    def evaluate(self, x, y=None, batch_size=32):
-        return self.model.evaluate(x, y, batch_size)
+    def evaluate(self, x, batch_size=32):
+        return callBigDlFunc(self.bigdl_type, "textClassifierEvaluate",
+                             self.value,
+                             x,
+                             batch_size)
 
-    def predict(self, x, batch_per_thread=4, distributed=True):
-        return self.model.predict(x, batch_per_thread, distributed)
+    def predict(self, x, batch_per_thread=4):
+        results = callBigDlFunc(self.bigdl_type, "textClassifierPredict",
+                                self.value,
+                                x,
+                                batch_per_thread)
+        return TextSet(results)

--- a/pyzoo/zoo/models/textclassification/text_classifier.py
+++ b/pyzoo/zoo/models/textclassification/text_classifier.py
@@ -114,6 +114,7 @@ class TextClassifier(ZooModel):
         model.__class__ = TextClassifier
         return model
 
+    # For the following methods, please refer to KerasNet for documentation.
     def compile(self, optimizer, loss, metrics=None):
         if isinstance(optimizer, six.string_types):
             optimizer = to_bigdl_optim_method(optimizer)
@@ -139,7 +140,17 @@ class TextClassifier(ZooModel):
                       path,
                       over_write)
 
+    def set_evaluate_status(self):
+        callBigDlFunc(self.bigdl_type, "textClassifierSetEvaluateStatus",
+                      self.value)
+
     def fit(self, x, batch_size=32, nb_epoch=10, validation_data=None):
+        """
+        Fit on TextSet.
+        """
+        assert isinstance(x, TextSet), "x should be a TextSet"
+        if validation_data:
+            assert isinstance(validation_data, TextSet), "validation_data should be a TextSet"
         callBigDlFunc(self.bigdl_type, "textClassifierFit",
                       self.value,
                       x,
@@ -148,12 +159,20 @@ class TextClassifier(ZooModel):
                       validation_data)
 
     def evaluate(self, x, batch_size=32):
+        """
+        Evaluate on TextSet.
+        """
+        assert isinstance(x, TextSet), "x should be a TextSet"
         return callBigDlFunc(self.bigdl_type, "textClassifierEvaluate",
                              self.value,
                              x,
                              batch_size)
 
     def predict(self, x, batch_per_thread=4):
+        """
+        Predict on TextSet.
+        """
+        assert isinstance(x, TextSet), "x should be a TextSet"
         results = callBigDlFunc(self.bigdl_type, "textClassifierPredict",
                                 self.value,
                                 x,

--- a/pyzoo/zoo/models/textclassification/text_classifier.py
+++ b/pyzoo/zoo/models/textclassification/text_classifier.py
@@ -140,11 +140,6 @@ class TextClassifier(ZooModel):
                       path,
                       over_write)
 
-    def set_evaluate_status(self):
-        callBigDlFunc(self.bigdl_type, "textClassifierSetEvaluateStatus",
-                      self.value)
-        return self
-
     def fit(self, x, batch_size=32, nb_epoch=10, validation_data=None):
         """
         Fit on TextSet.

--- a/pyzoo/zoo/pipeline/api/keras/engine/topology.py
+++ b/pyzoo/zoo/pipeline/api/keras/engine/topology.py
@@ -120,6 +120,14 @@ class KerasNet(ZooKerasLayer):
                       self.value,
                       float(clip_norm))
 
+    def set_evaluate_status(self):
+        """
+        Set the model to be in evaluate status, i.e. remove the effect of Dropout, etc.
+        """
+        callBigDlFunc(self.bigdl_type, "zooSetEvaluateStatus",
+                      self.value)
+        return self
+
     def fit(self, x, y=None, batch_size=32, nb_epoch=10, validation_data=None, distributed=True):
         """
         Train a model for a fixed number of epochs on a DataSet.

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/common/ZooModel.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/common/ZooModel.scala
@@ -108,6 +108,14 @@ abstract class ZooModel[A <: Activity: ClassTag, B <: Activity: ClassTag, T: Cla
     KerasUtils.toZeroBasedLabel(zeroBasedLabel, model.predictClass(x, batchSize))
   }
 
+  /**
+   * Set the model to be in evaluate status, i.e. remove the effect of Dropout, etc.
+   */
+  def setEvaluateStatus(): this.type = {
+    model.evaluate()
+    this
+  }
+
   override def updateOutput(input: A): B = {
     output = model.updateOutput(input)
     output

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/python/PythonZooModel.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/python/PythonZooModel.scala
@@ -133,7 +133,8 @@ class PythonZooModel[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonZ
     model.setTensorBoard(logDir, appName)
   }
 
-  def textClassifierSetEvaluateStatus(model: TextClassifier[T]): TextClassifier[T] = {
+def zooModelSetEvaluateStatus(
+    model: ZooModel[Activity, Activity, T]): ZooModel[Activity, Activity, T] = {
     model.setEvaluateStatus()
   }
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/python/PythonZooModel.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/python/PythonZooModel.scala
@@ -133,6 +133,10 @@ class PythonZooModel[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonZ
     model.setTensorBoard(logDir, appName)
   }
 
+  def textClassifierSetEvaluateStatus(model: TextClassifier[T]): TextClassifier[T] = {
+    model.setEvaluateStatus()
+  }
+
   def loadObjectDetector(path: String, weightPath: String = null): ObjectDetector[T] = {
     ObjectDetector.loadModel(path, weightPath)
   }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/textclassification/TextClassifier.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/textclassification/TextClassifier.scala
@@ -95,6 +95,14 @@ class TextClassifier[T: ClassTag] private(
       batchPerThread: Int): TextSet = {
     model.asInstanceOf[KerasNet[T]].predict(x, batchPerThread)
   }
+
+  def setTensorBoard(logDir: String, appName: String): Unit = {
+    model.asInstanceOf[KerasNet[T]].setTensorBoard(logDir, appName)
+  }
+
+  def setCheckpoint(path: String, overWrite: Boolean = true): Unit = {
+    model.asInstanceOf[KerasNet[T]].setCheckpoint(path, overWrite)
+  }
 }
 
 object TextClassifier {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/textclassification/TextClassifier.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/textclassification/TextClassifier.scala
@@ -68,6 +68,7 @@ class TextClassifier[T: ClassTag] private(
     model
   }
 
+  // For the following methods, please refer to KerasNet for documentation.
   def compile(
       optimizer: OptimMethod[T],
       loss: Criterion[T],

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/textclassification/TextClassifier.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/textclassification/TextClassifier.scala
@@ -104,11 +104,6 @@ class TextClassifier[T: ClassTag] private(
   def setCheckpoint(path: String, overWrite: Boolean = true): Unit = {
     model.asInstanceOf[KerasNet[T]].setCheckpoint(path, overWrite)
   }
-
-  def setEvaluateStatus(): this.type = {
-    model.asInstanceOf[KerasNet[T]].setEvaluateStatus()
-    this
-  }
 }
 
 object TextClassifier {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/textclassification/TextClassifier.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/textclassification/TextClassifier.scala
@@ -103,6 +103,11 @@ class TextClassifier[T: ClassTag] private(
   def setCheckpoint(path: String, overWrite: Boolean = true): Unit = {
     model.asInstanceOf[KerasNet[T]].setCheckpoint(path, overWrite)
   }
+
+  def setEvaluateStatus(): this.type = {
+    model.asInstanceOf[KerasNet[T]].setEvaluateStatus()
+    this
+  }
 }
 
 object TextClassifier {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
@@ -227,6 +227,13 @@ abstract class KerasNet[T: ClassTag](implicit ev: TensorNumeric[T])
   }
 
   /**
+   * Set the model to be in evaluate status, i.e. remove the effect of Dropout, etc.
+   */
+  def setEvaluateStatus(): this.type = {
+    evaluate()
+  }
+
+  /**
    * Convert RDD of Sample to DataSet of MiniBatch.
    */
   private def toDataSet(x: RDD[Sample[T]], batchSize: Int): DataSet[MiniBatch[T]] = {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
@@ -163,9 +163,7 @@ abstract class KerasNet[T: ClassTag](implicit ev: TensorNumeric[T])
    * @param logDir The base directory path to store training and validation logs.
    * @param appName The name of the application.
    */
-  def setTensorBoard(
-      logDir: String,
-      appName: String): Unit = {
+  def setTensorBoard(logDir: String, appName: String): Unit = {
     if (this.internalOptimizer != null) {
       internalOptimizer.setTrainSummary(TrainSummary(tensorBoardLogDir, tensorBoardAppName))
     }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/python/PythonZooKeras.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/python/PythonZooKeras.scala
@@ -281,6 +281,10 @@ class PythonZooKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonZ
     module.saveGraphTopology(logPath, backward)
   }
 
+  def zooSetEvaluateStatus(model: KerasNet[T]): KerasNet[T] = {
+    model.setEvaluateStatus()
+  }
+
   def zooPredictClasses(
       module: KerasNet[T],
       x: JavaRDD[Sample],

--- a/zoo/src/test/scala/com/intel/analytics/zoo/feature/text/TextSetSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/feature/text/TextSetSpec.scala
@@ -116,7 +116,8 @@ class TextSetSpec extends ZooSpecHelper {
     val saveFile = createTmpFile()
     model.saveModel(saveFile.getAbsolutePath, overWrite = true)
     val loadedModel = TextClassifier.loadModel[Float](saveFile.getAbsolutePath)
-    val predictResults = model.predict(transformed, batchPerThread = 2).toLocal().array
+    val predictResults = model.predict(transformed, batchPerThread = 2)
+      .toDistributed().rdd.collect()
   }
 
   "TextSet read without sc, fit, predict and evaluate" should "work properly" in {

--- a/zoo/src/test/scala/com/intel/analytics/zoo/feature/text/TextSetSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/feature/text/TextSetSpec.scala
@@ -16,27 +16,33 @@
 
 package com.intel.analytics.zoo.feature.text
 
+import com.intel.analytics.bigdl.optim.{Adagrad, SGD}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric.NumericFloat
 import com.intel.analytics.zoo.common.NNContext
+import com.intel.analytics.zoo.models.textclassification.TextClassifier
+import com.intel.analytics.zoo.pipeline.api.keras.ZooSpecHelper
 import com.intel.analytics.zoo.pipeline.api.keras.layers.{Convolution1D, Dense, Embedding, Flatten}
+import com.intel.analytics.zoo.pipeline.api.keras.metrics.Accuracy
 import com.intel.analytics.zoo.pipeline.api.keras.models.Sequential
+import com.intel.analytics.zoo.pipeline.api.keras.objectives.SparseCategoricalCrossEntropy
 import org.apache.spark.{SparkConf, SparkContext}
-import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.collection.immutable.HashSet
 
-class TextSetSpec extends FlatSpec with Matchers with BeforeAndAfter {
+class TextSetSpec extends ZooSpecHelper {
   val text1 = "Hello my friend, please annotate my text"
   val text2 = "hello world, this is some sentence for my test"
   val path: String = getClass.getClassLoader.getResource("news20").getPath
   var sc : SparkContext = _
+  val gloveDir: String = getClass.getClassLoader.getResource("glove.6B").getPath
+  val embeddingFile: String = gloveDir + "/glove.6B.50d.txt"
 
-  before {
+  override def doBefore(): Unit = {
     val conf = new SparkConf().setAppName("Test TextSet").setMaster("local[1]")
     sc = NNContext.initNNContext(conf)
   }
 
-  after {
+  override def doAfter(): Unit = {
     if (sc != null) {
       sc.stop()
     }
@@ -102,8 +108,8 @@ class TextSetSpec extends FlatSpec with Matchers with BeforeAndAfter {
     require(textSet.toDistributed().rdd.collect().head.keys() == HashSet("label", "text"))
     val transformed = textSet.tokenize().normalize()
       .shapeSequence(len = 30).word2idx().generateSample()
-    val model = buildModel()
-    model.compile("sgd", "sparse_categorical_crossentropy", List("accuracy"))
+    val model = TextClassifier(3, embeddingFile, transformed.getWordIndex, 30)
+    model.compile(new SGD[Float](), SparseCategoricalCrossEntropy[Float](), List(new Accuracy()))
     model.fit(transformed, batchSize = 4, nbEpoch = 2, validationData = transformed)
     require(! transformed.toDistributed().rdd.first().contains("predict"))
 
@@ -112,10 +118,16 @@ class TextSetSpec extends FlatSpec with Matchers with BeforeAndAfter {
     textFeatures.foreach(feature => {
       require(feature.contains("predict"))
       val input = feature.getSample.feature.reshape(Array(1, 30))
-      val output = model.forward(input).toTensor[Float].split(1)(0)
+      val output = model.evaluate().forward(input).toTensor[Float].split(1)(0)
       feature.getPredict[Float] should be (output)
     })
     val accuracy = model.evaluate(transformed, batchSize = 4)
+
+    // Test for loaded model predict on TextSet
+    val saveFile = createTmpFile()
+    model.saveModel(saveFile.getAbsolutePath, overWrite = true)
+    val loadedModel = TextClassifier.loadModel[Float](saveFile.getAbsolutePath)
+    val predictResults = model.predict(transformed, batchPerThread = 2).toLocal().array
   }
 
   "TextSet read without sc, fit, predict and evaluate" should "work properly" in {
@@ -127,8 +139,9 @@ class TextSetSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val wordIndex = tokenized.generateWordIndexMap()
     val transformed = tokenized -> WordIndexer(wordIndex) -> TextFeatureToSample()
     require(transformed.getWordIndex == wordIndex)
-    val model = buildModel()
-    model.compile("sgd", "sparse_categorical_crossentropy", List("accuracy"))
+    val model = TextClassifier(10, embeddingFile, wordIndex, 30)
+    model.compile(new Adagrad[Float](), SparseCategoricalCrossEntropy[Float](),
+      List(new Accuracy()))
     model.fit(transformed, batchSize = 4, nbEpoch = 2, validationData = transformed)
     require(! transformed.toLocal().array.head.contains("predict"))
 
@@ -137,9 +150,14 @@ class TextSetSpec extends FlatSpec with Matchers with BeforeAndAfter {
     textFeatures.foreach(feature => {
       require(feature.contains("predict"))
       val input = feature.getSample.feature.reshape(Array(1, 30))
-      val output = model.forward(input).toTensor[Float].split(1)(0)
+      val output = model.evaluate().forward(input).toTensor[Float].split(1)(0)
       feature.getPredict[Float] should be(output)
     })
     val accuracy = model.evaluate(transformed, batchSize = 4)
+
+    val saveFile = createTmpFile()
+    model.saveModel(saveFile.getAbsolutePath, overWrite = true)
+    val loadedModel = TextClassifier.loadModel[Float](saveFile.getAbsolutePath)
+    val predictResults = model.predict(transformed, batchPerThread = 2).toLocal().array
   }
 }

--- a/zoo/src/test/scala/com/intel/analytics/zoo/feature/text/TextSetSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/feature/text/TextSetSpec.scala
@@ -21,9 +21,7 @@ import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric.NumericF
 import com.intel.analytics.zoo.common.NNContext
 import com.intel.analytics.zoo.models.textclassification.TextClassifier
 import com.intel.analytics.zoo.pipeline.api.keras.ZooSpecHelper
-import com.intel.analytics.zoo.pipeline.api.keras.layers.{Convolution1D, Dense, Embedding, Flatten}
 import com.intel.analytics.zoo.pipeline.api.keras.metrics.Accuracy
-import com.intel.analytics.zoo.pipeline.api.keras.models.Sequential
 import com.intel.analytics.zoo.pipeline.api.keras.objectives.SparseCategoricalCrossEntropy
 import org.apache.spark.{SparkConf, SparkContext}
 
@@ -52,15 +50,6 @@ class TextSetSpec extends ZooSpecHelper {
     val feature1 = TextFeature(text1, label = 0)
     val feature2 = TextFeature(text2, label = 1)
     Array(feature1, feature2)
-  }
-
-  def buildModel(): Sequential[Float] = {
-    val model = Sequential()
-    model.add(Embedding(300, 20, inputLength = 30))
-    model.add(Convolution1D(8, 4))
-    model.add(Flatten())
-    model.add(Dense(3, activation = "softmax"))
-    model
   }
 
   "DistributedTextSet Transformation" should "work properly" in {
@@ -118,7 +107,7 @@ class TextSetSpec extends ZooSpecHelper {
     textFeatures.foreach(feature => {
       require(feature.contains("predict"))
       val input = feature.getSample.feature.reshape(Array(1, 30))
-      val output = model.evaluate().forward(input).toTensor[Float].split(1)(0)
+      val output = model.setEvaluateStatus().forward(input).toTensor[Float].split(1)(0)
       feature.getPredict[Float] should be (output)
     })
     val accuracy = model.evaluate(transformed, batchSize = 4)
@@ -150,7 +139,7 @@ class TextSetSpec extends ZooSpecHelper {
     textFeatures.foreach(feature => {
       require(feature.contains("predict"))
       val input = feature.getSample.feature.reshape(Array(1, 30))
-      val output = model.evaluate().forward(input).toTensor[Float].split(1)(0)
+      val output = model.setEvaluateStatus().forward(input).toTensor[Float].split(1)(0)
       feature.getPredict[Float] should be(output)
     })
     val accuracy = model.evaluate(transformed, batchSize = 4)

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/ZooSpecHelper.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/ZooSpecHelper.scala
@@ -17,7 +17,7 @@ package com.intel.analytics.zoo.pipeline.api.keras
 
 import java.io.{File => JFile}
 
-import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
+import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.{RandomGenerator, Table}
 import com.intel.analytics.zoo.models.common.ZooModel

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/DropoutSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/DropoutSpec.scala
@@ -24,6 +24,7 @@ import com.intel.analytics.zoo.pipeline.api.keras.serializer.ModuleSerialization
 import scala.util.Random
 
 class DropoutSpec extends KerasBaseSpec {
+
   "Dropout forward and backward" should "work properly" in {
     val seq = Sequential[Float]()
     val layer = Dropout[Float](0.3, inputShape = Shape(3, 4))
@@ -33,6 +34,16 @@ class DropoutSpec extends KerasBaseSpec {
     val output = seq.forward(input)
     val gradInput = seq.backward(input, output)
   }
+
+  "Dropout in evaluate status" should "get the output same as input" in {
+    val seq = Sequential[Float]()
+    val layer = Dropout[Float](0.2, inputShape = Shape(8, 10))
+    seq.add(layer)
+    val input = Tensor[Float](3, 8, 10).rand()
+    val output = seq.setEvaluateStatus().forward(input)
+    require(output == input)
+  }
+
 }
 
 class DropoutSerialTest extends ModuleSerializationTest {


### PR DESCRIPTION
Previously, `self.model.compile/fit/predict`, this will cause an error if the TextClassifier is directly loaded instead of initialized. Wrap the method from Scala side in this PR.

Add more unit tests for predict after model loading.

Add `setEvaluateStatus()` in KerasNet/ZooModel, which will be clearer than the previous `evaluate()` and also for Python use. Added unit tests.