### PR TITLE
[bug fix]fix feature set's random training in distrioptimizer

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/Train.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/Train.scala
@@ -57,7 +57,8 @@ object TrainInceptionV1 {
         param.batchSize,
         EngineRef.getNodeNumber(),
         EngineRef.getCoreNumber(),
-        param.classNumber
+        param.classNumber,
+        MemoryType.fromString(param.memoryType)
       )
 
       val model = if (param.modelSnapshot.isDefined) {


### PR DESCRIPTION
Fix #1083 

During the training in DistriOptimizer, DistriOptimizer will [call a zipPartition every iteration](https://github.com/intel-analytics/BigDL/blob/028b15505efdae03690016bf81309745577f75a2/spark/dl/src/main/scala/com/intel/analytics/bigdl/optim/DistriOptimizer.scala#L207), so the dataRdd will be recomputed every iteration.The DistributedFeatureSet will generate a new random number and create a new Iterator every iteration. The data fetch is actually random sampling, not a traverse.

