### PR TITLE
update docker from ubuntu 14 to 18

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM ubuntu:14.04
+FROM ubuntu:18.04
 
 MAINTAINER The Analytics-Zoo Authors https://github.com/intel-analytics/analytics-zoo
 
@@ -42,7 +42,7 @@ ENV JAVA_HOME                           /opt/jdk
 ENV PATH                                ${JAVA_HOME}/bin:${PATH}
 
 RUN apt-get update && \
-    apt-get install -y --force-yes vim curl nano wget unzip maven git
+    apt-get install -y apt-utils vim curl nano wget unzip maven git
 #java
 RUN wget https://build.funtoo.org/distfiles/oracle-java/jdk-8u152-linux-x64.tar.gz && \
     gunzip jdk-8u152-linux-x64.tar.gz && \
@@ -50,10 +50,8 @@ RUN wget https://build.funtoo.org/distfiles/oracle-java/jdk-8u152-linux-x64.tar.
     rm jdk-8u152-linux-x64.tar && \
     ln -s /opt/jdk1.8.0_152 /opt/jdk
 #python
-RUN apt-get install -y --force-yes software-properties-common python-software-properties python-pkg-resources && \
-    add-apt-repository -y ppa:jonathonf/python-2.7 && \
-    apt-get update && \
-    apt-get install -y --force-yes build-essential python python-setuptools python-dev && \
+RUN apt-get install -y python-minimal && \
+    apt-get install -y build-essential python python-setuptools python-dev && \
     wget https://bootstrap.pypa.io/get-pip.py && \
     python2 get-pip.py && \
     pip2 install --upgrade setuptools && \


### PR DESCRIPTION
this pr is to update docker parent image from ubuntu 14.04 to 18.04
the reason is the latest pandas(0.24.1) requires gcc 4.9+, ubuntu 14's gcc is 4.8
so update to ubuntu 18.04

has built and tested the apps running in the generated container.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-analytics/analytics-zoo/1144)
<!-- Reviewable:end -->
