### PR TITLE
Persist memory support in TextSet

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/qaranker/README.md
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/qaranker/README.md
@@ -55,6 +55,8 @@ See [here](#options) for more configurable options for this example.
 * `-e` `--nbEpoch` The number of iterations to train the model. Default is 30.
 * `-l` `--learningRate` The learning rate for the model. Default is 0.001.
 * `-m` `--model` Specify this option only if you want to load an existing KNRM model and in this case its path should be provided.
+* `--memoryType` optional. The default value is `DRAM`, you can change it to `PMEM` if have Intel Optane DC Persistent Memory.
+
 
 
 ## Results

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/qaranker/README.md
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/qaranker/README.md
@@ -54,8 +54,8 @@ See [here](#options) for more configurable options for this example.
 * `-b` `--batchSize` The number of samples per gradient update. Default is 200.
 * `-e` `--nbEpoch` The number of iterations to train the model. Default is 30.
 * `-l` `--learningRate` The learning rate for the model. Default is 0.001.
+* `--memoryType` The default value is `DRAM`, you can change it to `PMEM` if have Intel Optane DC Persistent Memory.
 * `-m` `--model` Specify this option only if you want to load an existing KNRM model and in this case its path should be provided.
-* `--memoryType` optional. The default value is `DRAM`, you can change it to `PMEM` if have Intel Optane DC Persistent Memory.
 
 
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/qaranker/README.md
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/qaranker/README.md
@@ -54,7 +54,7 @@ See [here](#options) for more configurable options for this example.
 * `-b` `--batchSize` The number of samples per gradient update. Default is 200.
 * `-e` `--nbEpoch` The number of iterations to train the model. Default is 30.
 * `-l` `--learningRate` The learning rate for the model. Default is 0.001.
-* `--memoryType` The default value is `DRAM`, you can change it to `PMEM` if have Intel Optane DC Persistent Memory.
+* `--memoryType` Memory type used for caching training data. Default is `DRAM`. You can change it to `PMEM` if you have Intel Optane DC Persistent Memory.
 * `-m` `--model` Specify this option only if you want to load an existing KNRM model and in this case its path should be provided.
 
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
@@ -104,7 +104,7 @@ class DistributedFeatureSet[T: ClassTag]
   }
 
   override def unpersist(): Unit = {
-    println("--------unpersisting----------")
+    FeatureSet.logger.info("Releasing data in AEP")
     buffer.map(_.free()).count()
     buffer.unpersist()
     indexes.unpersist()

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
@@ -104,6 +104,8 @@ class DistributedFeatureSet[T: ClassTag]
   }
 
   override def unpersist(): Unit = {
+    println("--------unpersisting----------")
+    buffer.map(_.free()).count()
     buffer.unpersist()
     indexes.unpersist()
     isCached = false

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/common/ArrayLike.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/common/ArrayLike.scala
@@ -24,7 +24,7 @@ private[zoo] abstract class ArrayLike[T: ClassTag] extends Serializable {
 
   def apply(i: Int): T = throw new Error()
 
-  def free(): Unit = throw new Error()
+  def free(): Unit = {}
 }
 
 private[zoo] class ArrayLikeWrapper[T: ClassTag](array: Array[T]) extends ArrayLike[T] {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/common/ArrayLike.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/common/ArrayLike.scala
@@ -23,6 +23,8 @@ private[zoo] abstract class ArrayLike[T: ClassTag] extends Serializable {
   def length: Int = throw new Error()
 
   def apply(i: Int): T = throw new Error()
+
+  def free(): Unit = throw new Error()
 }
 
 private[zoo] class ArrayLikeWrapper[T: ClassTag](array: Array[T]) extends ArrayLike[T] {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/pmem/FeatureSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/pmem/FeatureSet.scala
@@ -16,12 +16,14 @@
 
 package com.intel.analytics.zoo.feature.pmem
 
-import com.intel.analytics.bigdl.dataset.ByteRecord
+import com.intel.analytics.bigdl.dataset.{ByteRecord, Sample}
+import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
 import com.intel.analytics.zoo.feature.DistributedFeatureSet
 import com.intel.analytics.zoo.feature.common.ArrayLike
 import org.apache.spark.rdd.RDD
 
 import scala.reflect.ClassTag
+import scala.reflect.classTag
 
 private[zoo] abstract class NativeArrayConverter[T: ClassTag]
   extends Serializable {
@@ -64,6 +66,54 @@ private[zoo] case class ByteRecordArray(records: VarLenBytesArray,
   override def apply(i: Int): ByteRecord = {
     ByteRecord(records.get(i), label(i.toInt))
   }
+  override def free(): Unit = {
+    records.free()
+  }
+}
+
+private[zoo] class SampleConverter(
+    memoryType: MemoryType = PMEM) extends NativeArrayConverter[Sample[Float]] {
+
+  override def getBytesPerRecord(sample: Sample[Float]): Long = {
+    sample.getData().length * 4
+  }
+
+  override def toArray(
+      recordIterator: Iterator[Sample[Float]],
+      countPerPartition: Iterator[(Int, Long)]): Iterator[ArrayLike[Sample[Float]]] = {
+    val count = countPerPartition.next()
+    val nativeArray = new VarLenFloatsArray(count._1, count._2,
+          memoryType = memoryType)
+
+    val featureSizes = new Array[Array[Array[Int]]](count._1)
+    val labelSizes = new Array[Array[Array[Int]]](count._1)
+    var i = 0
+    while(recordIterator.hasNext) {
+      val data = recordIterator.next()
+      nativeArray.set(i, data.getData())
+      featureSizes(i) = data.getFeatureSize()
+      labelSizes(i) = data.getLabelSize()
+      i += 1
+    }
+    Iterator.single(SampleArray(nativeArray, featureSizes, labelSizes))
+  }
+}
+
+private[zoo] case class SampleArray(
+    samples: VarLenFloatsArray,
+    featureSizes: Array[Array[Array[Int]]],
+    labelSizes: Array[Array[Array[Int]]]) extends ArrayLike[Sample[Float]] {
+  override def length: Int = {
+    samples.recordNum
+  }
+
+  override def apply(i: Int): Sample[Float] = {
+    Sample[Float](samples.get(i), featureSizes(i), labelSizes(i))
+  }
+
+  override def free(): Unit = {
+    samples.free()
+  }
 }
 
 object PmemFeatureSet {
@@ -96,6 +146,9 @@ object PmemFeatureSet {
       case t if t == classOf[ByteRecord] =>
         rdd[ByteRecord](data.asInstanceOf[RDD[ByteRecord]],
           new ByteRecordConverter(memoryType)).asInstanceOf[DistributedFeatureSet[T]]
+      case t if t == classOf[Sample[Float]] =>
+        rdd[Sample[Float]](data.asInstanceOf[RDD[Sample[Float]]],
+          new SampleConverter(memoryType)).asInstanceOf[DistributedFeatureSet[T]]
       case _ =>
         throw new IllegalArgumentException(
           s"${implicitly[ClassTag[T]].runtimeClass} is not supported for now")

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/pmem/FeatureSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/pmem/FeatureSet.scala
@@ -17,13 +17,11 @@
 package com.intel.analytics.zoo.feature.pmem
 
 import com.intel.analytics.bigdl.dataset.{ByteRecord, Sample}
-import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
 import com.intel.analytics.zoo.feature.DistributedFeatureSet
 import com.intel.analytics.zoo.feature.common.ArrayLike
 import org.apache.spark.rdd.RDD
 
 import scala.reflect.ClassTag
-import scala.reflect.classTag
 
 private[zoo] abstract class NativeArrayConverter[T: ClassTag]
   extends Serializable {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextSet.scala
@@ -572,7 +572,7 @@ class DistributedTextSet(var rdd: RDD[TextFeature],
   }
 
   override def randomSplit(weights: Array[Double]): Array[TextSet] = {
-    rdd.randomSplit(weights).map(v => TextSet.rdd(v))
+    rdd.randomSplit(weights).map(v => TextSet.rdd(v, this.memoryType))
   }
 
   override def generateWordIndexMap(

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextSet.scala
@@ -36,7 +36,7 @@ import java.io.PrintWriter
 
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.zoo.feature.FeatureSet
-import com.intel.analytics.zoo.feature.pmem.{DIRECT, DRAM, MemoryType, PMEM}
+import com.intel.analytics.zoo.feature.pmem.{DRAM, MemoryType}
 import org.apache.spark.sql.SQLContext
 
 /**

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextSet.scala
@@ -35,6 +35,8 @@ import scala.io.Source
 import java.io.PrintWriter
 
 import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.zoo.feature.FeatureSet
+import com.intel.analytics.zoo.feature.pmem.{DIRECT, DRAM, MemoryType, PMEM}
 import org.apache.spark.sql.SQLContext
 
 /**
@@ -224,8 +226,8 @@ object TextSet {
   /**
    * Create a DistributedTextSet from RDD of TextFeature.
    */
-  def rdd(data: RDD[TextFeature]): DistributedTextSet = {
-    new DistributedTextSet(data)
+  def rdd(data: RDD[TextFeature], memoryType: MemoryType = DRAM): DistributedTextSet = {
+    new DistributedTextSet(data, memoryType)
   }
 
   /**
@@ -363,7 +365,8 @@ object TextSet {
   def fromRelationPairs(
       relations: RDD[Relation],
       corpus1: TextSet,
-      corpus2: TextSet): DistributedTextSet = {
+      corpus2: TextSet,
+      memoryType: MemoryType = DRAM): DistributedTextSet = {
     val pairsRDD = Relations.generateRelationPairs(relations)
     require(corpus1.isDistributed, "corpus1 must be a DistributedTextSet")
     require(corpus2.isDistributed, "corpus2 must be a DistributedTextSet")
@@ -391,7 +394,7 @@ object TextSet {
       textFeature(TextFeature.sample) = Sample(feature, label)
       textFeature
     })
-    TextSet.rdd(res)
+    TextSet.rdd(res, memoryType)
   }
 
   /**
@@ -543,7 +546,8 @@ class LocalTextSet(var array: Array[TextFeature]) extends TextSet {
 /**
  * DistributedTextSet is comprised of RDD of TextFeature.
  */
-class DistributedTextSet(var rdd: RDD[TextFeature]) extends TextSet {
+class DistributedTextSet(var rdd: RDD[TextFeature],
+                         memoryType: MemoryType = DRAM) extends TextSet {
 
   override def transform(transformer: Preprocessing[TextFeature, TextFeature]): TextSet = {
     rdd = transformer(rdd)
@@ -563,11 +567,12 @@ class DistributedTextSet(var rdd: RDD[TextFeature]) extends TextSet {
   }
 
   override def toDataSet: DataSet[Sample[Float]] = {
-    DataSet.rdd(rdd.map(_[Sample[Float]](TextFeature.sample)))
+    FeatureSet.rdd(rdd.map(_[Sample[Float]](TextFeature.sample)),
+      memoryType)
   }
 
   override def randomSplit(weights: Array[Double]): Array[TextSet] = {
-    rdd.randomSplit(weights).map(TextSet.rdd)
+    rdd.randomSplit(weights).map(v => TextSet.rdd(v))
   }
 
   override def generateWordIndexMap(

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
@@ -28,7 +28,6 @@ import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils._
 import com.intel.analytics.bigdl.utils.serializer.{DeserializeContext, ModuleData, ModuleSerializer, SerializeContext}
 import com.intel.analytics.bigdl.visualization.{TrainSummary, ValidationSummary}
-import com.intel.analytics.zoo.feature.DistributedFeatureSet
 import com.intel.analytics.zoo.feature.image.ImageSet
 import com.intel.analytics.zoo.feature.text._
 import com.intel.analytics.zoo.pipeline.api.{Net, Predictable}
@@ -377,7 +376,9 @@ abstract class KerasNet[T](implicit val tag: ClassTag[T], implicit val ev: Tenso
     val dataset = x.toDataSet
     this.fit((dataset -> SampleToMiniBatch[Float](batchSize)).asInstanceOf[DataSet[MiniBatch[T]]],
       nbEpoch, toDataSet(validationData, batchSize))
-    dataset.toDistributed().unpersist()
+    if (x.isDistributed) {
+      dataset.toDistributed().unpersist()
+    }
   }
 
   def fit(

--- a/zoo/src/test/scala/com/intel/analytics/zoo/feature/pmem/PersistentMemorySpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/feature/pmem/PersistentMemorySpec.scala
@@ -28,7 +28,7 @@ import org.scalatest.Ignore
 
 import scala.collection.mutable.ArrayBuffer
 
-//@Ignore
+@Ignore
 class PersistentMemorySpec extends ZooSpecHelper {
   var sc: SparkContext = null
 

--- a/zoo/src/test/scala/com/intel/analytics/zoo/feature/pmem/PersistentMemorySpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/feature/pmem/PersistentMemorySpec.scala
@@ -16,17 +16,19 @@
 
 package com.intel.analytics.zoo.feature.pmem
 
-import com.intel.analytics.bigdl.dataset.{DistributedDataSet, MiniBatch}
+import com.intel.analytics.bigdl.dataset.{DistributedDataSet, MiniBatch, Sample}
+import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Engine
 import com.intel.analytics.zoo.common.NNContext
 import com.intel.analytics.zoo.examples.inception.ImageNet2012
+import com.intel.analytics.zoo.feature.FeatureSet
 import com.intel.analytics.zoo.pipeline.api.keras.ZooSpecHelper
 import org.apache.spark.SparkContext
 import org.scalatest.Ignore
 
 import scala.collection.mutable.ArrayBuffer
 
-@Ignore
+//@Ignore
 class PersistentMemorySpec extends ZooSpecHelper {
   var sc: SparkContext = null
 
@@ -125,5 +127,20 @@ class PersistentMemorySpec extends ZooSpecHelper {
     val data = imageNet.data(train = false)
     assert(data.count() == 3)
     data.collect()
+  }
+
+  "getting data in FeatureSet" should "be right" in {
+    val samples = sc.range(1, 10).map(v =>
+      Sample[Float](Tensor[Float].range(v, v + 5), v))
+    val featureSet = FeatureSet.rdd(samples, memoryType = PMEM)
+    featureSet.shuffle()
+    val dataIter = featureSet.data(false)
+    val data = dataIter.mapPartitions(v =>
+      v.map(s => (s.feature(), s.label().valueAt(1)))
+    ).collect()
+    data.map(_._2.toInt).sorted should be (Array.range(1, 10))
+    data.foreach(d =>
+      d._1 should be (Tensor[Float].range(d._2, d._2 + 5))
+    )
   }
 }


### PR DESCRIPTION
Persist memory support in TextSet
User could set memoryType to `PMEM` to cache train dataset to Persist Memory.