### PR TITLE
Fix re-download nlp-architect every time when make_dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ target/
 /dist/
 pyzoo/.pytest_cache/
 
+# External Python packages
+python_packages/
+
 # SBT, Maven specific
 .cache
 .history

--- a/pyzoo/dev/prepare_env.sh
+++ b/pyzoo/dev/prepare_env.sh
@@ -30,7 +30,7 @@ if [ -z ${SPARK_HOME+x} ]; then echo "SPARK_HOME is unset"; exit 1; else echo "S
 
 export PYSPARK_ZIP=`find $SPARK_HOME/python/lib  -type f -iname '*.zip' | tr "\n" ":"`
 
-export PYTHONPATH=$PYSPARK_ZIP:$DL_PYTHON_HOME:$ANALYTICS_ZOO_ROOT/zoo/target/python/sources/:$ANALYTICS_ZOO_ROOT/zoo/target/classes/spark-analytics-zoo.conf:$ANALYTICS_ZOO_ROOT/zoo/target/extra-resources/zoo-version-info.properties:$PYTHONPATH
+export PYTHONPATH=$PYSPARK_ZIP:$DL_PYTHON_HOME:$ANALYTICS_ZOO_ROOT/zoo/python_packages/sources/:$ANALYTICS_ZOO_ROOT/zoo/target/classes/spark-analytics-zoo.conf:$ANALYTICS_ZOO_ROOT/zoo/target/extra-resources/zoo-version-info.properties:$PYTHONPATH
 echo "PYTHONPATH": $PYTHONPATH
 export ANALYTICS_ZOO_CLASSPATH=$(find $ANALYTICS_ZOO_ROOT/zoo/target/ -name "*with-dependencies.jar" | head -n 1)
 echo "ANALYTICS_ZOO_CLASSPATH": $ANALYTICS_ZOO_CLASSPATH

--- a/scripts/get_python_packages
+++ b/scripts/get_python_packages
@@ -16,7 +16,7 @@
 
 if (( $# < 2)); then
   echo "Getting $* $#"
-  echo "Bad parameters. Usage example: bash get_python_packages.sh /tmp/analytics_zoo_python/ 0.7.2"
+  echo "Bad parameters. Usage example: bash get_python_packages /tmp/analytics_zoo_python/ 0.7.2"
   exit -1
 fi
 
@@ -25,7 +25,7 @@ echo "DEST_DIR: $DEST_DIR"
 BIGDL_VERSION=$2
 NLP_ARCHITECT_VERSION="0.3.1"
 
-rm -rf $DEST_DIR/*
+rm -rf $DEST_DIR/*/
 
 echo "Fetching BigDL ${BIGDL_VERSION}"
 GET_COMMAND="mvn org.apache.maven.plugins:maven-dependency-plugin:2.4:get \
@@ -46,7 +46,7 @@ then
 fi
 
 echo "Fetching nlp-architect ${NLP_ARCHITECT_VERSION}"
-GET_COMMAND="wget https://github.com/NervanaSystems/nlp-architect/archive/v${NLP_ARCHITECT_VERSION}.zip -P $DEST_DIR"
+GET_COMMAND="wget -nc https://github.com/NervanaSystems/nlp-architect/archive/v${NLP_ARCHITECT_VERSION}.zip -P $DEST_DIR"
 echo "Running: $GET_COMMAND"
 $GET_COMMAND
 exit_status=$?

--- a/zoo/pom.xml
+++ b/zoo/pom.xml
@@ -339,7 +339,7 @@
                         <configuration>
                             <arguments>
                                 <argument>${project.basedir}/../scripts/get_python_packages</argument>
-                                <argument>${project.build.directory}/python</argument>
+                                <argument>${project.basedir}/python_packages</argument>
                                 <argument>${bigdl.version}</argument>
                             </arguments>
 

--- a/zoo/src/assembly/python-zip.xml
+++ b/zoo/src/assembly/python-zip.xml
@@ -11,6 +11,10 @@
             <includes>
                 <include>**/*.py</include>
             </includes>
+            <excludes>
+                <exclude>test/**/*</exclude>
+                <exclude>docs/**/*</exclude>
+            </excludes>
             <outputDirectory>/..</outputDirectory>
             <directory>${project.parent.basedir}/pyzoo</directory>
         </fileSet>
@@ -24,7 +28,7 @@
                 <exclude>docs/**/*</exclude>
             </excludes>
             <outputDirectory>/..</outputDirectory>
-            <directory>${project.build.directory}/python/sources</directory>
+            <directory>${project.parent.basedir}/zoo/python_packages/sources</directory>
         </fileSet>
 
         <fileSet>


### PR DESCRIPTION
Fix #1236 

- Previously all python packages will be downloaded to analytics-zoo/zoo/target/python, which will be cleaned when rebuilding the project.
- Now put external python packages under analytics-zoo/zoo/python_packages and do the check to prevent re-downloading the packages when building the project.

Remark: GitHub server seems doesn't control timestamp well, thus upon my test `wget -N` doesn't work and will still download again. I use `wget -nc` and in this case but it seems if the file isn't fully downloaded with the same name it will also not download. Since this is for our internal use mainly, first merge it and once we successfully download once, it will not re-download.