### PR TITLE
add variable creator scope to disable use_resource

### DIFF
--- a/pyzoo/zoo/pipeline/api/net.py
+++ b/pyzoo/zoo/pipeline/api/net.py
@@ -441,7 +441,7 @@ For example:
 from zoo.util.tf import variable_creator_scope
 with variable_creator_scope():
     model = tf.keras.models.Sequential([
-    tf.keras.layers.Embedding(1, 1, input_length=1)])                
+    tf.keras.layers.Embedding(1, 1, input_length=1)])
                 """)
 
         data = self.dataset.rdd

--- a/pyzoo/zoo/pipeline/api/net.py
+++ b/pyzoo/zoo/pipeline/api/net.py
@@ -443,6 +443,8 @@ with variable_creator_scope():
     model = tf.keras.models.Sequential([
     tf.keras.layers.Embedding(1, 1, input_length=1)])
                 """)
+            else:
+                raise e
 
         data = self.dataset.rdd
         batch_size = self.dataset.batch_size

--- a/pyzoo/zoo/pipeline/api/net.py
+++ b/pyzoo/zoo/pipeline/api/net.py
@@ -22,6 +22,7 @@ import six
 import os
 import json
 import numpy as np
+from py4j.protocol import Py4JJavaError
 from pyspark import RDD
 
 from bigdl.nn.criterion import Criterion
@@ -428,8 +429,20 @@ class TFOptimizer:
                 assigns.append(a)
             assign = tf.group(*assigns)
         self.assign = assign
-
-        self.training_helper_layer = TFTrainingHelper(self.export_dir)
+        try:
+            self.training_helper_layer = TFTrainingHelper(self.export_dir)
+        except Py4JJavaError as e:
+            if "expects to be colocated with unknown node" in str(e):
+                raise Exception("""
+If you are using the embedding layer in tf.keras, then this is a
+known issue of tensorflow, see https://github.com/tensorflow/tensorflow/issues/21889.
+Please add zoo.util.tf.variable_creator_scope before model construction.
+For example:
+from zoo.util.tf import variable_creator_scope
+with variable_creator_scope():
+    model = tf.keras.models.Sequential([
+    tf.keras.layers.Embedding(1, 1, input_length=1)])                
+                """)
 
         data = self.dataset.rdd
         batch_size = self.dataset.batch_size
@@ -597,6 +610,7 @@ class TFOptimizer:
             end_trigger = MaxEpoch(1)
 
         self.optimizer.set_end_when(end_trigger)
+
         self.optimizer.optimize()
 
         variables = self.training_helper_layer.get_weights()

--- a/pyzoo/zoo/util/tf.py
+++ b/pyzoo/zoo/util/tf.py
@@ -19,11 +19,24 @@ from tensorflow.core.framework import graph_pb2
 from tensorflow.core.framework import node_def_pb2
 from tensorflow.python.framework import graph_util
 from tensorflow.python.framework import ops
+from tensorflow.python.ops import variable_scope
 from tensorflow.python.platform import gfile
+from tensorflow.python.util import tf_contextlib
 import tensorflow as tf
 import os
 import json
 import copy
+
+
+def _variable_creator(next_creator, **kwargs):
+    kwargs["use_resource"] = False
+    return next_creator(**kwargs)
+
+
+@tf_contextlib.contextmanager
+def variable_creator_scope():
+    with variable_scope.variable_creator_scope(_variable_creator):
+        yield
 
 
 def process_grad(grad):


### PR DESCRIPTION
after this pr, user can use our variable_creator_scope do workaround the ResourceVariable problem
```    
   from zoo.util.tf import variable_creator_scope
    with variable_creator_scope():
        model = MultiTaskIntentModel(use_cudnn=args.use_cudnn)
        model.build(dataset.word_len,
                    dataset.label_vocab_size,
                    dataset.intent_size,
                    dataset.word_vocab_size,
                    dataset.char_vocab_size,
                    word_emb_dims=args.token_emb_size,
                    tagger_lstm_dims=args.lstm_hidden_size,
                    dropout=args.tagger_dropout)
```
