### PR TITLE
Update KNRM Python

### DIFF
--- a/pyzoo/test/zoo/models/textmatching/test_knrm.py
+++ b/pyzoo/test/zoo/models/textmatching/test_knrm.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+import os
 import pytest
 
 from keras.layers import *
@@ -22,6 +23,9 @@ from zoo.models.textmatching import KNRM
 from test.zoo.pipeline.utils.test_utils import ZooTestCase
 
 np.random.seed(1337)  # for reproducibility
+
+resource_path = os.path.join(os.path.split(__file__)[0], "../../resources")
+glove_path = os.path.join(resource_path, "glove.6B/glove.6B.50d.txt")
 
 
 class TestKNRM(ZooTestCase):
@@ -61,26 +65,25 @@ class TestKNRM(ZooTestCase):
         return model
 
     def test_with_keras(self):
-        kmodel = self.keras_knrm(5, 10, 20, 100)
+        kmodel = self.keras_knrm(5, 10, 22, 50)
         input_data = np.random.randint(20, size=(4, 15))
         koutput = kmodel.predict([input_data[:, :5], input_data[:, 5:]])
         kweights = kmodel.get_weights()
         bweights = [kweights[0], np.transpose(kweights[1]), kweights[2]]
-        model = KNRM(5, 10, 20, 100)
+        model = KNRM(5, 10, glove_path)
         model.set_weights(bweights)
         output = model.forward(input_data)
         self.assert_allclose(output, koutput)
 
     def test_forward_backward(self):
-        weights = np.random.random([40, 20])
-        model = KNRM(15, 60, 40, 20, embed_weights=weights,
+        model = KNRM(15, 60, glove_path, word_index={"is": 1, "to": 2, "the": 3, "for": 4},
                      kernel_num=10, sigma=0.15, exact_sigma=1e-4)
-        input_data = np.random.randint(40, size=(1, 75))
+        input_data = np.random.randint(5, size=(1, 75))
         self.assert_forward_backward(model, input_data)
 
     def test_save_load(self):
-        model = KNRM(5, 10, 100)
-        input_data = np.random.randint(100, size=(3, 15))
+        model = KNRM(5, 10, glove_path)
+        input_data = np.random.randint(20, size=(3, 15))
         self.assert_zoo_model_save_load(model, input_data)
 
 

--- a/pyzoo/zoo/feature/text/text_feature.py
+++ b/pyzoo/zoo/feature/text/text_feature.py
@@ -26,7 +26,7 @@ if sys.version >= '3':
 class TextFeature(JavaValue):
     """
     Each TextFeature keeps information of a single text record.
-    It can include various status of a text,
+    It can include various status (if any) of a text,
     e.g. original text content, uri, category label, tokens, index representation
     of tokens, BigDL Sample representation, prediction result and so on.
     """

--- a/pyzoo/zoo/feature/text/text_feature.py
+++ b/pyzoo/zoo/feature/text/text_feature.py
@@ -27,7 +27,7 @@ class TextFeature(JavaValue):
     """
     Each TextFeature keeps information of a single text record.
     It can include various status of a text,
-    e.g. original text content, category label, tokens, index representation
+    e.g. original text content, uri, category label, tokens, index representation
     of tokens, BigDL Sample representation, prediction result and so on.
     """
     def __init__(self, text=None, label=None, jvalue=None, bigdl_type="float"):

--- a/pyzoo/zoo/models/textmatching/knrm.py
+++ b/pyzoo/zoo/models/textmatching/knrm.py
@@ -64,7 +64,8 @@ class KNRM(TextMatcher):
     def __init__(self, text1_length, text2_length, embedding_file, word_index=None,
                  train_embed=True, kernel_num=21, sigma=0.1, exact_sigma=0.001,
                  target_mode="ranking", bigdl_type="float"):
-        embed_weights = prepare_embedding(embedding_file, word_index)
+        embed_weights = prepare_embedding(embedding_file, word_index,
+                                          randomize_unknown=True, normalize=True)
         vocab_size, embed_size = embed_weights.shape
         super(KNRM, self).__init__(text1_length, vocab_size, embed_size,
                                    embed_weights, train_embed, target_mode, bigdl_type)

--- a/pyzoo/zoo/models/textmatching/knrm.py
+++ b/pyzoo/zoo/models/textmatching/knrm.py
@@ -19,7 +19,7 @@ import sys
 import zoo.pipeline.api.autograd as A
 from zoo.models.common.zoo_model import ZooModel
 from zoo.models.textmatching.text_matcher import TextMatcher
-from zoo.pipeline.api.keras.layers import Input, Embedding, Dense, Squeeze
+from zoo.pipeline.api.keras.layers import Input, Embedding, Dense, Squeeze, prepare_embedding
 from zoo.pipeline.api.keras.models import Model
 from bigdl.util.common import callBigDlFunc, JTensor
 
@@ -47,10 +47,13 @@ class KNRM(TextMatcher):
     exact_sigma: Float. The sigma used for the kernel that harvests exact matches
                  in the case where RBF mu=1.0. Default is 0.001.
     """
-    def __init__(self, text1_length, text2_length, vocab_size, embed_size=300, embed_weights=None,
-                 train_embed=True, kernel_num=21, sigma=0.1, exact_sigma=0.001, bigdl_type="float"):
+    def __init__(self, text1_length, text2_length, embedding_file, word_index=None,
+                 train_embed=True, kernel_num=21, sigma=0.1, exact_sigma=0.001,
+                 target_mode="ranking", bigdl_type="float"):
+        embed_weights = prepare_embedding(embedding_file, word_index)
+        vocab_size, embed_size = embed_weights.shape
         super(KNRM, self).__init__(text1_length, vocab_size, embed_size,
-                                   embed_weights, train_embed, bigdl_type)
+                                   embed_weights, train_embed, target_mode, bigdl_type)
         self.text2_length = text2_length
         self.kernel_num = kernel_num
         self.sigma = float(sigma)
@@ -66,6 +69,7 @@ class KNRM(TextMatcher):
                                           self.kernel_num,
                                           self.sigma,
                                           self.exact_sigma,
+                                          self.target_mode,
                                           self.model)
 
     def build_model(self):

--- a/pyzoo/zoo/models/textmatching/knrm.py
+++ b/pyzoo/zoo/models/textmatching/knrm.py
@@ -36,16 +36,30 @@ class KNRM(TextMatcher):
     # Arguments:
     text1_length: Sequence length of text1 (query).
     text2_length: Sequence length of text2 (doc).
-    vocab_size: Int. The input_dim of the embedding layer. Ought to be the total number
-                of words in the corpus +1, with index 0 reserved for unknown words.
-    embed_size: Int. The output_dim of the embedding layer. Default is 300.
-    embed_weights: Numpy array. Pre-trained word embedding weights if any. Default is None
-                   and in this case, initial weights will be randomized.
+    embedding_file: The path to the word embedding file.
+                    Currently only the following GloVe files are supported:
+                    "glove.6B.50d.txt", "glove.6B.100d.txt", "glove.6B.200d.txt"
+                    "glove.6B.300d.txt", "glove.42B.300d.txt", "glove.840B.300d.txt".
+                    You can download from: https://nlp.stanford.edu/projects/glove/.
+    word_index: Dictionary of word (string) and its corresponding index (int).
+                The index is supposed to start from 1 with 0 reserved for unknown words.
+                During the prediction, if you have words that are not in the word_index
+                for the training, you can map them to index 0.
+                Default is None. In this case, all the words in the embedding_file will
+                be taken into account and you can call
+                WordEmbedding.get_word_index(embedding_file) to retrieve the dictionary.
     train_embed: Boolean. Whether to train the embedding layer or not. Default is True.
     kernel_num: Int. The number of kernels to use. Default is 21.
     sigma: Float. Defines the kernel width, or the range of its softTF count. Default is 0.1.
     exact_sigma: Float. The sigma used for the kernel that harvests exact matches
                  in the case where RBF mu=1.0. Default is 0.001.
+    target_mode: String. The target mode of the model. Either 'ranking' or 'classification'.
+                 For ranking, the output will be the relevance score between text1 and text2 and
+                 you are recommended to use RankHinge as loss for pairwise training.
+                 For classification, the last layer will be sigmoid and the output will be the
+                 probability between 0 and 1 indicating whether text1 is related to text2 and
+                 you are recommended to use 'binary_crossentropy' as loss for binary classification.
+                 Default mode is 'ranking'.
     """
     def __init__(self, text1_length, text2_length, embedding_file, word_index=None,
                  train_embed=True, kernel_num=21, sigma=0.1, exact_sigma=0.001,

--- a/pyzoo/zoo/models/textmatching/text_matcher.py
+++ b/pyzoo/zoo/models/textmatching/text_matcher.py
@@ -29,10 +29,11 @@ class TextMatcher(ZooModel):
     Referred to MatchZoo implementation: https://github.com/NTMC-Community/MatchZoo
     """
     def __init__(self, text1_length, vocab_size, embed_size=300, embed_weights=None,
-                 train_embed=True, bigdl_type="float"):
+                 train_embed=True, target_mode="ranking", bigdl_type="float"):
         self.text1_length = text1_length
         self.vocab_size = vocab_size
         self.embed_size = embed_size
         self.embed_weights = embed_weights
         self.train_embed = train_embed
+        self.target_mode = target_mode
         self.bigdl_type = bigdl_type

--- a/pyzoo/zoo/pipeline/api/keras/layers/embeddings.py
+++ b/pyzoo/zoo/pipeline/api/keras/layers/embeddings.py
@@ -130,6 +130,15 @@ class WordEmbedding(ZooKerasLayer):
                              embedding_file)
 
 
+def prepare_embedding(embedding_file, word_index=None,
+                      randomize_unknown=True, normalize=True):
+    return callBigDlFunc("float", "prepareEmbedding",
+                         embedding_file,
+                         word_index,
+                         randomize_unknown,
+                         normalize).to_ndarray()
+    
+
 class SparseEmbedding(ZooKerasLayer):
     """
     SparseEmbedding is the sparse version of layer Embedding.

--- a/pyzoo/zoo/pipeline/api/keras/layers/embeddings.py
+++ b/pyzoo/zoo/pipeline/api/keras/layers/embeddings.py
@@ -122,7 +122,7 @@ class WordEmbedding(ZooKerasLayer):
                         "glove.6B.300d.txt", "glove.42B.300d.txt", "glove.840B.300d.txt".
                         You can download them from: https://nlp.stanford.edu/projects/glove/.
 
-        # Returns
+        # Return
         Dictionary of word (string) and its corresponding index (int) obtained from
         the given embedding file.
         """
@@ -132,6 +132,30 @@ class WordEmbedding(ZooKerasLayer):
 
 def prepare_embedding(embedding_file, word_index=None,
                       randomize_unknown=True, normalize=True):
+    """
+    Prepare embedding weights from embedding_file given word_index.
+
+    # Arguments
+    embedding_file: The path to the embedding file.
+                    Currently only the following GloVe files are supported:
+                    "glove.6B.50d.txt", "glove.6B.100d.txt", "glove.6B.200d.txt"
+                    "glove.6B.300d.txt", "glove.42B.300d.txt", "glove.840B.300d.txt".
+                    You can download them from: https://nlp.stanford.edu/projects/glove/.
+    word_index: Dictionary of word (string) and its corresponding index (int).
+                The index is supposed to start from 1 with 0 reserved for unknown words.
+                During the prediction, if you have words that are not in the word_index
+                for the training, you can map them to index 0.
+                Default is None. In this case, all the words in the embedding_file will
+                be taken into account and you can call
+                WordEmbedding.get_word_index(embedding_file) to retrieve the dictionary.
+    randomize_unknown: Boolean. Whether to randomly initialize words that don't exist in
+                       embedding_file. Default is True.
+                       If False, corresponding entries to unknown words will be zero vectors.
+    normalize: Boolean. Whether to normalize word vectors. Default is True.
+
+    # Return
+    Pretrained embedding weights as a numpy array.
+    """
     return callBigDlFunc("float", "prepareEmbedding",
                          embedding_file,
                          word_index,

--- a/pyzoo/zoo/pipeline/api/keras/layers/embeddings.py
+++ b/pyzoo/zoo/pipeline/api/keras/layers/embeddings.py
@@ -136,18 +136,7 @@ def prepare_embedding(embedding_file, word_index=None,
     Prepare embedding weights from embedding_file given word_index.
 
     # Arguments
-    embedding_file: The path to the embedding file.
-                    Currently only the following GloVe files are supported:
-                    "glove.6B.50d.txt", "glove.6B.100d.txt", "glove.6B.200d.txt"
-                    "glove.6B.300d.txt", "glove.42B.300d.txt", "glove.840B.300d.txt".
-                    You can download them from: https://nlp.stanford.edu/projects/glove/.
-    word_index: Dictionary of word (string) and its corresponding index (int).
-                The index is supposed to start from 1 with 0 reserved for unknown words.
-                During the prediction, if you have words that are not in the word_index
-                for the training, you can map them to index 0.
-                Default is None. In this case, all the words in the embedding_file will
-                be taken into account and you can call
-                WordEmbedding.get_word_index(embedding_file) to retrieve the dictionary.
+    embedding_file and word_index: See WordEmbedding.
     randomize_unknown: Boolean. Whether to randomly initialize words that don't exist in
                        embedding_file. Default is True.
                        If False, corresponding entries to unknown words will be zero vectors.

--- a/pyzoo/zoo/pipeline/api/keras/layers/embeddings.py
+++ b/pyzoo/zoo/pipeline/api/keras/layers/embeddings.py
@@ -131,16 +131,16 @@ class WordEmbedding(ZooKerasLayer):
 
 
 def prepare_embedding(embedding_file, word_index=None,
-                      randomize_unknown=True, normalize=True):
+                      randomize_unknown=False, normalize=False):
     """
     Prepare embedding weights from embedding_file given word_index.
 
     # Arguments
     embedding_file and word_index: See WordEmbedding.
     randomize_unknown: Boolean. Whether to randomly initialize words that don't exist in
-                       embedding_file. Default is True.
-                       If False, corresponding entries to unknown words will be zero vectors.
-    normalize: Boolean. Whether to normalize word vectors. Default is True.
+                       embedding_file. Default is False and in this case corresponding entries
+                       to unknown words will be zero vectors.
+    normalize: Boolean. Whether to normalize word vectors. Default is False.
 
     # Return
     Pretrained embedding weights as a numpy array.

--- a/pyzoo/zoo/pipeline/api/keras/layers/embeddings.py
+++ b/pyzoo/zoo/pipeline/api/keras/layers/embeddings.py
@@ -150,7 +150,7 @@ def prepare_embedding(embedding_file, word_index=None,
                          word_index,
                          randomize_unknown,
                          normalize).to_ndarray()
-    
+
 
 class SparseEmbedding(ZooKerasLayer):
     """

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextFeature.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextFeature.scala
@@ -25,8 +25,8 @@ import scala.reflect.ClassTag
 
 /**
  * Each TextFeature keeps information of a single text record.
- * It can include various status of a text,
- * e.g. original text content, category label, tokens, index representation
+ * It can include various status (if any) of a text,
+ * e.g. original text content, uri, category label, tokens, index representation
  * of tokens, BigDL Sample representation, prediction result and so on.
  * It uses a HashMap to store all these data.
  * Each key is a string that can be used to identify the corresponding value.

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/python/PythonZooModel.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/python/PythonZooModel.scala
@@ -37,7 +37,7 @@ import com.intel.analytics.zoo.models.recommendation.{NeuralCF, Recommender, Use
 import com.intel.analytics.zoo.models.recommendation._
 import com.intel.analytics.zoo.models.textclassification.TextClassifier
 import com.intel.analytics.zoo.models.textmatching.KNRM
-import com.intel.analytics.zoo.pipeline.api.keras.layers.Embedding
+import com.intel.analytics.zoo.pipeline.api.keras.layers.{Embedding, WordEmbedding}
 import org.apache.spark.api.java.JavaRDD
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.DataFrame
@@ -322,15 +322,27 @@ def zooModelSetEvaluateStatus(
       kernelNum: Int = 21,
       sigma: Double = 0.1,
       exactSigma: Double = 0.001,
+      targetMode: String = "ranking",
       model: AbstractModule[Activity, Activity, T]): KNRM[T] = {
     KNRM[T](text1Length, text2Length, vocabSize, embedSize, toTensor(embedWeights),
-      trainEmbed, kernelNum, sigma, exactSigma, model)
+      trainEmbed, kernelNum, sigma, exactSigma, targetMode, model)
   }
 
   def loadKNRM(
       path: String,
       weightPath: String = null): KNRM[T] = {
     KNRM.loadModel(path, weightPath)
+  }
+
+  def prepareEmbedding(
+      embeddingFile: String,
+      wordIndex: JMap[String, Int] = null,
+      randomizeUnknownWords: Boolean = false,
+      normalizeEmbedding: Boolean = false): JTensor = {
+    val (_, _, embedWeights) = WordEmbedding.prepareEmbedding[T](
+      embeddingFile, if (wordIndex!= null) wordIndex.asScala.toMap else null,
+      randomizeUnknownWords, normalizeEmbedding)
+    toJTensor(embedWeights)
   }
 
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/python/PythonZooModel.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/python/PythonZooModel.scala
@@ -337,11 +337,11 @@ def zooModelSetEvaluateStatus(
   def prepareEmbedding(
       embeddingFile: String,
       wordIndex: JMap[String, Int] = null,
-      randomizeUnknownWords: Boolean = false,
-      normalizeEmbedding: Boolean = false): JTensor = {
+      randomizeUnknown: Boolean = false,
+      normalize: Boolean = false): JTensor = {
     val (_, _, embedWeights) = WordEmbedding.prepareEmbedding[T](
       embeddingFile, if (wordIndex!= null) wordIndex.asScala.toMap else null,
-      randomizeUnknownWords, normalizeEmbedding)
+      randomizeUnknown, normalize)
     toJTensor(embedWeights)
   }
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/textmatching/KNRM.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/textmatching/KNRM.scala
@@ -149,10 +149,11 @@ object KNRM {
       kernelNum: Int,
       sigma: Double,
       exactSigma: Double,
+      targetMode: String,
       model: AbstractModule[Activity, Activity, T])
     (implicit ev: TensorNumeric[T]): KNRM[T] = {
     new KNRM[T](text1Length, text2Length, vocabSize, embedSize, embedWeights,
-      trainEmbed, kernelNum, sigma, exactSigma).addModel(model)
+      trainEmbed, kernelNum, sigma, exactSigma, targetMode).addModel(model)
   }
 
   /**

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/textmatching/KNRM.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/textmatching/KNRM.scala
@@ -129,7 +129,7 @@ object KNRM {
       exactSigma: Double = 0.001,
       targetMode: String = "ranking")(implicit ev: TensorNumeric[T]): KNRM[T] = {
     val (vocabSize, embedSize, embedWeights) = WordEmbedding.prepareEmbedding[T](
-      embeddingFile, wordIndex, randomizeUnknownWords = true, normalizeEmbedding = true)
+      embeddingFile, wordIndex, randomizeUnknown = true, normalize = true)
     new KNRM[T](text1Length, text2Length, vocabSize, embedSize, embedWeights,
       trainEmbed, kernelNum, sigma, exactSigma, targetMode).build()
   }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/textmatching/KNRM.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/textmatching/KNRM.scala
@@ -54,8 +54,8 @@ import scala.reflect.ClassTag
  *                   you are recommended to use RankHinge as loss for pairwise training.
  *                   For classification, the last layer will be sigmoid and the output will be the
  *                   probability between 0 and 1 indicating whether text1 is related to text2 and
- *                   you are recommended to use BCECriterion as loss for binary classification.
- *                   Default mode is 'ranking'.
+ *                   you are recommended to use 'binary_crossentropy' as loss for binary
+ *                   classification. Default mode is 'ranking'.
  */
 class KNRM[T: ClassTag] private(
     override val text1Length: Int,
@@ -102,6 +102,22 @@ class KNRM[T: ClassTag] private(
 }
 
 object KNRM {
+  /**
+   * The factory method to create a KNRM instance using embeddingFile and wordIndex.
+   *
+   * @param embeddingFile The path to the word embedding file.
+   *                      Currently only the following GloVe files are supported:
+   *                      "glove.6B.50d.txt", "glove.6B.100d.txt", "glove.6B.200d.txt",
+   *                      "glove.6B.300d.txt", "glove.42B.300d.txt", "glove.840B.300d.txt".
+   *                      You can download from: https://nlp.stanford.edu/projects/glove/.
+   * @param wordIndex Map of word (String) and its corresponding index (integer).
+   *                  The index is supposed to start from 1 with 0 reserved for unknown words.
+   *                  During the prediction, if you have words that are not in the wordIndex
+   *                  for the training, you can map them to index 0.
+   *                  Default is null. In this case, all the words in the embeddingFile will
+   *                  be taken into account and you can call
+   *                  WordEmbedding.getWordIndex(embeddingFile) to retrieve the map.
+   */
   def apply[@specialized(Float, Double) T: ClassTag](
       text1Length: Int,
       text2Length: Int,

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/utils/KerasUtils.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/utils/KerasUtils.scala
@@ -161,6 +161,7 @@ object KerasUtils {
       case "kullback_leibler_divergence" => KullbackLeiblerDivergence[T]()
       case "cosine_proximity" => CosineProximity[T]()
       case "poisson" => Poisson[T]()
+      case "rank_hinge" => RankHinge[T]()
       case _ => throw new IllegalArgumentException(s"Unsupported loss: $loss")
     }
   }


### PR DESCRIPTION
Keep consistent with Scala, use embedding_file and word_index to construct a KNRM model.
For QARanker Python side, will split into several PRs to finish.