### PR TITLE
[WIP] Support tf.keras.metrics

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TFNet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TFNet.scala
@@ -28,7 +28,7 @@ import com.intel.analytics.zoo.pipeline.api.{Predictable, Predictor}
 import com.intel.analytics.zoo.pipeline.api.net.TFNet.TFGraphHolder
 import org.apache.spark.rdd.RDD
 import org.tensorflow.framework.GraphDef
-import org.tensorflow.types.{TFBool, UInt8}
+import org.tensorflow.types.UInt8
 import org.tensorflow.{DataType, Graph, Session, Tensor => TTensor}
 
 import scala.collection.JavaConverters._

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TFTrainingHelper.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TFTrainingHelper.scala
@@ -285,6 +285,7 @@ class TFOptimizer(modelPath: String,
 }
 
 
+// todo make it serializable
 class TFStatefulValidationMethod(val metricName: String,
                                  @ transient var graph: ClosableGraph,
                                  val outputNames: Array[String],
@@ -341,6 +342,7 @@ class TFStatefulValidationMethod(val metricName: String,
 
 }
 
+// todo make it serializable
 class TFStatefulValidationResult(@transient var graph: ClosableGraph,
                                  val outputNames: Array[String],
                                  val targetNames: Array[String],


### PR DESCRIPTION
This PR attempts to support tf.keras.metrics and custom designed metrics.
 
In tf.keras, there are two kinds of metrics, namely **stateful metrics** and **non-stateful metrics** (the official keras seems only support this).

1. A **non-stateful metrics** is basically a function (variable free tf graph) that maps two tensor to a single scalar and the final metric across all batches is simply averaged. 

    In this case, we can simple fetch the final metric tensor and average them.

2. A **stateful metrics** is an object (tf graph contains variable) that can keep updating this state (variables) using  two tensor inputs and get the final metrics using the variables after iterating all the batches. 

    In this case, we can first compute all the predictions and labels (presumably not very large) and collect them to driver, then iterate through those to calculate the final metric.