### PR TITLE
Add remote file system support for Utils

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/common/Utils.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/common/Utils.scala
@@ -56,23 +56,29 @@ private[zoo] object Utils {
   }
 
   /**
-   * List local or remote files (HDFS, S3 and FTP etc) with FileSystem API
+   * List paths of local or remote files (HDFS, S3 and FTP etc)
+   * with FileSystem API
    * @param path String path
    * @param recursive Recursive or not
    * @return Array[String]
    */
-  def listFiles(path: String, recursive: Boolean = false): Array[String] = {
+  def listPaths(path: String, recursive: Boolean = false): Array[String] = {
     val fs = getFileSystem(path)
     // List remote or local files
-    val files = fs.listFiles(new Path(path), recursive)
-    // Add file paths (string) into ArrayBuffer
     val res = new ArrayBuffer[String]()
-    while (files.hasNext) {
-      val file = files.next()
-      // Ignore dir
-      if (!file.isDirectory) {
-        res.append(file.getPath.toString)
+    try {
+      val files = fs.listFiles(new Path(path), recursive)
+      while (files.hasNext) {
+        val file = files.next()
+        // Ignore dir
+        if (!file.isDirectory) {
+          // Add file paths (string) into ArrayBuffer
+          res.append(file.getPath.toString)
+        }
       }
+    } catch {
+      case _: FileNotFoundException => logger.warn(s"$path doesn't exist!")
+      case _: IOException => logger.error(s"List paths of $path error!")
     }
     fs.close()
     res.toArray

--- a/zoo/src/main/scala/com/intel/analytics/zoo/common/Utils.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/common/Utils.scala
@@ -35,6 +35,11 @@ private[zoo] object Utils {
     files.toArray
   }
 
+  /**
+   * List files in local file system
+   * @param path String
+   * @param files File handles will be appended to files
+   */
   def listFiles(path: String, files: ArrayBuffer[File]): Unit = {
     val file = new File(path)
     if (file.isDirectory) {
@@ -50,7 +55,7 @@ private[zoo] object Utils {
   }
 
   /**
-   * List local or remote files (HDFS, S3, FTP etc) with FileSystem API
+   * List local or remote files (HDFS, S3 and FTP etc) with FileSystem API
    * @param path String path
    * @param recursive Recursive or not
    * @return Array[String]
@@ -94,6 +99,15 @@ private[zoo] object Utils {
   }
 
   /**
+   * Read bytes of multiple files
+   * @param paths String paths in Array
+   * @return 2 dim Byte Array
+   */
+  def readBytes(paths: Array[String]): Array[Array[Byte]] = {
+    paths.map(readBytes)
+  }
+
+  /**
    * Write string lines into given path (local or remote file system)
    * @param path String path
    * @param lines String content
@@ -107,6 +121,29 @@ private[zoo] object Utils {
     } finally {
       outStream.close()
     }
+  }
+
+  /**
+   * Create file in FileSystem (local or remote)
+   * @param path String path
+   * @param overwrite overwrite exiting file or not
+   * @return
+   */
+  def createFile(path: String, overwrite: Boolean = false): DataOutputStream = {
+    val fspath = new Path(path)
+    val fs = FileSystem.get(fspath.toUri, new Configuration())
+    fs.create(fspath, overwrite)
+  }
+
+  /**
+   * Open file in FileSystem (local or remote)
+   * @param path String path
+   * @return DataInputStream
+   */
+  def openFile(path: String): DataInputStream = {
+    val fspath = new Path(path)
+    val fs = FileSystem.get(fspath.toUri, new Configuration())
+    fs.open(fspath)
   }
 
   /**

--- a/zoo/src/main/scala/com/intel/analytics/zoo/common/Utils.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/common/Utils.scala
@@ -74,11 +74,14 @@ private[zoo] object Utils {
         res.append(file.getPath.toString)
       }
     }
+    fs.close()
     res.toArray
   }
 
   /**
-   * Read bytes of local or remote file
+   * Read all bytes of file (local or remote) and return bytes Array.
+   * WARNING: Don't use it to read large files. It may cause performance issue
+   * and OOM.
    * @param path String
    * @return Array[Byte]
    */
@@ -87,7 +90,10 @@ private[zoo] object Utils {
   }
 
   /**
-   * Read bytes of multiple files
+   * Read all bytes of multiple files (local or remote) and
+   * return 2 dim bytes Array.
+   * WARNING: Don't use it to read large files. It may cause performance issue
+   * and OOM.
    * @param paths String paths in Array
    * @return 2 dim Byte Array
    */
@@ -108,9 +114,10 @@ private[zoo] object Utils {
     } finally {
       outStream.close()
     }
+    fs.close()
   }
 
-  private def getFileSystem(fileName: String): FileSystem = {
+  def getFileSystem(fileName: String): FileSystem = {
     FileSystem.get(new Path(fileName).toUri, new Configuration())
   }
 
@@ -120,7 +127,7 @@ private[zoo] object Utils {
    * @param overwrite overwrite exiting file or not
    * @return
    */
-  def createFile(path: String, overwrite: Boolean = false): DataOutputStream = {
+  def create(path: String, overwrite: Boolean = false): DataOutputStream = {
     getFileSystem(path).create(new Path(path), overwrite)
   }
 
@@ -129,12 +136,14 @@ private[zoo] object Utils {
    * @param path String path
    * @return DataInputStream
    */
-  def openFile(path: String): DataInputStream = {
+  def open(path: String): DataInputStream = {
     getFileSystem(path).open(new Path(path))
   }
 
   /**
-   * Save bytes into given path (local or remote file system)
+   * Save bytes into given path (local or remote file system).
+   * WARNING: Don't use it to read large files. It may cause performance issue
+   * and OOM.
    * @param bytes bytes
    * @param fileName String path
    * @param isOverwrite Overwrite exiting file or not

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/streaming/objectdetection/ImagePathWriter.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/streaming/objectdetection/ImagePathWriter.scala
@@ -22,7 +22,7 @@ import org.apache.log4j.{Level, Logger}
 import scopt.OptionParser
 
 /*
-  * Based on https://github.com/intel-analytics/meph-streaming
+  * Based on Yuhao's code (https://github.com/intel-analytics/meph-streaming)
   * Periodically write a text file to streamingPath, which contains 10 image paths.
   */
 object ImagePathWriter {
@@ -36,7 +36,7 @@ object ImagePathWriter {
       val lists = Utils.listFiles(params.imageSourcePath, false)
       lists.grouped(10).zipWithIndex.foreach { case (batch, id) =>
         val batchPath = new Path(params.streamingPath, id + ".txt").toString
-        val dataOutStream = Utils.createFile(batchPath, true)
+        val dataOutStream = Utils.create(batchPath, true)
         try {
           batch.foreach(line => dataOutStream.writeBytes(line + "\n"))
         } finally {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/streaming/objectdetection/ImagePathWriter.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/streaming/objectdetection/ImagePathWriter.scala
@@ -32,7 +32,7 @@ object ImagePathWriter {
     val logger = Logger.getLogger(getClass)
 
     parser.parse(args, PathWriterParam()).foreach { params =>
-      val lists = Utils.listFiles(params.imageSourcePath, false)
+      val lists = Utils.listPaths(params.imageSourcePath, false)
       lists.grouped(10).zipWithIndex.foreach { case (batch, id) =>
         val batchPath = new Path(params.streamingPath, id + ".txt").toString
         val dataOutStream = Utils.create(batchPath, true)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/streaming/objectdetection/ImagePathWriter.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/streaming/objectdetection/ImagePathWriter.scala
@@ -22,8 +22,7 @@ import org.apache.log4j.{Level, Logger}
 import scopt.OptionParser
 
 /*
-  * Based on Yuhao's code (https://github.com/intel-analytics/meph-streaming)
-  * Periodically write a text file to streamingPath, which contains 10 image paths.
+  * Periodically write a text file (contains 10 image paths) to streamingPath
   */
 object ImagePathWriter {
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/streaming/objectdetection/StreamingObjectDetection.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/streaming/objectdetection/StreamingObjectDetection.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.zoo.examples.streaming.objectdetection
 
 
 import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
-import com.intel.analytics.zoo.common.NNContext
+import com.intel.analytics.zoo.common.{NNContext, Utils}
 import com.intel.analytics.zoo.feature.image.{ImageBytesToMat, ImageSet}
 import com.intel.analytics.zoo.models.image.objectdetection.{ObjectDetector, Visualizer}
 import org.apache.hadoop.conf.Configuration
@@ -98,14 +98,7 @@ object StreamingObjectDetection {
    */
   def readFile(path: String): ImageFeature = {
     logger.info("Read image file " + path)
-    val fspath = new Path(path)
-    val fs = FileSystem.get(fspath.toUri, new Configuration())
-    // Read local or remote image
-    val inputStream = fs.open(fspath)
-    val data = new Array[Byte](fs.getFileStatus(new Path(path))
-      .getLen.toInt)
-    inputStream.readFully(data)
-    inputStream.close()
+    val data = Utils.readBytes(path)
     ImageFeature.apply(data, null, path)
   }
 
@@ -118,12 +111,7 @@ object StreamingObjectDetection {
   def writeFile(outPath: String, path: String, content: Array[Byte]): Unit = {
     val fspath = getOutPath(outPath, path, "jpg")
     logger.info("Writing image file " + fspath.toString)
-    val fs = FileSystem.get(fspath.toUri, new Configuration())
-    val outStream = fs.create(
-      fspath,
-      true)
-    outStream.write(content)
-    outStream.close()
+    Utils.saveBytes(content, fspath.toString, true)
   }
 
   /**

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/streaming/objectdetection/StreamingObjectDetection.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/streaming/objectdetection/StreamingObjectDetection.scala
@@ -21,8 +21,7 @@ import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
 import com.intel.analytics.zoo.common.{NNContext, Utils}
 import com.intel.analytics.zoo.feature.image.{ImageBytesToMat, ImageSet}
 import com.intel.analytics.zoo.models.image.objectdetection.{ObjectDetector, Visualizer}
-import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.fs.Path
 import org.apache.log4j.{Level, Logger}
 import org.apache.spark.streaming.{Seconds, StreamingContext}
 import org.opencv.imgcodecs.Imgcodecs

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/streaming/objectdetection/StreamingObjectDetection.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/streaming/objectdetection/StreamingObjectDetection.scala
@@ -91,7 +91,7 @@ object StreamingObjectDetection {
   }
 
   /**
-   * Read files from local or remote dir
+   * Read image files from local or remote file system
    * @param path file path
    * @return ImageFeature
    */
@@ -102,7 +102,7 @@ object StreamingObjectDetection {
   }
 
   /**
-   * Write files to local or remote dir
+   * Write image file to local or remote file system
    * @param outPath output dir
    * @param path input file path
    * @param content file content

--- a/zoo/src/test/scala/com/intel/analytics/zoo/common/UtilsSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/common/UtilsSpec.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018 Analytics Zoo Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.zoo.common
+
+import org.apache.hadoop.fs.Path
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.util.Random
+
+class UtilsSpec extends FlatSpec with Matchers {
+  val path: String = getClass.getClassLoader.getResource("qa").getPath
+  val txtRelations: String = path + "/relations.txt"
+
+  "Utils listFiles" should "work properly" in {
+    val files = Utils.listFiles(path)
+    assert(files.size == 3)
+    val recursiveFiles = Utils.listFiles(path, true)
+    assert(recursiveFiles.size == 13)
+  }
+
+  "Utils readBytes" should "work properly" in {
+    val inputStream = Utils.open(txtRelations)
+    val fileLen = inputStream.available()
+    inputStream.close()
+    val bytes = Utils.readBytes(txtRelations)
+    assert(bytes.length == fileLen)
+  }
+
+  "Utils saveBytes" should "work properly" in {
+    val fs = Utils.getFileSystem(path)
+    // Generate random file
+    val randomFile = Random.nextInt(1000)
+    val randomContent = new Array[Byte](1000)
+    Random.nextBytes(randomContent)
+    Utils.saveBytes(randomContent, path + "/" + randomFile)
+    // Delete random file
+    fs.deleteOnExit(new Path(path + "/" + randomFile))
+    fs.close()
+  }
+}

--- a/zoo/src/test/scala/com/intel/analytics/zoo/common/UtilsSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/common/UtilsSpec.scala
@@ -26,9 +26,9 @@ class UtilsSpec extends FlatSpec with Matchers {
   val txtRelations: String = path + "/relations.txt"
 
   "Utils listFiles" should "work properly" in {
-    val files = Utils.listFiles(path)
+    val files = Utils.listPaths(path)
     assert(files.size == 3)
-    val recursiveFiles = Utils.listFiles(path, true)
+    val recursiveFiles = Utils.listPaths(path, true)
     assert(recursiveFiles.size == 13)
   }
 


### PR DESCRIPTION
Add remote file system support for Utils
* Add `listPaths` for listing file paths on both local and remote file system.
* Add `writeLines` for saving `String` to file.
* Add `readBytes` (based on `bigdl.utils.File`) for reading all bytes of given file.
* Add `open` and `create` methods for handling large files.
