### PR TITLE
Google Dataproc support description in docs

### DIFF
--- a/docs/docs/ProgrammingGuide/run-on-dataproc.md
+++ b/docs/docs/ProgrammingGuide/run-on-dataproc.md
@@ -1,17 +1,6 @@
-
-<<<<<<< HEAD
 ## **Deploy Analytics Zoo with BigDL on Dataproc**
 
 Before using Analytics Zoo and BigDL on Google Dataproc, you need setup a project and create a cluster on Dataproc(you may refer to [https://cloud.google.com/sdk/docs/how-to](https://cloud.google.com/dataproc/docs/how-to) for more instructions). Now you can create a Cloud Dataproc cluster using the Google Cloud SDK's(https://cloud.google.com/sdk/docs/) gcloud command-line tool.
-
-To make it easy to try out Analytics Zoo on Spark on Dataproc, an initial action script is provided.
-=======
-## **Deploy Zoo with BigDL on Dataproc**
-
-Before using Zoo and BigDL on Google Dataproc, you need setup a project and create a cluster on Dataproc(you may refer to [https://cloud.google.com/sdk/docs/how-to](https://cloud.google.com/dataproc/docs/how-to) for more instructions). Now you can create a Cloud Dataproc cluster using the Google Cloud SDK's(https://cloud.google.com/sdk/docs/) gcloud command-line tool.
-
-To make it easy to try out BigDL on Spark on Dataproc, an initial action script is provided.
->>>>>>> cf4a7617285dac1c53090c83d27dc9ee1d539a73
 
 Note:
  The actual version of the initialization script with Zoo support is still under review here: [https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/pull/469]).

--- a/docs/docs/ProgrammingGuide/run-on-dataproc.md
+++ b/docs/docs/ProgrammingGuide/run-on-dataproc.md
@@ -1,0 +1,42 @@
+
+## **Deploy Analytics Zoo with BigDL on Dataproc**
+
+Before using Analytics Zoo and BigDL on Google Dataproc, you need setup a project and create a cluster on Dataproc(you may refer to [https://cloud.google.com/sdk/docs/how-to](https://cloud.google.com/dataproc/docs/how-to) for more instructions). Now you can create a Cloud Dataproc cluster using the Google Cloud SDK's(https://cloud.google.com/sdk/docs/) gcloud command-line tool.
+
+To make it easy to try out Analytics Zoo on Spark on Dataproc, an initial action script is provided.
+
+Note:
+ The actual version of the initialization script with Zoo support is still under review here: [https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/pull/469]).
+ So at the time of writing you should download and place the updated version of this script somewhere accessible for you 
+ (into your own Google Storage bucket, for example) and set appropriate location for `--initialization-actions`. 
+  
+You can use use this initialization action to create a new Dataproc cluster with Zoo and BigDL pre-installed in it.
+
+By default, it will automatically download only BigDL 0.7.2 for Dataproc 1.3 (Spark 2.3 and Scala 2.11.8).
+So you must specify to download Zoo (which includes BigDL) with: `bigdl-download-url` property in metadata:
+
+```bash
+gcloud dataproc clusters create <CLUSTER_NAME> \
+    --image-version 1.0 \
+    --initialization-actions gs://dataproc-initialization-actions/bigdl/bigdl.sh \
+    --initialization-action-timeout 10m \
+    --metadata 'bigdl-download-url=https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.7.2-spark_2.3.1/0.4.0/analytics-zoo-bigdl_0.7.2-spark_2.3.1-0.4.0-dist-all.zip'
+```
+
+To download a different version of Zoo or one targeted to a different version of Spark/Scala, find the download URL from the BigDL releases page, and set the metadata key "bigdl-download-url" 
+or here [https://repo1.maven.org/maven2/com/intel/analytics/zoo/].
+
+More information please refer https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/tree/master/bigdl
+
+Once the cluster is provisioned, you will be able to see the cluster running in the Google Cloud Platform Console. Now you can SSH to the master node.
+
+Cloud Dataproc support various way to SSH to the master, here we use SSH from Google Cloud SDK.
+E.g.,
+```bash
+gcloud compute --project <PROJECT_ID> ssh --zone <ZONE> <CLUSTER_NAME>
+```
+Google cloud SDK will perform the authentication for you and open an SSH client (Eg Putty).
+
+You should be able to find BigDL is located under /opt/intel-bigdl. And your VM is ready for running deep learning examples at scale!
+
+Now you can run jobs with Zoo on Google Dataproc as usual with `gcloud dataproc jobs submit spark`.

--- a/docs/docs/ProgrammingGuide/run-on-dataproc.md
+++ b/docs/docs/ProgrammingGuide/run-on-dataproc.md
@@ -1,27 +1,37 @@
 ## **Deploy Analytics Zoo with BigDL on Dataproc**
 
-Before using Analytics Zoo and BigDL on Google Dataproc, you need setup a project and create a cluster on Dataproc(you may refer to [https://cloud.google.com/sdk/docs/how-to](https://cloud.google.com/dataproc/docs/how-to) for more instructions). Now you can create a Cloud Dataproc cluster using the Google Cloud SDK's(https://cloud.google.com/sdk/docs/) gcloud command-line tool.
+Before using Analytics Zoo and BigDL on Google Dataproc, you need setup a project and create a cluster on Dataproc 
+(you may refer to [https://cloud.google.com/sdk/docs/how-to](https://cloud.google.com/dataproc/docs/how-to) 
+for more instructions). 
+Now you can create a Cloud Dataproc cluster using the Google Cloud SDK's (https://cloud.google.com/sdk/docs/) 
+`gcloud` command-line tool.
 
 Note:
  The actual version of the initialization script with Zoo support is still under review here: [https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/pull/469]).
  So at the time of writing you should download and place the updated version of this script somewhere accessible for you 
- (into your own Google Storage bucket, for example) and set appropriate location for `--initialization-actions`. 
+ (into your own Google Storage bucket, for example) and set appropriate location for `--initialization-actions`.
+ 
   
-You can use use this initialization action to create a new Dataproc cluster with Zoo and BigDL pre-installed in it.
+You can use use this initialization action to create a new Dataproc cluster with Analytics Zoo and BigDL pre-installed 
+in it.
 
 By default, it will automatically download only BigDL 0.7.2 for Dataproc 1.3 (Spark 2.3 and Scala 2.11.8).
-So you must specify to download Zoo (which includes BigDL) with: `bigdl-download-url` property in metadata:
+So you must specify to download Analytics Zoo instead (which includes BigDL) with: `bigdl-download-url` 
+property in metadata:
 
 ```bash
 gcloud dataproc clusters create <CLUSTER_NAME> \
-    --image-version 1.0 \
+    --image-version 1.3 \
     --initialization-actions gs://dataproc-initialization-actions/bigdl/bigdl.sh \
     --initialization-action-timeout 10m \
     --metadata 'bigdl-download-url=https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.7.2-spark_2.3.1/0.4.0/analytics-zoo-bigdl_0.7.2-spark_2.3.1-0.4.0-dist-all.zip'
 ```
 
-To download a different version of Zoo or one targeted to a different version of Spark/Scala, find the download URL from the BigDL releases page, and set the metadata key "bigdl-download-url" 
-or here [https://repo1.maven.org/maven2/com/intel/analytics/zoo/].
+To download a different version of Zoo or one targeted to a different version of Spark/Scala, 
+find the download URL from the [Analytics Zoo releases page](https://analytics-zoo.github.io/0.4.0/#release-download/) 
+or [maven repository](https://repo1.maven.org/maven2/com/intel/analytics/zoo/), 
+and set the metadata key "bigdl-download-url" 
+.
 
 More information please refer https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/tree/master/bigdl
 
@@ -34,6 +44,6 @@ gcloud compute --project <PROJECT_ID> ssh --zone <ZONE> <CLUSTER_NAME>
 ```
 Google cloud SDK will perform the authentication for you and open an SSH client (Eg Putty).
 
-You should be able to find BigDL is located under /opt/intel-bigdl. And your VM is ready for running deep learning examples at scale!
-
-Now you can run jobs with Zoo on Google Dataproc as usual with `gcloud dataproc jobs submit spark`.
+You should be able to find Analytics Zoo and BigDL located under /opt/intel-bigdl. 
+Now you can run jobs with Zoo and BigDL on Google Dataproc 
+as usual with `gcloud dataproc jobs submit spark`.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -44,6 +44,7 @@ pages:
     - Text Matching API: ProgrammingGuide/text-matching.md
     - Sequence to Sequence API: ProgrammingGuide/seq2seq.md
   - Reference Use Cases: ProgrammingGuide/usercases-overview.md
+  - Run on Google Cloud Dataproc: ProgrammingGuide/run-on-dataproc.md
 - White Paper:
   - BigDL: wp-bigdl.md
 - API Guide:

--- a/zoo/pom.xml
+++ b/zoo/pom.xml
@@ -261,7 +261,7 @@
         <dependency>
             <groupId>com.intel.analytics.zoo</groupId>
             <artifactId>zoo-core-dist-all</artifactId>
-            <version>0.5.0-SNAPSHOT</version>
+            <version>0.4.0</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This PR adds some important details to deploy jobs with Zoo on Google Dataproc. It is mostly based on the description from current BigDL docs.

The details here:
https://groups.google.com/forum/#!topic/bigdl-user-group/6hD1pz18968
And here:
https://github.com/GoogleCloudPlatform/dataproc-initialization-actions/pull/469
