### PR TITLE
Move predict methods to a trait and fix tfnet memory leak

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/common/PythonZoo.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/common/PythonZoo.scala
@@ -15,9 +15,22 @@
  */
 package com.intel.analytics.zoo.common
 
-import com.intel.analytics.bigdl.python.api.{JTensor, PythonBigDLKeras}
+import java.util
+
+import com.intel.analytics.bigdl.python.api.{JTensor, PythonBigDLKeras, Sample}
 import com.intel.analytics.bigdl.tensor.{DenseType, SparseType, Tensor}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.zoo.pipeline.api.Predictable
+import org.apache.spark.api.java.JavaRDD
+import java.util.{List => JList, Map => JMap}
+
+import com.intel.analytics.bigdl.Module
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
+import com.intel.analytics.bigdl.optim.LocalPredictor
+import com.intel.analytics.bigdl.utils.Table
+import com.intel.analytics.zoo.feature.image.ImageSet
+import com.intel.analytics.zoo.feature.text.TextSet
+import scala.collection.JavaConverters._
 
 import scala.reflect.ClassTag
 
@@ -100,5 +113,81 @@ class PythonZoo[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonBigDLK
           s" ${tensor.getTensorType}")
     }
   }
+
+  def activityToList(outputActivity: Activity): JList[Object] = {
+    if (outputActivity.isInstanceOf[Tensor[T]]) {
+      val list = new util.ArrayList[Object]()
+      list.add(toJTensor(outputActivity.toTensor))
+      list
+    } else {
+      table2JList(outputActivity.toTable)
+    }
+  }
+
+  private def table2JList(t: Table): JList[Object] = {
+    var i = 1
+    val list = new util.ArrayList[Object]()
+    while (i <= t.length()) {
+      val item = t[Object](i)
+      if (item.isInstanceOf[Tensor[T]]) {
+        list.add(toJTensor(item.asInstanceOf[Tensor[T]]))
+      } else if (item.isInstanceOf[Table]) {
+        list.add(table2JList(item.asInstanceOf[Table]))
+      } else {
+        throw new IllegalArgumentException(s"Table contains unrecognizable objects $item")
+      }
+      i += 1
+    }
+    list
+  }
+
+  def zooPredict(
+                  module: Predictable[T],
+                  x: JavaRDD[Sample],
+                  batchPerThread: Int): JavaRDD[JList[Object]] = {
+    module.predict(x.rdd.map(toJSample), batchPerThread).map(activityToList).toJavaRDD()
+  }
+
+  def zooForward(model: AbstractModule[Activity, Activity, T],
+                 input: JList[JTensor],
+                 inputIsTable: Boolean): JList[Object] = {
+    val inputActivity = jTensorsToActivity(input, inputIsTable)
+    val outputActivity = model.forward(inputActivity)
+    activityToList(outputActivity)
+  }
+
+  def zooPredict(
+                  module: Module[T],
+                  x: JList[JTensor],
+                  batchPerThread: Int): JList[JList[Object]] = {
+    val sampleArray = toSampleArray(x.asScala.toList.map{f => toTensor(f)})
+    val localPredictor = LocalPredictor(module,
+      batchPerCore = batchPerThread)
+    val result = localPredictor.predict(sampleArray)
+    result.map(activityToList).toList.asJava
+  }
+
+  def zooPredict(
+                  module: Predictable[T],
+                  x: ImageSet,
+                  batchPerThread: Int): ImageSet = {
+    module.predict(x, batchPerThread)
+  }
+
+  def zooPredict(
+                  module: Predictable[T],
+                  x: TextSet,
+                  batchPerThread: Int): TextSet = {
+    module.predict(x, batchPerThread)
+  }
+
+  def zooPredictClasses(
+                         module: Predictable[T],
+                         x: JavaRDD[Sample],
+                         batchPerThread: Int,
+                         zeroBasedLabel: Boolean = true): JavaRDD[Int] = {
+    module.predictClasses(toJSample(x), batchPerThread, zeroBasedLabel).toJavaRDD()
+  }
+
 
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextPredictor.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextPredictor.scala
@@ -22,12 +22,11 @@ import com.intel.analytics.bigdl.models.utils.ModelBroadcast
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.zoo.pipeline.api.keras.layers.utils.EngineRef
-import com.intel.analytics.zoo.pipeline.api.keras.models.KerasNet
 
 import scala.reflect.ClassTag
 
 class TextPredictor[T: ClassTag](
-    model: KerasNet[T],
+    model: Module[T],
     batchPerThread: Int)(implicit ev: TensorNumeric[T]) extends Serializable {
 
   def predict(
@@ -39,14 +38,14 @@ class TextPredictor[T: ClassTag](
 
 object TextPredictor {
   def apply[T: ClassTag](
-    model: KerasNet[T],
+    model: Module[T],
     batchPerThread: Int)(implicit ev: TensorNumeric[T]): TextPredictor[T] = {
     new TextPredictor[T](model, batchPerThread)
   }
 
   def predict[T: ClassTag](
     textSet: DistributedTextSet,
-    model: KerasNet[T],
+    model: Module[T],
     batchPerThread: Int,
     shareBuffer: Boolean = false)(implicit ev: TensorNumeric[T]): DistributedTextSet = {
     val rdd = textSet.rdd

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/Predictor.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/Predictor.scala
@@ -35,8 +35,8 @@ import scala.collection.Iterator.empty
 import scala.reflect.ClassTag
 
 
-class MapIteratorWithShutdown[T, B](preIter: Iterator[T], shutdownHook: () => Unit)
-                                   (f: T => GenTraversableOnce[B]) extends Iterator[B] {
+class FlatMapIteratorWithShutdown[T, B](preIter: Iterator[T], shutdownHook: () => Unit)
+                                       (f: T => GenTraversableOnce[B]) extends Iterator[B] {
   private var cur: Iterator[B] = empty
   private def nextCur() {
     try {
@@ -62,10 +62,10 @@ class MapIteratorWithShutdown[T, B](preIter: Iterator[T], shutdownHook: () => Un
   override def next(): B = (if (hasNext) cur else empty).next()
 }
 
-object MapIteratorWithShutdown {
+object FlatMapIteratorWithShutdown {
   def apply[T, B](preIter: Iterator[T], shutdownHook: () => Unit)
-                 (f: T => GenTraversableOnce[B]): MapIteratorWithShutdown[T, B] =
-    new MapIteratorWithShutdown(preIter, shutdownHook)(f)
+                 (f: T => GenTraversableOnce[B]): FlatMapIteratorWithShutdown[T, B] =
+    new FlatMapIteratorWithShutdown(preIter, shutdownHook)(f)
 }
 
 object Predictor {
@@ -174,7 +174,7 @@ object Predictor {
       def shutdownHook() = {
         localModel.release()
       }
-      MapIteratorWithShutdown(batchedIter, shutdownHook) { imageFeatures =>
+      FlatMapIteratorWithShutdown(batchedIter, shutdownHook) { imageFeatures =>
         Predictor.predictImageBatch[T](localModel, imageFeatures, outputLayer, predictKey,
           localToBatch, shareBuffer)
         imageFeatures
@@ -207,7 +207,7 @@ object Predictor {
       def shutdownHook() = {
         localModel.release()
       }
-      MapIteratorWithShutdown(miniBatch, shutdownHook) { batch =>
+      FlatMapIteratorWithShutdown(miniBatch, shutdownHook) { batch =>
         val output = localModel.forward(batch.getInput)
         splitBatch(output, shareBuffer, batch.size())
       }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/Predictor.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/Predictor.scala
@@ -1,0 +1,400 @@
+/*
+ * Copyright 2018 Analytics Zoo Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.zoo.pipeline.api
+
+import com.intel.analytics.bigdl._
+import com.intel.analytics.bigdl.dataset.{LocalDataSet, MiniBatch, PaddingParam, Sample, SampleToMiniBatch, Transformer, DataSet => _}
+import com.intel.analytics.bigdl.models.utils.ModelBroadcast
+import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.optim.LocalPredictor
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.transform.vision.image.{DistributedImageFrame, ImageFeature, ImageFrame}
+import com.intel.analytics.bigdl.utils.{T, Table}
+import com.intel.analytics.zoo.feature.image.ImageSet
+import com.intel.analytics.zoo.feature.text._
+import com.intel.analytics.zoo.pipeline.api.keras.layers.utils.KerasUtils
+import org.apache.spark.rdd.RDD
+
+import scala.reflect.ClassTag
+
+object Predictor {
+  def apply[T: ClassTag](model: Module[T],
+                         featurePaddingParam: Option[PaddingParam[T]] = None,
+                         batchPerPartition: Int = 4)
+                        (implicit ev: TensorNumeric[T]): Predictor[T] = {
+    new Predictor[T](model, featurePaddingParam, batchPerPartition)
+  }
+
+  private[zoo] def predictImageBatch[T: ClassTag](
+                     localModel: Module[T], imageFeatures: Seq[ImageFeature],
+                     outputLayer: String, predictKey: String,
+                     localToBatch: Transformer[Sample[T], MiniBatch[T]],
+                     shareBuffer: Boolean)(implicit ev: TensorNumeric[T]): Seq[ImageFeature] = {
+    val validImageFeatures = imageFeatures.filter(_.isValid)
+    val samples = validImageFeatures.map(x => x[Sample[T]](ImageFeature.sample))
+    val batchOut = predictSamples(localModel, samples, localToBatch, shareBuffer, outputLayer)
+    validImageFeatures.toIterator.zip(batchOut).foreach(tuple => {
+      tuple._1(predictKey) = tuple._2
+    })
+    imageFeatures
+  }
+
+  private[zoo] def predictSamples[T: ClassTag]
+  (localModel: Module[T], samples: Seq[Sample[T]],
+   localToBatch: Transformer[Sample[T], MiniBatch[T]],
+   shareBuffer: Boolean,
+   outputLayer: String = null)(implicit ev: TensorNumeric[T]): Iterator[Activity] = {
+    val layer = if (outputLayer == null) {
+      localModel
+    } else {
+      val ol = localModel(outputLayer)
+      require(ol.isDefined, s"cannot find layer that map name $outputLayer")
+      ol.get
+    }
+    localToBatch(samples.toIterator).flatMap(batch => {
+      localModel.forward(batch.getInput())
+      splitBatch[T](layer.output, shareBuffer, batch.size())
+    })
+  }
+
+  private[zoo] def splitTensor[T: ClassTag](output: Tensor[T],
+                                              shareBuffer: Boolean, batchSize: Int)
+                                             (implicit ev: TensorNumeric[T]): Array[Activity] = {
+    val result = if (shareBuffer) output else output.clone
+    val out = if (batchSize == 1) {
+      Array(result.squeeze)
+    } else {
+      val size = result.size(1)
+      require(batchSize == size,
+        s"The batchSize is required to be $size, while actual is $batchSize")
+      result.split(1)
+    }
+    out.asInstanceOf[Array[Activity]]
+  }
+
+  private[zoo] def splitBatch[T: ClassTag](output: Activity, shareBuffer: Boolean, batchSize: Int)
+                                            (implicit ev: TensorNumeric[T]): Array[Activity] = {
+    val out = if (output.isTensor) {
+      splitTensor(output.toTensor, shareBuffer, batchSize)
+    } else {
+      val result = output.toTable
+      val tables = new Array[Table](batchSize)
+
+
+      (1 to result.length()).foreach(key => {
+        val split = splitBatch(result(key), shareBuffer, batchSize)
+        val size = split.length
+        require(batchSize == size,
+          s"The batchSize is required to be $size, while actual is $batchSize")
+        var i = 0
+        while (i < batchSize) {
+          if (tables(i) == null) tables(i) = T()
+          tables(i).insert(split(i))
+          i += 1
+        }
+      })
+      tables
+    }
+    out.asInstanceOf[Array[Activity]]
+  }
+
+
+  def predictImage[T: ClassTag](imageFrame: DistributedImageFrame,
+                                outputLayer: String = null,
+                                shareBuffer: Boolean = false,
+                                predictKey: String = ImageFeature.predict,
+                                batchPerPartition: Int,
+                                model: Module[T],
+                                featurePaddingParam: Option[PaddingParam[T]])(
+                                 implicit ev: TensorNumeric[T]): DistributedImageFrame = {
+    val localBatchPerPartition = batchPerPartition
+
+    val rdd = imageFrame.asInstanceOf[DistributedImageFrame].rdd
+    val modelBroad = ModelBroadcast[T]().broadcast(rdd.sparkContext, model.evaluate())
+    val partitionNum = rdd.partitions.length
+    val toBatchBroad = rdd.sparkContext.broadcast(SampleToMiniBatch(
+      batchSize = partitionNum * batchPerPartition,
+      partitionNum = Some(partitionNum),
+      featurePaddingParam = featurePaddingParam), shareBuffer)
+    val result = rdd.mapPartitions(partition => {
+      val localModel = modelBroad.value()
+      val localToBatch = toBatchBroad.value._1.cloneTransformer()
+
+      partition.grouped(localBatchPerPartition).flatMap(imageFeatures => {
+        Predictor.predictImageBatch[T](localModel, imageFeatures, outputLayer, predictKey,
+          localToBatch, shareBuffer)
+        imageFeatures
+      })
+    })
+    ImageFrame.rdd(result)
+  }
+
+  def predict[T: ClassTag](dataSet: RDD[Sample[T]], batchSize: Int = -1,
+      shareBuffer: Boolean = false, model: Module[T], batchPerPartition: Int,
+      featurePaddingParam: Option[PaddingParam[T]])
+                          (implicit ev: TensorNumeric[T]): RDD[Activity] = {
+    val modelBroad = ModelBroadcast[T]().broadcast(dataSet.sparkContext, model.evaluate())
+    val partitionNum = dataSet.partitions.length
+    val totalBatch = if (batchSize > 0) {
+      require(batchSize % partitionNum == 0, s"Predictor.predict: total batch size $batchSize " +
+        s"should be divided by partitionNum ${partitionNum}")
+      batchSize
+    } else {
+      batchPerPartition * partitionNum
+    }
+    val otherBroad = dataSet.sparkContext.broadcast(SampleToMiniBatch(
+      batchSize = totalBatch,
+      partitionNum = Some(partitionNum),
+      featurePaddingParam = featurePaddingParam))
+    dataSet.mapPartitions { partition =>
+      val localModel = modelBroad.value()
+      val localTransformer = otherBroad.value.cloneTransformer()
+      val miniBatch = localTransformer(partition)
+      miniBatch.flatMap(batch => {
+        val output = localModel.forward(batch.getInput)
+        splitBatch(output, shareBuffer, batch.size())
+
+      })
+    }
+  }
+
+  def predictClass[T: ClassTag](dataSet: RDD[Sample[T]], batchSize: Int = -1, model: Module[T],
+             batchPerPartition: Int, featurePaddingParam: Option[PaddingParam[T]])(
+    implicit ev: TensorNumeric[T]): RDD[Int] = {
+    val result = Predictor.predict(dataSet, batchSize, true, model,
+      batchPerPartition, featurePaddingParam)
+    result.mapPartitions { partition =>
+      partition.map(output => {
+        val _output = output.toTensor[T]
+        require(_output.dim() == 1, s"Predictor.predictClass:" +
+          s"Only support one sample has one label, but got ${_output.dim()} label")
+        ev.toType[Int](_output.max(1)._2.valueAt(1))
+      })
+    }
+  }
+}
+
+trait Predictable[T]  {
+
+  this: Module[T] =>
+
+
+  implicit val tag: ClassTag[T]
+  implicit val ev: com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric[T]
+
+
+  /**
+   * Use a model to do prediction for RDD.
+   *
+   * @param x Prediction data, RDD of Sample.
+   * @param batchPerThread The total batchSize is batchPerThread * rdd.getNumPartitions.
+   */
+  def predict(
+               x: RDD[Sample[T]],
+               batchPerThread: Int)(implicit ev: TensorNumeric[T]): RDD[Activity] = {
+    this.predict(x, batchPerThread * x.getNumPartitions, false)
+  }
+
+  /**
+   * Use a model to do prediction for RDD.
+   * The default batchPerThread is 4,
+   * and the total batchSize is batchPerThread * rdd.getNumPartitions.
+   * @param x Prediction data, RDD of Sample.
+   */
+  def predict(
+               x: RDD[Sample[T]])(implicit ev: TensorNumeric[T]): RDD[Activity] = {
+    this.predict(x, batchPerThread = 4)
+  }
+
+  /**
+   * Use a model to do prediction in local mode.
+   *
+   * @param x Prediction data, LocalDataSet.
+   * @param batchPerThread The total batchSize is batchPerThread * numOfCores.
+   */
+  def predict(
+               x: LocalDataSet[MiniBatch[T]],
+               batchPerThread: Int)(implicit ev: TensorNumeric[T]): Array[Activity] = {
+    val localPredictor = LocalPredictor(this, batchPerCore = batchPerThread)
+    localPredictor.predict(x)
+  }
+
+  /**
+   * Use a model to do prediction in local mode.
+   * The total batch size is batchPerThread * numOfCores, and batchPerThread is 4 by default.
+   * @param x Prediction data, LocalDataSet.
+   */
+  def predict(
+               x: LocalDataSet[MiniBatch[T]])(implicit ev: TensorNumeric[T]): Array[Activity] = {
+    predict(x, batchPerThread = 4)
+  }
+
+  /**
+   * Use a model to do prediction in local mode.
+   *
+   * @param x Prediction data, array of Sample.
+   * @param batchPerThread The total batchSize is batchPerThread * numOfCores.
+   */
+  def predict(
+               x: Array[Sample[T]],
+               batchPerThread: Int)(implicit ev: TensorNumeric[T]): Array[Activity] = {
+    val localPredictor = LocalPredictor(this, batchPerCore = batchPerThread)
+    localPredictor.predict(x)
+  }
+
+  /**
+   * Use a model to do prediction in local mode.
+   * The total batch size is batchPerThread * numOfCores, and batchPerThread is 4 by default.
+   * @param x Prediction data, array of Sample.
+   */
+  def predict(
+               x: Array[Sample[T]])(implicit ev: TensorNumeric[T]): Array[Activity] = {
+    predict(x, batchPerThread = 4)
+  }
+
+  /**
+   * Use a model to do prediction on ImageSet.
+   *
+   * @param x Prediction data, ImageSet.
+   * @param batchPerThread The total batch size is
+   *        batchPerThread * rdd.getNumPartitions(distributed mode)
+   *        or batchPerThread * numOfCores(local mode)
+   */
+  def predict(
+               x: ImageSet,
+               batchPerThread: Int): ImageSet = {
+    ImageSet.fromImageFrame(predictImage(x.toImageFrame(),
+      batchPerPartition = batchPerThread))
+  }
+
+  /**
+   * The default batchPerThread is 4.
+   * For DistributedImageSet, the total batchSize is batchPerThread * rdd.getNumPartitions.
+   * For LocalImageSet, the total batchSize is batchPerThread * numOfCores.
+   *
+   * @param x Prediction data, ImageSet.
+   */
+  def predict(
+               x: ImageSet): ImageSet = {
+    predict(x, batchPerThread = 4)
+  }
+
+  /**
+   * Use a model to do prediction on TextSet.
+   *
+   * @param x Prediction data, TextSet.
+   * @param batchPerThread The total batch size is
+   *        batchPerThread * rdd.getNumPartitions(distributed mode)
+   *        or batchPerThread * numOfCores(local mode)
+   */
+  def predict(
+               x: TextSet,
+               batchPerThread: Int): TextSet = {
+    x match {
+      case distributed: DistributedTextSet =>
+        TextPredictor[T](this, batchPerThread).predict(distributed)
+      case local: LocalTextSet =>
+        val features = local.array
+        val samples = features.map(_.getSample).asInstanceOf[Array[Sample[T]]]
+        val predictions = predict(samples, batchPerThread)
+        val results = features.zip(predictions).map{case (feature, predict) =>
+          feature(TextFeature.predict) = predict
+          feature
+        }
+        TextSet.array(results).setWordIndex(x.getWordIndex)
+    }
+  }
+
+  /**
+   * The default batchPerThread is 4.
+   * For DistributedTextSet, the total batchSize is batchPerThread * rdd.getNumPartitions.
+   * For LocalTextSet, the total batchSize is batchPerThread * numOfCores.
+   *
+   * @param x Prediction data, TextSet.
+   */
+  def predict(
+               x: TextSet): TextSet = {
+    predict(x, batchPerThread = 4)
+  }
+
+  /**
+   * Use a model to predict for classes. By default, label predictions start from 0.
+   *
+   * @param x Prediction data, RDD of Sample.
+   * @param batchPerThread The default batchPerThread is 4,
+   *       and the total batchSize is batchPerThread * rdd.getNumPartitions.
+   * @param zeroBasedLabel Boolean. Whether result labels start from 0.
+   *                       Default is true. If false, result labels start from 1.
+   */
+  def predictClasses(
+                      x: RDD[Sample[T]],
+                      batchPerThread: Int = 4,
+                      zeroBasedLabel: Boolean = true): RDD[Int] = {
+    KerasUtils.toZeroBasedLabel(zeroBasedLabel,
+      this.predictClass(x, batchPerThread * x.getNumPartitions))
+  }
+
+}
+
+/**
+ * Predictor for distributed data
+ *
+ * NOTE: The `predictClass`, `predict` and `predictImage` will call the relevant methods of
+ * object `Predictor`. Why we do this? Because every these methods uses the ClassTag `T`. If we do
+ * these jobs in the methods of class`Predictor`, when we do `mapPartition`, Spark will find all
+ * used values and do serialization. The `T` is the argument of constructor, the serialization will
+ * package the whole `Predictor` class, which contains the`model`. It will send a duplicate model
+ * to the workers. So we should move these methods to object `Predictor`.
+ *
+ * @param model BigDL model
+ * @param featurePaddingParam featurePaddingParam if the inputs have variant size
+ * @param batchPerPartition batch size per partition, default is 4
+ */
+class Predictor[T: ClassTag] private[zoo](
+                                             model: Module[T],
+                                             featurePaddingParam: Option[PaddingParam[T]] = None,
+                                             batchPerPartition: Int = 4)
+                                           (implicit ev: TensorNumeric[T]) extends Serializable {
+
+  def predictClass(dataSet: RDD[Sample[T]], batchSize: Int = -1): RDD[Int] = {
+    Predictor.predictClass(dataSet, batchSize, model, batchPerPartition, featurePaddingParam)
+  }
+
+  def predict(dataSet: RDD[Sample[T]], batchSize: Int = -1,
+              shareBuffer: Boolean = false): RDD[Activity] = {
+    Predictor.predict(dataSet, batchSize, shareBuffer, model, batchPerPartition,
+      featurePaddingParam)
+  }
+
+
+  /**
+   * model predict DistributedImageFrame, return imageFrame with predicted tensor
+   * @param imageFrame imageFrame that contains images
+   * @param outputLayer if outputLayer is not null, the output of layer that matches
+   *                      outputLayer will be used as predicted output
+   * @param shareBuffer whether to share same memory for each batch predict results
+   * @param predictKey key to store predicted result
+   */
+  def predictImage(imageFrame: DistributedImageFrame,
+                   outputLayer: String = null,
+                   shareBuffer: Boolean = false,
+                   predictKey: String = ImageFeature.predict): DistributedImageFrame = {
+    Predictor.predictImage(imageFrame, outputLayer, shareBuffer, predictKey, batchPerPartition,
+      model, featurePaddingParam)
+  }
+}

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
@@ -46,7 +46,7 @@ import scala.language.implicitConversions
 abstract class KerasNet[T](implicit val tag: ClassTag[T], implicit val ev: TensorNumeric[T])
   extends KerasLayer[Activity, Activity, T] with Net with Predictable[T] {
 
-  val module: Module[T] = this
+  protected val module: Module[T] = this
 
   def getSubModules(): List[AbstractModule[Activity, Activity, T]] = {
     require(this.labor.isInstanceOf[Container[Activity, Activity, T]],

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
@@ -30,7 +30,7 @@ import com.intel.analytics.bigdl.utils.serializer.{DeserializeContext, ModuleDat
 import com.intel.analytics.bigdl.visualization.{TrainSummary, ValidationSummary}
 import com.intel.analytics.zoo.feature.image.ImageSet
 import com.intel.analytics.zoo.feature.text._
-import com.intel.analytics.zoo.pipeline.api.Net
+import com.intel.analytics.zoo.pipeline.api.{Net, Predictable}
 import com.intel.analytics.zoo.pipeline.api.autograd.{Lambda, Variable}
 import com.intel.analytics.zoo.pipeline.api.autograd._
 import com.intel.analytics.zoo.pipeline.api.keras.layers.Input
@@ -43,8 +43,8 @@ import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 import scala.language.implicitConversions
 
-abstract class KerasNet[T: ClassTag](implicit ev: TensorNumeric[T])
-  extends KerasLayer[Activity, Activity, T] with Net {
+abstract class KerasNet[T](implicit val tag: ClassTag[T], implicit val ev: TensorNumeric[T])
+  extends KerasLayer[Activity, Activity, T] with Net with Predictable[T] {
 
   def getSubModules(): List[AbstractModule[Activity, Activity, T]] = {
     require(this.labor.isInstanceOf[Container[Activity, Activity, T]],
@@ -438,157 +438,6 @@ abstract class KerasNet[T: ClassTag](implicit ev: TensorNumeric[T])
         val localSet = toDataSet(local, batchSize).asInstanceOf[LocalDataSet[MiniBatch[T]]]
         evaluate(localSet)
     }
-  }
-
-  /**
-   * Use a model to do prediction for RDD.
-   *
-   * @param x Prediction data, RDD of Sample.
-   * @param batchPerThread The total batchSize is batchPerThread * rdd.getNumPartitions.
-   */
-  def predict(
-      x: RDD[Sample[T]],
-      batchPerThread: Int)(implicit ev: TensorNumeric[T]): RDD[Activity] = {
-    this.predict(x, batchPerThread * x.getNumPartitions, false)
-  }
-
-  /**
-   * Use a model to do prediction for RDD.
-   * The default batchPerThread is 4,
-   * and the total batchSize is batchPerThread * rdd.getNumPartitions.
-   * @param x Prediction data, RDD of Sample.
-   */
-  def predict(
-      x: RDD[Sample[T]])(implicit ev: TensorNumeric[T]): RDD[Activity] = {
-    this.predict(x, batchPerThread = 4)
-  }
-
-  /**
-   * Use a model to do prediction in local mode.
-   *
-   * @param x Prediction data, LocalDataSet.
-   * @param batchPerThread The total batchSize is batchPerThread * numOfCores.
-   */
-  def predict(
-      x: LocalDataSet[MiniBatch[T]],
-      batchPerThread: Int)(implicit ev: TensorNumeric[T]): Array[Activity] = {
-    val localPredictor = LocalPredictor(this, batchPerCore = batchPerThread)
-    localPredictor.predict(x)
-  }
-
-  /**
-   * Use a model to do prediction in local mode.
-   * The total batch size is batchPerThread * numOfCores, and batchPerThread is 4 by default.
-   * @param x Prediction data, LocalDataSet.
-   */
-  def predict(
-      x: LocalDataSet[MiniBatch[T]])(implicit ev: TensorNumeric[T]): Array[Activity] = {
-    predict(x, batchPerThread = 4)
-  }
-
-  /**
-   * Use a model to do prediction in local mode.
-   *
-   * @param x Prediction data, array of Sample.
-   * @param batchPerThread The total batchSize is batchPerThread * numOfCores.
-   */
-  def predict(
-      x: Array[Sample[T]],
-      batchPerThread: Int)(implicit ev: TensorNumeric[T]): Array[Activity] = {
-    val localPredictor = LocalPredictor(this, batchPerCore = batchPerThread)
-    localPredictor.predict(x)
-  }
-
-  /**
-   * Use a model to do prediction in local mode.
-   * The total batch size is batchPerThread * numOfCores, and batchPerThread is 4 by default.
-   * @param x Prediction data, array of Sample.
-   */
-  def predict(
-      x: Array[Sample[T]])(implicit ev: TensorNumeric[T]): Array[Activity] = {
-    predict(x, batchPerThread = 4)
-  }
-
-  /**
-   * Use a model to do prediction on ImageSet.
-   *
-   * @param x Prediction data, ImageSet.
-   * @param batchPerThread The total batch size is
-   *        batchPerThread * rdd.getNumPartitions(distributed mode)
-   *        or batchPerThread * numOfCores(local mode)
-   */
-  def predict(
-      x: ImageSet,
-      batchPerThread: Int): ImageSet = {
-    ImageSet.fromImageFrame(predictImage(x.toImageFrame(),
-      batchPerPartition = batchPerThread))
-  }
-
-  /**
-   * The default batchPerThread is 4.
-   * For DistributedImageSet, the total batchSize is batchPerThread * rdd.getNumPartitions.
-   * For LocalImageSet, the total batchSize is batchPerThread * numOfCores.
-   *
-   * @param x Prediction data, ImageSet.
-   */
-  def predict(
-      x: ImageSet): ImageSet = {
-    predict(x, batchPerThread = 4)
-  }
-
-  /**
-   * Use a model to do prediction on TextSet.
-   *
-   * @param x Prediction data, TextSet.
-   * @param batchPerThread The total batch size is
-   *        batchPerThread * rdd.getNumPartitions(distributed mode)
-   *        or batchPerThread * numOfCores(local mode)
-   */
-  def predict(
-      x: TextSet,
-      batchPerThread: Int): TextSet = {
-    x match {
-      case distributed: DistributedTextSet =>
-        TextPredictor[T](this, batchPerThread).predict(distributed)
-      case local: LocalTextSet =>
-        val features = local.array
-        val samples = features.map(_.getSample).asInstanceOf[Array[Sample[T]]]
-        val predictions = predict(samples, batchPerThread)
-        val results = features.zip(predictions).map{case (feature, predict) =>
-          feature(TextFeature.predict) = predict
-          feature
-        }
-        TextSet.array(results).setWordIndex(x.getWordIndex)
-    }
-  }
-
-  /**
-   * The default batchPerThread is 4.
-   * For DistributedTextSet, the total batchSize is batchPerThread * rdd.getNumPartitions.
-   * For LocalTextSet, the total batchSize is batchPerThread * numOfCores.
-   *
-   * @param x Prediction data, TextSet.
-   */
-  def predict(
-      x: TextSet): TextSet = {
-    predict(x, batchPerThread = 4)
-  }
-
-  /**
-   * Use a model to predict for classes. By default, label predictions start from 0.
-   *
-   * @param x Prediction data, RDD of Sample.
-   * @param batchPerThread The default batchPerThread is 4,
-   *       and the total batchSize is batchPerThread * rdd.getNumPartitions.
-   * @param zeroBasedLabel Boolean. Whether result labels start from 0.
-   *                       Default is true. If false, result labels start from 1.
-   */
-  def predictClasses(
-      x: RDD[Sample[T]],
-      batchPerThread: Int = 4,
-      zeroBasedLabel: Boolean = true): RDD[Int] = {
-    KerasUtils.toZeroBasedLabel(zeroBasedLabel,
-      super.predictClass(x, batchPerThread * x.getNumPartitions))
   }
 
   def toModel(): Model[T]

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
@@ -46,6 +46,8 @@ import scala.language.implicitConversions
 abstract class KerasNet[T](implicit val tag: ClassTag[T], implicit val ev: TensorNumeric[T])
   extends KerasLayer[Activity, Activity, T] with Net with Predictable[T] {
 
+  val module: Module[T] = this
+
   def getSubModules(): List[AbstractModule[Activity, Activity, T]] = {
     require(this.labor.isInstanceOf[Container[Activity, Activity, T]],
       s"labor should be a container, but we got: $this")

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/NetUtils.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/NetUtils.scala
@@ -15,6 +15,8 @@
  */
 package com.intel.analytics.zoo.pipeline.api.net
 
+import java.util.concurrent.{ConcurrentHashMap, ConcurrentMap}
+
 import com.esotericsoftware.kryo.{Kryo, KryoSerializable}
 import com.esotericsoftware.kryo.io.{Input, Output}
 import com.intel.analytics.bigdl.Module

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/NetUtils.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/NetUtils.scala
@@ -28,6 +28,7 @@ import com.intel.analytics.bigdl.serialization.Bigdl.BigDLModule
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.serializer._
+import com.intel.analytics.zoo.pipeline.api.Predictable
 import com.intel.analytics.zoo.pipeline.api.keras.layers.KerasLayerWrapper
 import com.intel.analytics.zoo.pipeline.api.keras.layers.utils.KerasUtils
 import org.apache.spark.utils.SparkUtils
@@ -43,8 +44,10 @@ import scala.reflect.ClassTag
 import scala.reflect.io.Path
 
 
-class GraphNet[T: ClassTag](graph: Graph[T])(implicit ev: TensorNumeric[T])
-  extends Container[Activity, Activity, T] with NetUtils[T, GraphNet[T]] {
+class GraphNet[T](graph: Graph[T])(implicit val tag: ClassTag[T], implicit val ev: TensorNumeric[T])
+  extends Container[Activity, Activity, T] with NetUtils[T, GraphNet[T]] with Predictable[T] {
+
+  protected val module: Module[T] = this
 
   // need to refer this object to make the register effective
   GraphNet

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TFNet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TFNet.scala
@@ -55,6 +55,7 @@ class TFNet(private val graphDef: TFGraphHolder,
                     config: Array[Int])
   extends AbstractModule[Activity, Activity, Float] with Predictable[Float] {
 
+  val module: Module[Float] = this
   implicit val ev = TensorNumeric.NumericFloat
   implicit val tag: ClassTag[Float] = ClassTag(Float.getClass)
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TFNet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TFNet.scala
@@ -55,7 +55,7 @@ class TFNet(private val graphDef: TFGraphHolder,
                     config: Array[Int])
   extends AbstractModule[Activity, Activity, Float] with Predictable[Float] {
 
-  val module: Module[Float] = this
+  protected val module: Module[Float] = this
   implicit val ev = TensorNumeric.NumericFloat
   implicit val tag: ClassTag[Float] = ClassTag.Float
 


### PR DESCRIPTION
1. move predict methods to a trait so that other mode (like TFNet)l can use these methods
2. create a new predictor for the use of analytics-zoo
3. fix memory leak when using TFNet (create a Iterator that will call a shutdown hook when hasNext return false)