### PR TITLE
seq2seq and InternalTimeDistributed bug fix

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/seq2seq/RNNDecoder.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/seq2seq/RNNDecoder.scala
@@ -99,7 +99,7 @@ class RNNDecoder[T: ClassTag](val rnns: Array[Recurrent[T]],
   override def updateGradInput(input: Activity, gradOutput: Tensor[T]): Activity = {
     labor.updateGradInput(input, gradOutput)
     val gradStates = rnns.map(_.getGradHiddenState())
-    val rnnsGradInput = input.toTable[Tensor[T]](1).zero()
+    val rnnsGradInput = Tensor[T](input.toTable[Tensor[T]](1).size())
 
     gradInput = T(rnnsGradInput, T.array(gradStates))
     gradInput

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/seq2seq/Seq2seq.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/seq2seq/Seq2seq.scala
@@ -92,7 +92,7 @@ model.asInstanceOf[KerasNet[T]].compile(optimizer, loss, metrics)
             buildOutput: KerasLayer[Tensor[T], Tensor[T], T] = null): Tensor[T] = {
     val sent1 = input
     val sent2 = startSign
-    sent2.resize(Array(1, 1) ++ startSign.size())
+    sent2.resize(Array(1) ++ startSign.size())
 
     var curInput = sent2
     val sizes = curInput.size()
@@ -101,7 +101,11 @@ model.asInstanceOf[KerasNet[T]].compile(optimizer, loss, metrics)
     var break = false
 
     if (!buildOutput.isBuilt()) {
-      buildOutput.build(generator.getOutputShape())
+      if (generator != null) {
+        buildOutput.build(generator.getOutputShape())
+      } else {
+        buildOutput.build(decoder.getOutputShape())
+      }
     }
     var j = 1
     // Iteratively output predicted words

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/seq2seq/Seq2seq.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/seq2seq/Seq2seq.scala
@@ -91,7 +91,8 @@ model.asInstanceOf[KerasNet[T]].compile(optimizer, loss, metrics)
             stopSign: Tensor[T] = null,
             buildOutput: KerasLayer[Tensor[T], Tensor[T], T] = null): Tensor[T] = {
     val sent1 = input
-    val sent2 = startSign
+    val sent2 = Tensor[T](startSign.size())
+    sent2.copy(startSign)
     sent2.resize(Array(1) ++ startSign.size())
 
     var curInput = sent2
@@ -100,7 +101,7 @@ model.asInstanceOf[KerasNet[T]].compile(optimizer, loss, metrics)
     concat.narrow(Seq2seq.timeDim, 1, 1).copy(sent2)
     var break = false
 
-    if (!buildOutput.isBuilt()) {
+    if (buildOutput != null && !buildOutput.isBuilt()) {
       if (generator != null) {
         buildOutput.build(generator.getOutputShape())
       } else {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/InternalTimeDistributed.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/InternalTimeDistributed.scala
@@ -96,13 +96,12 @@ private[zoo] class InternalTimeDistributed[T: ClassTag](
     val batch = _inputSize(0)
     val steps = _inputSize(1)
 
-    if (outputSize == null) {
-      val combinedShape = _output.size()
-      require(combinedShape(0) == batch * steps,
-        s"combined batch: ${combinedShape(0)} should match ${batch} * ${steps}")
-      val splitedShape = Array(batch, steps) ++ combinedShape.drop(1)
-      outputSize = splitedShape
-    }
+    val combinedShape = _output.size()
+    require(combinedShape(0) == batch * steps,
+      s"combined batch: ${combinedShape(0)} should match ${batch} * ${steps}")
+    val splitedShape = Array(batch, steps) ++ combinedShape.drop(1)
+    outputSize = splitedShape
+
     input.resize(_inputSize)
     output.set(_output).resize(outputSize)
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/python/PythonZooKeras.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/python/PythonZooKeras.scala
@@ -1229,14 +1229,14 @@ class PythonZooKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonZ
 
   def createZooKerasRNNEncoder(rnns: JList[Recurrent[T]],
     embedding: KerasLayer[Tensor[T], Tensor[T], T] = null,
-    inputShape: Shape = null): RNNEncoder[T] = {
-    RNNEncoder(rnns.asScala.toArray, embedding, inputShape)
+    inputShape: JList[Int] = null): RNNEncoder[T] = {
+    RNNEncoder(rnns.asScala.toArray, embedding, toScalaShape(inputShape))
   }
 
   def createZooKerasRNNDecoder(rnns: JList[Recurrent[T]],
     embedding: KerasLayer[Tensor[T], Tensor[T], T] = null,
-    inputShape: Shape = null): RNNDecoder[T] = {
-    RNNDecoder(rnns.asScala.toArray, embedding, inputShape)
+    inputShape: JList[Int] = null): RNNDecoder[T] = {
+    RNNDecoder(rnns.asScala.toArray, embedding, toScalaShape(inputShape))
   }
 
   def createZooKerasBridge(bridgeType: String, decoderHiddenSize: Int,

--- a/zoo/src/test/scala/com/intel/analytics/zoo/models/seq2seq/Seq2seqSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/models/seq2seq/Seq2seqSpec.scala
@@ -55,12 +55,14 @@ class Seq2seqSpec extends FlatSpec with Matchers with BeforeAndAfter {
     model2.forward(T(input, input2))
     model2.backward(T(input, input2), gradOutput)
 
-    val sent1 = Tensor(Array[Float](5.4f, 6.3f), Array(1, 2))
-    val sent2 = Tensor(Array[Float](1.3f), Array(1))
-    val layers = new KerasLayerWrapper[Float](Max[Float](2)
-      .asInstanceOf[AbstractModule[Activity, Activity, Float]])
-      .asInstanceOf[KerasLayer[Tensor[Float], Tensor[Float], Float]]
-    val result = model.infer(sent1, sent2, maxSeqLen = 30, buildOutput = layers).toTensor[Float]
+    val sent1 = Tensor(Array[Float](25f, 39f, 99f, 123f), Array(1, 2, 2))
+    val sent2 = Tensor(Array[Float](45f, 60f), Array(1, 2))
+    val encoder3 = RNNEncoder[Float]("lstm", numLayer, 2)
+    val decoder3 = RNNDecoder[Float]("lstm", numLayer, 2)
+    val model3 = Seq2seq[Float](encoder3, decoder3,
+      SingleShape(List(2, 2)), SingleShape(List(2, 2)))
+
+    val result = model3.infer(sent1, sent2, maxSeqLen = 3).toTensor[Float]
   }
 
   "Seq2seq model with customized rnn" should "be able to work" in {

--- a/zoo/src/test/scala/com/intel/analytics/zoo/models/seq2seq/Seq2seqSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/models/seq2seq/Seq2seqSpec.scala
@@ -16,15 +16,15 @@
 
 package com.intel.analytics.zoo.models.seq2seq
 
+import com.intel.analytics.bigdl.nn.Max
+import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
 import com.intel.analytics.bigdl.nn.keras.KerasLayer
 import com.intel.analytics.bigdl.tensor.Tensor
-import com.intel.analytics.bigdl.utils.{MultiShape, Shape, SingleShape, T}
+import com.intel.analytics.bigdl.utils.{MultiShape, SingleShape, T}
 import com.intel.analytics.zoo.pipeline.api.keras.layers._
 import com.intel.analytics.zoo.pipeline.api.keras.models.Sequential
 import com.intel.analytics.zoo.pipeline.api.keras.serializer.ModuleSerializationTest
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
-
-import scala.util.Random
 
 class Seq2seqSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
@@ -54,6 +54,13 @@ class Seq2seqSpec extends FlatSpec with Matchers with BeforeAndAfter {
       )
     model2.forward(T(input, input2))
     model2.backward(T(input, input2), gradOutput)
+
+    val sent1 = Tensor(Array[Float](5.4f, 6.3f), Array(1, 2))
+    val sent2 = Tensor(Array[Float](1.3f), Array(1))
+    val layers = new KerasLayerWrapper[Float](Max[Float](2)
+      .asInstanceOf[AbstractModule[Activity, Activity, Float]])
+      .asInstanceOf[KerasLayer[Tensor[Float], Tensor[Float], Float]]
+    val result = model.infer(sent1, sent2, maxSeqLen = 30, buildOutput = layers).toTensor[Float]
   }
 
   "Seq2seq model with customized rnn" should "be able to work" in {


### PR DESCRIPTION
This PR includes several seq2seq bug fix which included in https://github.com/intel-analytics/analytics-zoo/pull/1062/files. Just in case PR #1062 cannot be merged before 0.4 release.

1. RNNDecoder should not update input
2. seq2seq infer should take into account `generator` is null
3. InternalTimeDistributed should compute `outputsize` in each `forward`