### PR TITLE
Support ML Vector for NNFrames.

### DIFF
--- a/pyzoo/test/zoo/pipeline/nnframes/test_nn_classifier.py
+++ b/pyzoo/test/zoo/pipeline/nnframes/test_nn_classifier.py
@@ -522,7 +522,7 @@ class TestNNClassifer():
             scaler = MinMaxScaler().setInputCol("features").setOutputCol("scaled")
             model = Sequential().add(Linear(2, 2))
             criterion = ClassNLLCriterion()
-            classifier = NNClassifier(model, criterion, MLlibVectorToTensor([2]))\
+            classifier = NNClassifier(model, criterion)\
                 .setBatchSize(4) \
                 .setLearningRate(0.01).setMaxEpoch(1).setFeaturesCol("scaled")
 

--- a/pyzoo/zoo/feature/common.py
+++ b/pyzoo/zoo/feature/common.py
@@ -91,6 +91,7 @@ class ArrayToTensor(Preprocessing):
 class MLlibVectorToTensor(Preprocessing):
     """
     a Transformer that converts MLlib Vector to a Tensor.
+    .. note:: Deprecated in 0.4.0. NNEstimator will automatically extract Vectors now.
     :param size dimensions of target Tensor.
     """
     def __init__(self, size, bigdl_type="float"):

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/common/MLlibVectorToTensor.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/common/MLlibVectorToTensor.scala
@@ -23,8 +23,11 @@ import scala.reflect.ClassTag
 
 /**
  * a Preprocessing that converts MLlib Vector to a Tensor.
+ * :: deprecated, NNEstimator can automatically extract Vectors now.
+ *
  * @param size dimensions of target Tensor.
  */
+@deprecated("NNEstimator can automatically extract Vectors now", "0.4.0")
 class MLlibVectorToTensor[T: ClassTag](size: Array[Int])(implicit ev: TensorNumeric[T])
   extends Preprocessing[Vector, Tensor[T]] {
 
@@ -34,6 +37,11 @@ class MLlibVectorToTensor[T: ClassTag](size: Array[Int])(implicit ev: TensorNume
 }
 
 object MLlibVectorToTensor {
+
+  /**
+   * :: deprecated, NNEstimator can automatically extract Vectors now.
+   */
+  @deprecated("NNEstimator can automatically extract Vectors now", "0.4.0")
   def apply[T: ClassTag](size: Array[Int])(implicit ev: TensorNumeric[T]): MLlibVectorToTensor[T] =
     new MLlibVectorToTensor[T](size)
 }


### PR DESCRIPTION
The PR leverages the Spark-version projects in BigDL to process both MLlib and ML Vectors, thus to allow NNEstimator and NNClassifier to use ML Vectors as features and labels.