### PR TITLE
Update pip release script

### DIFF
--- a/pyzoo/dev/release/release.sh
+++ b/pyzoo/dev/release/release.sh
@@ -24,45 +24,40 @@ echo $ANALYTICS_ZOO_HOME
 ANALYTICS_ZOO_PYTHON_DIR="$(cd ${RUN_SCRIPT_DIR}/../../../pyzoo; pwd)"
 echo $ANALYTICS_ZOO_PYTHON_DIR
 
-if (( $# < 2)); then
-  echo "Bad parameters. Usage example: bash release.sh linux without_bigdl false 0.1.0.dev2"
+if (( $# < 1)); then
+  echo "Bad parameters. Usage example: bash release.sh linux"
+  echo "If needed, you can also add other profiles such as: -Dspark.version=2.3.2 -Dbigdl.artifactId=bigdl-SPARK_2.3 -P spark_2.x"
   exit -1
 fi
 
 platform=$1
-spark_profile=$2
-quick=$3
+profiles=${*:2}
 version=`cat $ANALYTICS_ZOO_PYTHON_DIR/zoo/__init__.py | grep "__version__" | awk '{print $NF}' | tr -d '"'`
 
 
 cd ${ANALYTICS_ZOO_HOME}
 if [ "$platform" ==  "mac" ]; then
     echo "Building Analytics Zoo for mac system"
-    dist_profile="-P mac -P $spark_profile"
+    dist_profile="-P mac -P without_bigdl $profiles"
     verbose_pname="macosx_10_11_x86_64"
 elif [ "$platform" == "linux" ]; then
     echo "Building Analytics Zoo for linux system"
-    dist_profile="-P $spark_profile"
+    dist_profile="-P without_bigdl $profiles"
     verbose_pname="manylinux1_x86_64"
 else
-    echo "unsupport platform"
+    echo "Unsupported platform. Only linux and mac are supported for now."
 fi
 
-analytics_zoo_build_command="${ANALYTICS_ZOO_HOME}/make-dist.sh ${dist_profile}"
-if [ "$quick" == "true" ]; then
-    echo "Skip disting Analytics Zoo"
-else
-    echo "Dist Analytics Zoo: $analytics_zoo_build_command"
-    $analytics_zoo_build_command
-fi
+build_command="${ANALYTICS_ZOO_HOME}/make-dist.sh ${dist_profile}"
+$build_command
 
 cd $ANALYTICS_ZOO_PYTHON_DIR
 sdist_command="python setup.py sdist"
-echo "packing source code: ${sdist_command}"
+echo "Packing source code: ${sdist_command}"
 $sdist_command
 
-if [ -d "${ANALYTICS_ZOO_DIR}/pyzoo/dist" ]; then
-   rm -r ${ANALYTICS_ZOO_DIR}/pyzoo/dist
+if [ -d "${ANALYTICS_ZOO_HOME}/pyzoo/dist" ]; then
+   rm -r ${ANALYTICS_ZOO_HOME}/pyzoo/dist
 fi
 
 wheel_command="python setup.py bdist_wheel --universal --plat-name ${verbose_pname}"
@@ -80,6 +75,5 @@ if [ -d "${ANALYTICS_ZOO_HOME}/pyzoo/analytics_zoo.egg-info" ]; then
 fi
 
 upload_command="twine upload dist/analytics_zoo-${version}-py2.py3-none-${verbose_pname}.whl"
-echo "Please manually upload with this command:  $upload_command"
-
+echo "Command for uploading to pypi: $upload_command"
 $upload_command


### PR DESCRIPTION
- Support custom profile options
- Remove unnecessary quick install option
- Put without_bigdl as default
- Update some typos.

Usage:
```
bash release.sh linux -Dspark.version=2.3.2 -Dbigdl.artifactId=bigdl-SPARK_2.3 -P spark_2.x
```
This command is the same as Scala's release command.