### PR TITLE
support TFEstimator for model without parameters

### DIFF
--- a/pyzoo/zoo/tfpark/estimator.py
+++ b/pyzoo/zoo/tfpark/estimator.py
@@ -163,8 +163,8 @@ class TFEstimator(object):
                     checkpoint_path = latest_checkpoint
 
                 with tf.Session() as sess:
-                    saver = tf.train.Saver()
                     if checkpoint_path:
+                        saver = tf.train.Saver()
                         saver.restore(sess, checkpoint_path)
                     else:
                         sess.run(tf.global_variables_initializer())
@@ -200,8 +200,8 @@ class TFEstimator(object):
                     checkpoint_path = latest_checkpoint
 
                 with tf.Session() as sess:
-                    saver = tf.train.Saver()
                     if checkpoint_path:
+                        saver = tf.train.Saver()
                         saver.restore(sess, checkpoint_path)
                     else:
                         sess.run(tf.global_variables_initializer())


### PR DESCRIPTION
Adjusted the place to create `tf.train.Saver()`. There would be no parameters when using `tf.import_graph_def` to restore the model to evaluate or predict. In such a case, a `ValueError` would occur because there are no parameters to save or restore when creating `tf.train.Saver()`