### PR TITLE
Add CategoricalAccuracy, BinaryAccuracy, and SparseCategoricalAccuracy

### DIFF
--- a/pyzoo/zoo/models/anomalydetection/anomaly_detector.py
+++ b/pyzoo/zoo/models/anomalydetection/anomaly_detector.py
@@ -97,7 +97,7 @@ class AnomalyDetector(ZooModel):
         if isinstance(loss, six.string_types):
             loss = to_bigdl_criterion(loss)
         if metrics and all(isinstance(metric, six.string_types) for metric in metrics):
-            metrics = to_bigdl_metrics(metrics)
+            metrics = to_bigdl_metrics(metrics, loss)
         callBigDlFunc(self.bigdl_type, "anomalyDetectorCompile",
                       self.value,
                       optimizer,

--- a/pyzoo/zoo/models/seq2seq/seq2seq.py
+++ b/pyzoo/zoo/models/seq2seq/seq2seq.py
@@ -246,7 +246,7 @@ class Seq2seq(ZooModel):
         if isinstance(loss, six.string_types):
             loss = to_bigdl_criterion(loss)
         if metrics and all(isinstance(metric, six.string_types) for metric in metrics):
-            metrics = to_bigdl_metrics(metrics)
+            metrics = to_bigdl_metrics(metrics, loss)
         callBigDlFunc(self.bigdl_type, "seq2seqCompile",
                       self.value,
                       optimizer,

--- a/pyzoo/zoo/models/textclassification/text_classifier.py
+++ b/pyzoo/zoo/models/textclassification/text_classifier.py
@@ -121,7 +121,7 @@ class TextClassifier(ZooModel):
         if isinstance(loss, six.string_types):
             loss = to_bigdl_criterion(loss)
         if metrics and all(isinstance(metric, six.string_types) for metric in metrics):
-            metrics = to_bigdl_metrics(metrics)
+            metrics = to_bigdl_metrics(metrics, loss)
         callBigDlFunc(self.bigdl_type, "textClassifierCompile",
                       self.value,
                       optimizer,

--- a/pyzoo/zoo/pipeline/api/keras/engine/topology.py
+++ b/pyzoo/zoo/pipeline/api/keras/engine/topology.py
@@ -49,7 +49,7 @@ class KerasNet(ZooKerasLayer):
             from zoo.pipeline.api.autograd import CustomLoss
             loss = CustomLoss(loss, self.get_output_shape()[1:])
         if metrics and all(isinstance(metric, six.string_types) for metric in metrics):
-            metrics = to_bigdl_metrics(metrics)
+            metrics = to_bigdl_metrics(metrics, loss)
         callBigDlFunc(self.bigdl_type, "zooCompile",
                       self.value,
                       optimizer,

--- a/pyzoo/zoo/pipeline/api/keras/metrics.py
+++ b/pyzoo/zoo/pipeline/api/keras/metrics.py
@@ -56,6 +56,39 @@ class Accuracy(ZooKerasCreator, JavaValue):
                                        zero_based_label)
 
 
+class SparseCategoricalAccuracy(ZooKerasCreator, JavaValue):
+    """
+    Measures top1 accuracy for multi-class classification with sparse target.
+
+    >>> acc = SparseCategoricalAccuracy()
+    creating: createZooKerasSparseCategoricalAccuracy
+    """
+    def __init__(self, bigdl_type="float"):
+        super(SparseCategoricalAccuracy, self).__init__(None, bigdl_type)
+
+
+class CategoricalAccuracy(ZooKerasCreator, JavaValue):
+    """
+    Measures top1 accuracy for multi-class classification when target is one-hot encoded.
+
+    >>> acc = CategoricalAccuracy()
+    creating: createZooKerasCategoricalAccuracy
+    """
+    def __init__(self, bigdl_type="float"):
+        super(CategoricalAccuracy, self).__init__(None, bigdl_type)
+
+
+class BinaryAccuracy(ZooKerasCreator, JavaValue):
+    """
+    Measures top1 accuracy for binary classification with zero-based index.
+
+    >>> acc = BinaryAccuracy()
+    creating: createZooKerasBinaryAccuracy
+    """
+    def __init__(self, bigdl_type="float"):
+        super(BinaryAccuracy, self).__init__(None, bigdl_type)
+
+
 class Top5Accuracy(ZooKerasCreator, JavaValue):
     """
     Measures top5 accuracy for multi-class classification.

--- a/pyzoo/zoo/pipeline/api/keras/utils.py
+++ b/pyzoo/zoo/pipeline/api/keras/utils.py
@@ -69,10 +69,22 @@ def to_bigdl_criterion(criterion):
         raise TypeError("Unsupported loss: %s" % criterion)
 
 
-def to_bigdl_metric(metric):
+def to_bigdl_metric(metric, loss):
     metric = metric.lower()
+    loss_str = (loss if isinstance(loss, six.string_types) else loss.__class__.__name__).lower()
     if metric == "accuracy" or metric == "acc":
-        return metrics.Accuracy()
+        if loss_str == "sparse_categorical_crossentropy"\
+                or loss_str == "sparsecategoricalcrossentropy":
+            return metrics.SparseCategoricalAccuracy()
+        elif loss_str == "categorical_crossentropy"\
+                or loss_str == "categoricalcrossentropy":
+            return metrics.CategoricalAccuracy()
+        elif loss_str == "binary_crossentropy"\
+                or loss_str == "binarycrossentropy":
+            return metrics.BinaryAccuracy()
+        else:
+            raise TypeError(
+                "Not supported combination: metric {} and loss {}".format(metric, loss_str))
     elif metric == "top5accuracy" or metric == "top5acc":
         return metrics.Top5Accuracy()
     elif metric == "mae":
@@ -88,5 +100,5 @@ def to_bigdl_metric(metric):
         raise TypeError("Unsupported metric: %s" % metric)
 
 
-def to_bigdl_metrics(metrics):
-    return [to_bigdl_metric(m) for m in metrics]
+def to_bigdl_metrics(metrics, loss):
+    return [to_bigdl_metric(m, loss) for m in metrics]

--- a/pyzoo/zoo/pipeline/api/net.py
+++ b/pyzoo/zoo/pipeline/api/net.py
@@ -568,7 +568,7 @@ with variable_creator_scope():
             if dataset.val_rdd is None and val_spilt == 0.0:
                 raise ValueError("Validation data is not specified. Please set " +
                                  "val rdd in TFDataset, or set val_split larger than zero")
-            bigdl_val_methods = [to_bigdl_metric(m) for m in keras_model.metrics_names]
+            bigdl_val_methods = [to_bigdl_metric(m, keras_model.loss) for m in keras_model.metrics_names]
             val_outputs = keras_model.outputs
             val_labels = keras_model.targets
         else:

--- a/pyzoo/zoo/pipeline/api/net.py
+++ b/pyzoo/zoo/pipeline/api/net.py
@@ -568,7 +568,8 @@ with variable_creator_scope():
             if dataset.val_rdd is None and val_spilt == 0.0:
                 raise ValueError("Validation data is not specified. Please set " +
                                  "val rdd in TFDataset, or set val_split larger than zero")
-            bigdl_val_methods = [to_bigdl_metric(m, keras_model.loss) for m in keras_model.metrics_names]
+            bigdl_val_methods =\
+                [to_bigdl_metric(m, keras_model.loss) for m in keras_model.metrics_names]
             val_outputs = keras_model.outputs
             val_labels = keras_model.targets
         else:

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
@@ -127,7 +127,7 @@ abstract class KerasNet[T](implicit val tag: ClassTag[T], implicit val ev: Tenso
       metrics: List[String])(implicit ev: TensorNumeric[T]): Unit = {
     this.compile(KerasUtils.toBigDLOptimMethod[T](optimizer),
       KerasUtils.toBigDLCriterion[T](loss),
-      KerasUtils.toBigDLMetrics[T](metrics))
+      KerasUtils.toBigDLMetrics[T](metrics, loss))
   }
 
   def compile(

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/python/PythonZooKeras.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/python/PythonZooKeras.scala
@@ -16,7 +16,6 @@
 
 package com.intel.analytics.zoo.pipeline.api.keras.python
 
-import java.util
 import java.util.{List => JList, Map => JMap}
 
 import com.intel.analytics.bigdl.{Criterion, Module}
@@ -36,7 +35,6 @@ import com.intel.analytics.zoo.feature.image.ImageSet
 import com.intel.analytics.zoo.pipeline.api.autograd._
 import com.intel.analytics.zoo.pipeline.api.keras.layers.{KerasLayerWrapper, _}
 import com.intel.analytics.zoo.pipeline.api.keras.layers.utils.KerasUtils
-import com.intel.analytics.zoo.pipeline.api.keras.metrics.{AUC, Accuracy, Top5Accuracy}
 import com.intel.analytics.zoo.pipeline.api.keras.models.{KerasNet, Model, Sequential}
 import com.intel.analytics.zoo.pipeline.api.keras.objectives._
 import com.intel.analytics.zoo.pipeline.api.keras.optimizers.Adam
@@ -45,6 +43,7 @@ import com.intel.analytics.zoo.common.PythonZoo
 import com.intel.analytics.zoo.feature.text.TextSet
 import com.intel.analytics.zoo.models.common.ZooModel
 import com.intel.analytics.zoo.models.seq2seq.{Bridge, RNNDecoder, RNNEncoder}
+import com.intel.analytics.zoo.pipeline.api.keras.{metrics => zmetrics}
 import com.intel.analytics.zoo.pipeline.api.net.GraphNet
 
 import scala.collection.mutable.ArrayBuffer
@@ -988,7 +987,7 @@ class PythonZooKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonZ
   }
 
   def createAUC(thresholdNum: Int): ValidationMethod[T] = {
-    new AUC[T](thresholdNum)
+    new zmetrics.AUC[T](thresholdNum)
   }
 
   def createZooKerasAdam(
@@ -1199,12 +1198,24 @@ class PythonZooKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonZ
 
   def createZooKerasAccuracy(
       zeroBasedLabel: Boolean = true): ValidationMethod[T] = {
-    new Accuracy(zeroBasedLabel)
+    new zmetrics.Accuracy(zeroBasedLabel)
+  }
+
+  def createZooKerasSparseCategoricalAccuracy(): ValidationMethod[T] = {
+    new zmetrics.SparseCategoricalAccuracy()
+  }
+
+  def createZooKerasBinaryAccuracy(): ValidationMethod[T] = {
+    new zmetrics.BinaryAccuracy()
+  }
+
+  def createZooKerasCategoricalAccuracy(): ValidationMethod[T] = {
+    new zmetrics.CategoricalAccuracy()
   }
 
   def createZooKerasTop5Accuracy(
       zeroBasedLabel: Boolean = true): ValidationMethod[T] = {
-    new Top5Accuracy(zeroBasedLabel)
+    new zmetrics.Top5Accuracy(zeroBasedLabel)
   }
 
   def createZooKerasWordEmbedding(

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/metrics/AccuracySpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/metrics/AccuracySpec.scala
@@ -22,6 +22,52 @@ import org.scalatest.{FlatSpec, Matchers}
 
 class AccuracySpec extends FlatSpec with Matchers {
 
+  "top1 accuracy for categoricalAccuracy" should "be correct on 2d tensor" in {
+    val output = Tensor[Double](Storage(Array[Double](
+      0, 0, 0, 1,
+      0, 1, 0, 0,
+      1, 0, 0, 0
+    )), 1, Array(3, 4))
+
+    val target = Tensor[Double](Storage(Array[Double](
+      0, 0, 0, 1,
+      0, 0, 1, 0,
+      1, 0, 0, 0
+    )), 1, Array(3, 4))
+    val validation = new CategoricalAccuracy[Double]()
+    val result = validation(output, target)
+    val test = new AccuracyResult(2, 3)
+    result should be(test)
+  }
+
+  "accuracy for binaryAccuracy" should "be correct" in {
+    val output = Tensor(Storage(Array[Double](0.3)), 1, Array(1))
+    val target = Tensor(Storage(Array[Double](0)))
+    val validation = new BinaryAccuracy[Double]()
+    val result = validation(output, target)
+    val test = new AccuracyResult(1, 1)
+    result should be(test)
+  }
+
+  "accuracy for SparseCategoricalAccuracy" should "be correct" in {
+    val output = Tensor(Storage(Array[Double](
+      0, 0, 0, 1,
+      0, 1, 0, 0,
+      1, 0, 0, 0
+    )), 1, Array(3, 4))
+
+    val target = Tensor(Storage(Array[Double](
+      3,
+      1,
+      2
+    )))
+
+    val validation = new Accuracy[Double]()
+    val result = validation(output, target)
+    val test = new AccuracyResult(2, 3)
+    result should be(test)
+  }
+
   "top1 accuracy using 0-based label" should "be correct on 2d tensor" in {
     val output = Tensor(Storage(Array[Double](
       0, 0, 0, 1,


### PR DESCRIPTION
In order to consistent with the loss function, this patch would introduce CategoricalAccuracy, BinaryAccuracy, and SparseCategoricalAccuracy and deprecate the `Accuracy` class.