### PR TITLE
add zoo-core to default jar

### DIFF
--- a/zoo/pom.xml
+++ b/zoo/pom.xml
@@ -389,6 +389,7 @@
                             <artifactSet>
                                 <includes>
                                     <include>org.spark-project.spark:unused</include>
+                                    <include>com.intel.analytics.zoo:zoo-core-dist-all</include>
                                 </includes>
                             </artifactSet>
                         </configuration>


### PR DESCRIPTION
this pr is to add zoo-core artifact into default jar when do mvn package
have tested it, the jar will contain the classes and so files from zoo-core
and size changed from 4M to 18.4M

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-analytics/analytics-zoo/1140)
<!-- Reviewable:end -->
