### PR TITLE
structured streaming example for image inference

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/nnframes/stucturedStreaming/ImagePathWriter.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/nnframes/stucturedStreaming/ImagePathWriter.scala
@@ -1,0 +1,43 @@
+package com.intel.analytics.zoo.examples.nnframes.stucturedStreaming
+
+import java.io.{File, PrintWriter}
+
+import org.apache.hadoop.fs.Path
+import org.apache.log4j.{Level, Logger}
+import scopt.OptionParser
+
+/**
+ * The java program periodically write a text file to streamingPath, which contains 2 image paths.
+ */
+object ImagePathWriter {
+
+  def main(args: Array[String]): Unit = {
+    Logger.getLogger("org").setLevel(Level.WARN)
+
+    parser.parse(args, PathWriterParam()).foreach { params =>
+      val lists = new File(params.imageSourcePath).listFiles().map(_.getAbsolutePath)
+      lists.grouped(2).zipWithIndex.foreach { case (batch, id) =>
+        val batchPath = new Path(params.streamingPath, id + ".txt").toString
+        val pw = new PrintWriter(batchPath)
+        batch.foreach(line => pw.println(line))
+        pw.close()
+        println("wrote " + batchPath)
+        Thread.sleep(5000)
+      }
+    }
+  }
+
+  private case class PathWriterParam(imageSourcePath: String = "",
+      streamingPath: String = "file:///tmp/zoo/streaming")
+
+  private val parser = new OptionParser[PathWriterParam]("PathWriterParam") {
+    head("PathWriterParam")
+    opt[String]("imageSourcePath")
+      .text("folder that contains the source images, local file system only")
+      .action((x, c) => c.copy(imageSourcePath = x))
+      .required()
+    opt[String]("streamingPath")
+      .text("folder that used to store the streaming paths, local file system only, i.e. file:///path")
+      .action((x, c) => c.copy(streamingPath = x))
+  }
+}

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/nnframes/stucturedStreaming/ImageStructuredStreamingExample.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/nnframes/stucturedStreaming/ImageStructuredStreamingExample.scala
@@ -1,0 +1,74 @@
+package com.intel.analytics.zoo.examples.nnframes.stucturedStreaming
+
+import com.intel.analytics.bigdl.models.utils.ModelBroadcast
+import com.intel.analytics.bigdl.nn.Module
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric.NumericFloat
+import com.intel.analytics.zoo.common.NNContext
+import com.intel.analytics.zoo.feature.image._
+import org.apache.log4j.{Level, Logger}
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions._
+import scopt.OptionParser
+
+
+object ImageStructuredStreamingExample {
+
+  def main(args: Array[String]): Unit = {
+
+    Logger.getLogger("org").setLevel(Level.WARN)
+    parser.parse(args, ImageStreamingInferenceParams()).foreach { params =>
+      val sc = NNContext.initNNContext("imageinfer")
+      val spark = SparkSession
+        .builder.config(sc.getConf)
+        .getOrCreate()
+
+      val lines = spark.readStream
+        .format("text")
+        .option("path", params.streamingPath)
+        .load()
+
+      val transformer = ImageResize(256, 256) -> ImageCenterCrop(224, 224) ->
+        ImageChannelNormalize(123, 117, 104) -> ImageMatToTensor() -> ImageSetToSample()
+      val model = Module.loadModule[Float](params.model)
+      val featureTransformersBC = sc.broadcast(transformer)
+      val modelBroadCast = ModelBroadcast[Float]().broadcast(sc, model.evaluate())
+
+      val readImageUDF = udf ( (path: String) => {
+        val featureSteps = featureTransformersBC.value.cloneTransformer()
+        val localModel = modelBroadCast.value()
+        val localImageSet = ImageSet.read(path, imageCodec = 1).transform(transformer)
+        val prediction = localModel.predictImage(localImageSet.toImageFrame())
+          .toLocal().array.map(_.predict()).head.asInstanceOf[Tensor[Float]].toArray()
+        prediction.zipWithIndex.maxBy(_._1)._2
+      })
+
+      val imageDF = lines.withColumn("output", readImageUDF(col("value")))
+      val query = imageDF.writeStream
+        .outputMode("update")
+        .format("console")
+        .option("truncate", false)
+        .start()
+
+      query.awaitTermination()
+    }
+
+  }
+
+  private case class ImageStreamingInferenceParams(streamingPath: String = "",
+                                             model: String = "")
+
+  private val parser = new OptionParser[ImageStreamingInferenceParams]("ImageStreamingInference") {
+    head("Image Inference for Structured Streaming")
+    opt[String]("model")
+      .text("path to the model file")
+      .action((x, c) => c.copy(model = x))
+      .required()
+    opt[String]("streamingPath")
+      .text("folder that used to store the streaming paths, local file system only, i.e. file:///path")
+      .action((x, c) => c.copy(streamingPath = x))
+      .required()
+  }
+
+}
+

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/nnframes/stucturedStreaming/README.md
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/nnframes/stucturedStreaming/README.md
@@ -1,0 +1,95 @@
+## Overview
+This is a Scala example for image inference with Spark Structured Streaming.
+
+Analytics Zoo provides the DataFrame-based API for image reading, preprocessing, model training
+and inference. The related classes followed the typical estimator/transformer pattern of Spark
+ML and can be used in a standard Spark ML pipeline.
+
+This example contains two programs:
+1. ImagePathWriter is used as the producer, it will write the image path to a specific folder
+ every a few seconds to simulate the streaming input.
+2. ImageStructedStreaming will load the pretrained model and run inference in Spark Structured
+ Streaming.
+
+## Download Analytics Zoo
+You can download Analytics Zoo prebuilt release and nightly build package from [here](https://analytics-zoo.github.io/master/#release-download/) and extract it.
+
+## Run the example
+
+1. Prepare pre-trained model and defenition file.
+You can download the pre-trained model from
+[Analytics Zoo](https://analytics-zoo.github.io/0.4.0/#ProgrammingGuide/image-classification/).
+Models like Inception or ResNet can work with the preprocessing steps defined in ImageStructedStreaming.
+
+2. Prepare dataset
+You can use your own image data (JPG or PNG), or some images from imagenet-2012 validation
+dataset <http://image-net.org/download-images> to run the example. 
+
+3. Run this example
+
+Run the following command for Spark local mode, adjust the memory size according to your image:
+
+```bash
+export SPARK_HOME=the root directory of Spark
+export ANALYTICS_ZOO_HOME=the folder where you extract the downloaded Analytics Zoo zip package
+
+${ANALYTICS_ZOO_HOME}/bin/spark-shell-with-zoo.sh \
+    --master local[1] \
+    --driver-memory 5g \
+    --class com.intel.analytics.zoo.examples.nnframes.stucturedStreaming.ImageStructuredStreamingExample \
+    --streamingPath /home/yuhao/workspace/github/hhbyyh/Test/ZooExample/src/streaming/test/folder \
+    --model /home/yuhao/workspace/model/analytics-zoo_resnet-50_imagenet_0.1.0.model
+```
+
+Then run the following command to start the producer
+
+```bash
+export SPARK_HOME=the root directory of Spark
+export ANALYTICS_ZOO_HOME=the folder where you extract the downloaded Analytics Zoo zip package
+
+${ANALYTICS_ZOO_HOME}/bin/spark-shell-with-zoo.sh \
+    --master local[1] \
+    --driver-memory 1g \
+    --class com.intel.analytics.zoo.examples.nnframes.stucturedStreaming.ImagePathWriter \
+    --imageSourcePath /home/yuhao/workspace/data/imagenet/predict_m \
+    --streamingPath /home/yuhao/workspace/github/hhbyyh/Test/ZooExample/src/streaming/test/folder
+```
+ 
+
+From the inference, you should see something like this in the console:
+
+```
+...
+
+Batch: 3
+-------------------------------------------
++--------------------------------------------------------------------------+------+
+|value                                                                     |output|
++--------------------------------------------------------------------------+------+
+|/home/yuhao/workspace/data/imagenet/predict_m/ILSVRC2012_val_00000231.JPEG|125   |
+|/home/yuhao/workspace/data/imagenet/predict_m/ILSVRC2012_val_00000041.JPEG|431   |
++--------------------------------------------------------------------------+------+
+
+-------------------------------------------
+Batch: 4
+-------------------------------------------
++--------------------------------------------------------------------------+------+
+|value                                                                     |output|
++--------------------------------------------------------------------------+------+
+|/home/yuhao/workspace/data/imagenet/predict_m/ILSVRC2012_val_00000363.JPEG|133   |
+|/home/yuhao/workspace/data/imagenet/predict_m/ILSVRC2012_val_00000198.JPEG|16    |
++--------------------------------------------------------------------------+------+
+
+-------------------------------------------
+Batch: 5
+-------------------------------------------
++--------------------------------------------------------------------------+------+
+|value                                                                     |output|
++--------------------------------------------------------------------------+------+
+|/home/yuhao/workspace/data/imagenet/predict_m/ILSVRC2012_val_00000154.JPEG|115   |
+|/home/yuhao/workspace/data/imagenet/predict_m/ILSVRC2012_val_00000477.JPEG|584   |
++--------------------------------------------------------------------------+------+
+
+...
+
+```


### PR DESCRIPTION
scala one, python will be sent in a separate PR.

Right now, the example only works with local file system since ImageSet.read cannot read HDFS without SparkContext
