### PR TITLE
Enhance TextSet wordIndex API

### DIFF
--- a/pyzoo/test/zoo/feature/text/test_text_set.py
+++ b/pyzoo/test/zoo/feature/text/test_text_set.py
@@ -98,7 +98,8 @@ class TestTextSet:
         transformed.save_word_index(vocab_file)
         local_set2 = LocalTextSet(self.texts, self.labels)
         local_set2.load_word_index(vocab_file)
-        transformed2 = local_set2.tokenize().normalize().word2idx().shape_sequence(10).generate_sample()
+        transformed2 = local_set2.tokenize().normalize().word2idx()\
+            .shape_sequence(10).generate_sample()
         samples2 = transformed2.get_samples()
         for s1, s2 in zip(samples, samples2):
             assert np.allclose(s1.feature.to_ndarray(), s2.feature.to_ndarray())
@@ -160,7 +161,8 @@ class TestTextSet:
         transformed.save_word_index(vocab_file)
         distributed_set2 = DistributedTextSet(texts_rdd, labels_rdd)
         distributed_set2.load_word_index(vocab_file)
-        transformed2 = distributed_set2.tokenize().normalize().word2idx().shape_sequence(5).generate_sample()
+        transformed2 = distributed_set2.tokenize().normalize().word2idx()\
+            .shape_sequence(5).generate_sample()
         samples2 = transformed2.get_samples().collect()
         for s1, s2 in zip(samples, samples2):
             assert np.allclose(s1.feature.to_ndarray(), s2.feature.to_ndarray())

--- a/pyzoo/zoo/feature/common.py
+++ b/pyzoo/zoo/feature/common.py
@@ -54,8 +54,8 @@ class Relations(object):
         For csv file, it should be without header.
         For txt file, each line should contain one record with fields separated by comma.
 
-        :param path: The path to the relations file, which can either be a local file path
-                     or HDFS path.
+        :param path: The path to the relations file, which can either be a local or disrtibuted file
+                     system (such as HDFS) path.
         :param sc: An instance of SparkContext.
                    If specified, return RDD of Relation.
                    Default is None and in this case return list of Relation.

--- a/pyzoo/zoo/feature/text/text_set.py
+++ b/pyzoo/zoo/feature/text/text_set.py
@@ -98,9 +98,9 @@ class TextSet(JavaValue):
         directly use this word_index during inference.
         Each separate line should be "word id".
 
-        Note that after calling `load_wordindex`, you do not need to specify any argument when calling
-        `word2idx` in the preprocessing pipeline as now you are using exactly the loaded word_index for
-        transformation.
+        Note that after calling `load_word_index`, you do not need to specify any argument when
+        calling `word2idx` in the preprocessing pipeline as now you are using exactly the loaded
+        word_index for transformation.
 
         For LocalTextSet, load txt from a local file system.
         For DistributedTextSet, load txt from a local file system or HDFS.

--- a/pyzoo/zoo/feature/text/text_set.py
+++ b/pyzoo/zoo/feature/text/text_set.py
@@ -80,6 +80,14 @@ class TextSet(JavaValue):
         """
         return callBigDlFunc(self.bigdl_type, "textSetGetWordIndex", self.value)
 
+    def set_word_index(self, vocab):
+        """
+        Set the word index dictionary to the TextSet.
+
+        :return: TextSet with the word_index set.
+        """
+        return callBigDlFunc(self.bigdl_type, "textSetSetWordIndex", self.value, vocab)
+
     def generate_word_index_map(self, remove_topN=0, max_words_num=-1,
                                 min_freq=1, existing_map=None):
         """

--- a/pyzoo/zoo/feature/text/text_set.py
+++ b/pyzoo/zoo/feature/text/text_set.py
@@ -86,7 +86,7 @@ class TextSet(JavaValue):
         Each separate line will be "word id".
 
         For LocalTextSet, save txt to a local file system.
-        For DistributedTextSet, save txt to a local file system or HDFS.
+        For DistributedTextSet, save txt to a local or distributed file system (such as HDFS).
 
         :param path: The path to the text file.
         """
@@ -103,7 +103,7 @@ class TextSet(JavaValue):
         word_index for transformation.
 
         For LocalTextSet, load txt from a local file system.
-        For DistributedTextSet, load txt from a local file system or HDFS.
+        For DistributedTextSet, load txt from a local or distributed file system (such as HDFS).
 
         :return: TextSet with the loaded word_index.
         """
@@ -310,8 +310,9 @@ class TextSet(JavaValue):
         All texts will be given a label according to the subdirectory where it is located.
         Labels start from 0.
 
-        :param path: Folder path to texts. Local file system and HDFS are supported.
-                     If you want to read from HDFS, sc needs to be specified.
+        :param path: The folder path to texts. Local or distributed file system (such as HDFS)
+                     are supported. If you want to read from a distributed file system, sc
+                     needs to be specified.
         :param sc: An instance of SparkContext.
                    If specified, texts will be read as a DistributedTextSet.
                    Default is None and in this case texts will be read as a LocalTextSet.
@@ -331,11 +332,9 @@ class TextSet(JavaValue):
         id(string) and text(string).
         Note that the csv file should be without header.
 
-        If sc is defined, read texts as DistributedTextSet from local file system or HDFS.
-        If sc is None, read texts as LocalTextSet from local file system.
-
-        :param path: The path to the csv file. Local file system and HDFS are supported.
-                     If you want to read from HDFS, sc needs to be specified.
+        :param path: The path to the csv file. Local or distributed file system (such as HDFS)
+                     are supported. If you want to read from a distributed file system, sc
+                     needs to be specified.
         :param sc: An instance of SparkContext.
                    If specified, texts will be read as a DistributedTextSet.
                    Default is None and in this case texts will be read as a LocalTextSet.

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/common/Relations.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/common/Relations.scala
@@ -33,7 +33,8 @@ object Relations {
    * For csv file, it should be without header.
    * For txt file, each line should contain one record with fields separated by comma.
    *
-   * @param path The path to the relations file, which can either be a local file path or HDFS path.
+   * @param path The path to the relations file, which can either be a local or disrtibuted file
+   *             system (such as HDFS) path.
    * @param sc An instance of SparkContext.
    * @param minPartitions Integer. A suggestion value of the minimal partition number for input
    *                      texts. Default is 1.

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/python/PythonTextFeature.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/python/PythonTextFeature.scala
@@ -261,8 +261,8 @@ class PythonTextFeature[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pyth
 
   def textSetSetWordIndex(
       textSet: TextSet,
-      map: JMap[String, Int]): TextSet = {
-    textSet.setWordIndex(if (map != null) map.asScala.toMap else null)
+      vocab: JMap[String, Int]): TextSet = {
+    textSet.setWordIndex(if (vocab != null) vocab.asScala.toMap else null)
   }
 
   def textSetTokenize(textSet: TextSet): TextSet = {
@@ -403,6 +403,12 @@ class PythonTextFeature[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pyth
       textSet: TextSet,
       path: String): Unit = {
     textSet.saveWordIndex(path)
+  }
+
+  def textSetLoadWordIndex(
+      textSet: TextSet,
+      path: String): Unit = {
+    textSet.loadWordIndex(path)
   }
 
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/python/PythonTextFeature.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/python/PythonTextFeature.scala
@@ -407,7 +407,7 @@ class PythonTextFeature[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pyth
 
   def textSetLoadWordIndex(
       textSet: TextSet,
-      path: String): Unit = {
+      path: String): TextSet = {
     textSet.loadWordIndex(path)
   }
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/python/PythonTextFeature.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/python/PythonTextFeature.scala
@@ -98,8 +98,8 @@ class PythonTextFeature[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pyth
     Normalizer()
   }
 
-  def createWordIndexer(map: JMap[String, Int]): WordIndexer = {
-    WordIndexer(if (map != null) map.asScala.toMap else null)
+  def createWordIndexer(vocab: JMap[String, Int]): WordIndexer = {
+    WordIndexer(if (vocab != null) vocab.asScala.toMap else null)
   }
 
   def createSequenceShaper(
@@ -257,6 +257,12 @@ class PythonTextFeature[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pyth
       textSet: TextSet,
       weights: JList[Double]): JList[TextSet] = {
     textSet.randomSplit(weights.asScala.toArray).toList.asJava
+  }
+
+  def textSetSetWordIndex(
+      textSet: TextSet,
+      map: JMap[String, Int]): TextSet = {
+    textSet.setWordIndex(if (map != null) map.asScala.toMap else null)
   }
 
   def textSetTokenize(textSet: TextSet): TextSet = {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextSet.scala
@@ -109,7 +109,7 @@ abstract class TextSet {
 
   /**
    * Map word tokens to indices.
-   * Important: You need to note that this method behaves differently for training and inference.
+   * Important: Take care that this method behaves a bit differently for training and inference.
    *
    * ---------------------------------------Training--------------------------------------------
    * During the training, you need to generate a new wordIndex map according to the texts you are
@@ -120,7 +120,6 @@ abstract class TextSet {
    * each word sorted in descending order.
    * After word2idx, you can get the generated wordIndex map by calling 'getWordIndex'.
    * Also, you can call `saveWordIndex` to save this wordIndex map to be used in future training.
-   *
    *
    * @param removeTopN Non-negative integer. Remove the topN words with highest frequencies in
    *                   the case where those are treated as stopwords.
@@ -198,6 +197,13 @@ abstract class TextSet {
    */
   def getWordIndex: Map[String, Int] = wordIndex
 
+  /**
+   * Assign a wordIndex map for this TextSet to use during word2idx.
+   * If you load the wordIndex from the saved file, you are recommended to use `loadWordIndex`
+   * directly.
+   *
+   * @param vocab Map of each word (String) and its index (integer).
+   */
   def setWordIndex(vocab: Map[String, Int]): this.type = {
     wordIndex = vocab
     this
@@ -592,7 +598,7 @@ object TextSet {
    *                    map with index starting from 1 will be generated.
    *                    If not null, then the generated map will preserve the word index in
    *                    existingMap and assign subsequent indices to new words.
-   * @return WordIndex map.
+   * @return wordIndex map.
    */
   def wordsToMap(words: Array[String], existingMap: Map[String, Int] = null): Map[String, Int] = {
     if (existingMap == null) {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextSet.scala
@@ -214,7 +214,7 @@ abstract class TextSet {
    * Each separate line will be "word id".
    *
    * For LocalTextSet, save txt to a local file system.
-   * For DistributedTextSet, save txt to a local file system or HDFS.
+   * For DistributedTextSet, save txt to a local or distributed file system (such as HDFS).
    *
    * @param path The path to the text file.
    */
@@ -235,7 +235,7 @@ abstract class TextSet {
    * transformation.
    *
    * For LocalTextSet, load txt from a local file system.
-   * For DistributedTextSet, load txt from a local file system or HDFS.
+   * For DistributedTextSet, load txt from a local or distributed file system (such as HDFS).
    *
    * @param path The path to the text file.
    */
@@ -276,8 +276,9 @@ object TextSet {
    * All texts will be given a label according to the subdirectory where it is located.
    * Labels start from 0.
    *
-   * @param path The folder path to texts. Local file system and HDFS are supported.
-   *             If you want to read from HDFS, sc needs to be specified.
+   * @param path The folder path to texts. Local or distributed file system (such as HDFS)
+   *             are supported. If you want to read from a distributed file system, sc
+   *             needs to be specified.
    * @param sc An instance of SparkContext.
    *           If specified, texts will be read as a DistributedTextSet.
    *           Default is null and in this case texts will be read as a LocalTextSet.
@@ -330,8 +331,9 @@ object TextSet {
    * Each record is supposed to contain the following two fields in order:
    * id(String) and text(String).
    *
-   * @param path The path to the csv file. Local file system and HDFS are supported.
-   *             If you want to read from HDFS, sc needs to be specified.
+   * @param path The path to the csv file. Local or distributed file system (such as HDFS)
+   *             are supported. If you want to read from a distributed file system, sc
+   *             needs to be specified.
    * @param sc An instance of SparkContext.
    *           If specified, texts will be read as a DistributedTextSet.
    *           Default is null and in this case texts will be read as a LocalTextSet.

--- a/zoo/src/test/scala/com/intel/analytics/zoo/feature/text/TextSetSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/feature/text/TextSetSpec.scala
@@ -121,6 +121,14 @@ class TextSetSpec extends ZooSpecHelper {
       wordIndex("annotate"), wordIndex("text"))))
   }
 
+  "Save a TextSet with no wordIndex" should "raise an error" in {
+    intercept[Exception] {
+      val tmpFile = createTmpFile()
+      val distributed = TextSet.rdd(sc.parallelize(genFeatures()))
+      distributed.saveWordIndex(tmpFile.getAbsolutePath)
+    }
+  }
+
   "TextSet read with sc, fit, predict and evaluate" should "work properly" in {
     val textSet = TextSet.read(path, sc)
     require(textSet.isDistributed)

--- a/zoo/src/test/scala/com/intel/analytics/zoo/feature/text/TextSetSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/feature/text/TextSetSpec.scala
@@ -30,7 +30,6 @@ import com.intel.analytics.zoo.pipeline.api.keras.models.Sequential
 import com.intel.analytics.zoo.pipeline.api.keras.objectives.{RankHinge, SparseCategoricalCrossEntropy}
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.{SparkConf, SparkContext}
-import com.intel.analytics.zoo.feature.text.TextFeature
 
 import scala.collection.immutable.HashSet
 

--- a/zoo/src/test/scala/com/intel/analytics/zoo/feature/text/TextSetSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/feature/text/TextSetSpec.scala
@@ -78,6 +78,18 @@ class TextSetSpec extends ZooSpecHelper {
     require(features.length == 2)
     require(features(0).keys() == HashSet("label", "text", "tokens", "indexedTokens", "sample"))
     require(features(0)[Array[Float]]("indexedTokens").length == 5)
+
+    val tmpFile = createTmpFile()
+    transformed.saveWordIndex(tmpFile.getAbsolutePath)
+
+    val distributed2 = TextSet.rdd(sc.parallelize(genFeatures().take(1)))
+      .loadWordIndex(tmpFile.getAbsolutePath)
+    require(distributed2.getWordIndex == wordIndex)
+    val transformed2 = distributed2.tokenize().normalize().word2idx()
+      .shapeSequence(4, TruncMode.post)
+    val indices = transformed2.toDistributed().rdd.first().getIndices.map(_.toInt)
+    require(indices.sameElements(Array(wordIndex("hello"), wordIndex("my"),
+      wordIndex("friend"), wordIndex("please"))))
   }
 
   "LocalTextSet Transformation" should "work properly" in {
@@ -96,6 +108,17 @@ class TextSetSpec extends ZooSpecHelper {
     require(features.length == 2)
     require(features(0).keys() == HashSet("label", "text", "tokens", "indexedTokens", "sample"))
     require(features(0).getIndices.length == 10)
+
+    val tmpFile = createTmpFile()
+    transformed.saveWordIndex(tmpFile.getAbsolutePath)
+
+    val local2 = TextSet.array(genFeatures().take(1))
+      .loadWordIndex(tmpFile.getAbsolutePath)
+    require(local2.getWordIndex == wordIndex)
+    val transformed2 = local2.tokenize().normalize().word2idx().shapeSequence(4)
+    val indices = transformed2.toLocal().array(0).getIndices.map(_.toInt)
+    require(indices.sameElements(Array(wordIndex("friend"), wordIndex("please"),
+      wordIndex("annotate"), wordIndex("text"))))
   }
 
   "TextSet read with sc, fit, predict and evaluate" should "work properly" in {


### PR DESCRIPTION
Especially for the convenience of inference:
- Refactor saveWordIndex method to support HDFS.
- Add loadWordIndex method.
- Add more docs for word2idx.
- Add missing Python wrap.
- Add uts to cover the changes.

Will add examples and update website doc gradually in the future.