### PR TITLE
Modify keras batch normalization to support 2D input

### DIFF
--- a/pyzoo/test/zoo/pipeline/api/keras/test_layer.py
+++ b/pyzoo/test/zoo/pipeline/api/keras/test_layer.py
@@ -41,6 +41,7 @@ class TestLayer(ZooTestCase):
                            WeightsConverter.convert_embedding)
 
     def test_batchnormalization(self):
+        print("Running batch normal test")
         K.set_image_dim_ordering("th")
         input_data = np.random.random_sample([2, 5, 32, 32])
         zlayer = ZLayer.BatchNormalization(axis=1, input_shape=(5, 32, 32))
@@ -52,6 +53,12 @@ class TestLayer(ZooTestCase):
         zlayer = ZLayer.BatchNormalization(axis=-1, dim_ordering="tf", input_shape=(32, 32, 4))
         klayer = KLayer.BatchNormalization(axis=-1, input_shape=(32, 32, 4))
         self.compare_layer(klayer, zlayer, input_data2,
+                           WeightsConverter.convert_batchnormalization)
+        K.set_image_dim_ordering("th")
+        input_data = np.random.random_sample([2, 5])
+        zlayer = ZLayer.BatchNormalization(axis=1, input_shape=(5))
+        klayer = KLayer.BatchNormalization(axis=1, input_shape=(5))
+        self.compare_layer(klayer, zlayer, input_data,
                            WeightsConverter.convert_batchnormalization)
 
     def test_merge_sum(self):

--- a/pyzoo/test/zoo/pipeline/api/keras/test_layer.py
+++ b/pyzoo/test/zoo/pipeline/api/keras/test_layer.py
@@ -56,8 +56,8 @@ class TestLayer(ZooTestCase):
                            WeightsConverter.convert_batchnormalization)
         K.set_image_dim_ordering("th")
         input_data = np.random.random_sample([2, 5])
-        zlayer = ZLayer.BatchNormalization(axis=1, input_shape=(5))
-        klayer = KLayer.BatchNormalization(axis=1, input_shape=(5))
+        zlayer = ZLayer.BatchNormalization(axis=1, input_shape=(5,))
+        klayer = KLayer.BatchNormalization(axis=1, input_shape=(5,))
         self.compare_layer(klayer, zlayer, input_data,
                            WeightsConverter.convert_batchnormalization)
 

--- a/pyzoo/zoo/pipeline/api/keras/layers/normalization.py
+++ b/pyzoo/zoo/pipeline/api/keras/layers/normalization.py
@@ -30,7 +30,7 @@ class BatchNormalization(ZooKerasLayer):
     Normalize the activations of the previous layer at each batch, i.e. applies a transformation
     that maintains the mean activation close to 0 and the activation standard deviation close to 1.
     It is a feature-wise normalization, each feature map in the input will be normalized separately.
-    The input of this layer should be 4D.
+    The input of this layer should be 4D or 2D.
 
     When you use this layer as the first layer of a model, you need to provide the argument
     input_shape (a shape tuple, does not include the batch dimension).

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/BatchNormalization.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/BatchNormalization.scala
@@ -17,6 +17,7 @@
 package com.intel.analytics.zoo.pipeline.api.keras.layers
 
 import com.intel.analytics.bigdl.nn.{BatchNormalization => BBatchNormalization}
+import com.intel.analytics.bigdl.nn.{Xavier, RandomUniform, RandomNormal}
 import com.intel.analytics.bigdl.nn.keras.{BatchNormalization => BKBatchNormalization}
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, DataFormat}
 import com.intel.analytics.bigdl.tensor.Tensor
@@ -26,7 +27,6 @@ import com.intel.analytics.zoo.pipeline.api.Net
 import com.intel.analytics.zoo.pipeline.api.keras.layers.utils.KerasUtils
 
 import scala.reflect.ClassTag
-import com.intel.analytics.bigdl.nn._
 
 /**
  * Batch normalization layer.

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/BatchNormalization.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/BatchNormalization.scala
@@ -84,28 +84,29 @@ class BatchNormalization[T: ClassTag](
 
   override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val input = inputShape.toSingle().toArray
-    if(input.length == 4) {
-      val nChannel = dimOrdering match {
-        case DataFormat.NCHW => input(1)
-        case DataFormat.NHWC => input(3)
-      }
-      // TODO: support arbitrary input shape
-      val layer = SpatialBatchNormalization(
-        nOutput = nChannel,
-        eps = epsilon,
-        momentum = momentum,
-        initWeight = getInit(gammaInit, nChannel),
-        initBias = getInit(betaInit, nChannel),
-        dataFormat = dimOrdering)
-      layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
-    } else {
-      val nOutput = input(1)
-      BBatchNormalization[T](nOutput,
-        epsilon,
-        momentum,
-        affine = true,
-        initWeight = getInit(gammaInit, nOutput),
-        initBias = getInit(betaInit, nOutput))
+    input.length match {
+      case 4 => val nChannel = dimOrdering match {
+          case DataFormat.NCHW => input(1)
+          case DataFormat.NHWC => input(3)
+        }
+        // TODO: support arbitrary input shape
+        val layer = SpatialBatchNormalization(
+          nOutput = nChannel,
+          eps = epsilon,
+          momentum = momentum,
+          initWeight = getInit(gammaInit, nChannel),
+          initBias = getInit(betaInit, nChannel),
+          dataFormat = dimOrdering)
+        layer.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
+      case 2 => val nOutput = input(1)
+        BBatchNormalization[T](nOutput,
+          epsilon,
+          momentum,
+          affine = true,
+          initWeight = getInit(gammaInit, nOutput),
+          initBias = getInit(betaInit, nOutput))
+      case _ => throw new IllegalArgumentException(s"BatchNormalization requires 4D or 2D input," +
+        s" but got input dim ${input.length}")
     }
   }
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/python/PythonZooKeras.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/python/PythonZooKeras.scala
@@ -30,6 +30,7 @@ import com.intel.analytics.bigdl.nn.InitializationMethod
 import com.intel.analytics.bigdl.nn.Container
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
 import com.intel.analytics.bigdl.nn.keras.{KerasLayer, KerasModel}
+import com.intel.analytics.bigdl.nn.{BatchNormalization => BNBatchNormalization}
 import com.intel.analytics.bigdl.utils.{Shape, Table}
 import com.intel.analytics.zoo.feature.image.ImageSet
 import com.intel.analytics.zoo.pipeline.api.autograd._
@@ -267,6 +268,16 @@ class PythonZooKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonZ
       inputShape: JList[Int] = null): BatchNormalization[T] = {
     BatchNormalization[T](epsilon, momentum, betaInit,
       gammaInit, dimOrdering, toScalaShape(inputShape))
+  }
+
+  def setRunningMean(module: BatchNormalization[T], runningMean: JTensor): Unit = {
+    module.labor.asInstanceOf[BNBatchNormalization[T]]
+      .runningMean.set(toTensor(runningMean))
+  }
+
+  def setRunningStd(module: BatchNormalization[T], runningStd: JTensor): Unit = {
+    module.labor.asInstanceOf[BNBatchNormalization[T]]
+      .runningVar.set(toTensor(runningStd))
   }
 
   def createZooKerasConvolution2D(

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/BatchNormalizationSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/BatchNormalizationSpec.scala
@@ -16,6 +16,8 @@
 
 package com.intel.analytics.zoo.pipeline.api.keras.layers
 
+import java.lang.reflect.InvocationTargetException
+
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
 import com.intel.analytics.zoo.pipeline.api.keras.models.Sequential
@@ -26,7 +28,7 @@ import scala.util.Random
 class BatchNormalizationSpec extends KerasBaseSpec {
 
   // Compared results with Keras on Python side
-  "BatchNormalization" should "work properly" in {
+  "BatchNormalization" should "work properly for 3D data" in {
     val seq = Sequential[Float]()
     val layer = BatchNormalization[Float](betaInit = "glorot_uniform",
       gammaInit = "normal", inputShape = Shape(3, 12, 12))
@@ -35,6 +37,32 @@ class BatchNormalizationSpec extends KerasBaseSpec {
     val input = Tensor[Float](2, 3, 12, 12).rand()
     val output = seq.forward(input)
     val gradInput = seq.backward(input, output)
+  }
+
+  "BatchNormalization" should "work properly for 1D data" in {
+    val seq = Sequential[Float]()
+    val layer = BatchNormalization[Float](betaInit = "glorot_uniform",
+      gammaInit = "normal", inputShape = Shape(12))
+    seq.add(layer)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 12))
+    val input = Tensor[Float](2, 12).rand()
+    val output = seq.forward(input)
+    val gradInput = seq.backward(input, output)
+  }
+
+  "BatchNormalization" should "not work properly for 2D data" in {
+    val thrown = intercept[InvocationTargetException] {
+      val seq = Sequential[Float]()
+      val layer = BatchNormalization[Float](betaInit = "glorot_uniform",
+        gammaInit = "normal", inputShape = Shape(3, 12))
+      seq.add(layer)
+      seq.getOutputShape().toSingle().toArray should be(Array(-1, 3, 12))
+      val input = Tensor[Float](2, 3, 12).rand()
+      val output = seq.forward(input)
+      val gradInput = seq.backward(input, output)
+    }
+    assert(thrown.getTargetException.getMessage()
+      .contains("BatchNormalization requires 4D or 2D input"))
   }
 
 }

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/BatchNormalizationSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/BatchNormalizationSpec.scala
@@ -28,7 +28,7 @@ import scala.util.Random
 class BatchNormalizationSpec extends KerasBaseSpec {
 
   // Compared results with Keras on Python side
-  "BatchNormalization" should "work properly for 3D data" in {
+  "BatchNormalization" should "work properly for 4D input" in {
     val seq = Sequential[Float]()
     val layer = BatchNormalization[Float](betaInit = "glorot_uniform",
       gammaInit = "normal", inputShape = Shape(3, 12, 12))
@@ -39,7 +39,7 @@ class BatchNormalizationSpec extends KerasBaseSpec {
     val gradInput = seq.backward(input, output)
   }
 
-  "BatchNormalization" should "work properly for 1D data" in {
+  "BatchNormalization" should "work properly for 2D input" in {
     val seq = Sequential[Float]()
     val layer = BatchNormalization[Float](betaInit = "glorot_uniform",
       gammaInit = "normal", inputShape = Shape(12))
@@ -50,7 +50,7 @@ class BatchNormalizationSpec extends KerasBaseSpec {
     val gradInput = seq.backward(input, output)
   }
 
-  "BatchNormalization" should "not work properly for 2D data" in {
+  "BatchNormalization" should "not work properly for 3D input" in {
     val thrown = intercept[InvocationTargetException] {
       val seq = Sequential[Float]()
       val layer = BatchNormalization[Float](betaInit = "glorot_uniform",

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/BatchNormalizationSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/BatchNormalizationSpec.scala
@@ -50,7 +50,7 @@ class BatchNormalizationSpec extends KerasBaseSpec {
     val gradInput = seq.backward(input, output)
   }
 
-  "BatchNormalization" should "not work properly for 3D input" in {
+  "BatchNormalization" should "not work properly for 3D inputMeanSquaredLogarithmicErrorSpec:" in {
     val thrown = intercept[InvocationTargetException] {
       val seq = Sequential[Float]()
       val layer = BatchNormalization[Float](betaInit = "glorot_uniform",


### PR DESCRIPTION
Batch normalization to support 2D input and normalize the second dimension.

Related issue: https://github.com/intel-analytics/analytics-zoo/issues/1222
