### PR TITLE
Support ResNet50-int8 model in ImageClassifier

### DIFF
--- a/pyzoo/zoo/feature/image/imagePreprocessing.py
+++ b/pyzoo/zoo/feature/image/imagePreprocessing.py
@@ -128,7 +128,7 @@ class ImageSetToSample(ImagePreprocessing):
     :param target_keys keys that maps targets (each target should be a tensor)
     :param sample_key key to store sample
     """
-    def __init__(self, input_keys=["imageTensor"], target_keys=None,
+    def __init__(self, input_keys=["imageTensor"], target_keys=["label"],
                  sample_key="sample", bigdl_type="float"):
         super(ImageSetToSample, self).__init__(bigdl_type, input_keys, target_keys, sample_key)
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/ImageNetInference.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/ImageNetInference.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 The BigDL Authors.
+ * Copyright 2018 Analytics Zoo Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/ImageNetInference.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/ImageNetInference.scala
@@ -37,22 +37,23 @@ object ImageNetInference {
 
   def main(args: Array[String]): Unit = {
     System.setProperty("bigdl.engineType", "mkldnn")
+
     val parser = new OptionParser[ImageNetInferenceParams]("ImageNet Int8 Example") {
       opt[String]('f', "folder")
-        .text("The path to the imagenet dataset for inference")
+        .text("The folder path that contains ImageNet no-resize sequence files")
         .action((x, c) => c.copy(folder = x))
         .required()
       opt[String]('m', "model")
-        .text("The path to the int8 quantized ResNet50 model snapshot")
+        .text("The path to the pre-trained int8 ResNet50 model snapshot")
         .action((x, c) => c.copy(model = x))
         .required()
       opt[Int]('b', "batchSize")
-        .text("batch size")
+        .text("The total batch size for inference")
         .action((x, c) => c.copy(batchSize = x))
     }
     parser.parse(args, ImageNetInferenceParams()).map(param => {
       val sc = NNContext.initNNContext("ImageNet2012 with Int8 Inference Example")
-      val images = ImageSet.readSeqFiles(param.folder, sc)
+      val images = ImageSet.readSequenceFiles(param.folder, sc)
       val model = ImageClassifier.loadModel[Float](param.model)
       val result = model.evaluateImageSet(images, param.batchSize,
         Array(new Top1Accuracy[Float], new Top5Accuracy[Float]))

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/ImageNetInference.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/ImageNetInference.scala
@@ -54,7 +54,7 @@ object ImageNetInference {
     parser.parse(args, ImageNetInferenceParams()).map(param => {
       val sc = NNContext.initNNContext("ImageNet2012 with Int8 Inference Example")
       val images = ImageSet.readSeqFiles(param.folder, sc)
-      val model = ImageClassifier.loadModel[Float](param.model, quantize = true)
+      val model = ImageClassifier.loadModel[Float](param.model)
       val result = model.evaluateImageSet(images, param.batchSize,
         Array(new Top1Accuracy[Float], new Top5Accuracy[Float]))
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/ImageNetInference.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/ImageNetInference.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.zoo.examples.vnni.bigdl
+
+import com.intel.analytics.bigdl.optim.{Top1Accuracy, Top5Accuracy}
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric._
+import com.intel.analytics.bigdl.utils.LoggerFilter
+import com.intel.analytics.zoo.common.NNContext
+import com.intel.analytics.zoo.feature.image.ImageSet
+import com.intel.analytics.zoo.models.image.imageclassification.ImageClassifier
+import org.apache.log4j.{Level, Logger}
+import scopt.OptionParser
+
+
+case class ImageNetInferenceParams(folder: String = "./",
+                                   model: String = "",
+                                   batchSize: Int = 128)
+
+object ImageNetInference {
+  LoggerFilter.redirectSparkInfoLogs()
+  Logger.getLogger("com.intel.analytics.bigdl.optim").setLevel(Level.INFO)
+
+  val logger: Logger = Logger.getLogger(getClass)
+
+  def main(args: Array[String]): Unit = {
+    System.setProperty("bigdl.engineType", "mkldnn")
+    val parser = new OptionParser[ImageNetInferenceParams]("ImageNet Int8 Example") {
+      opt[String]('f', "folder")
+        .text("The path to the imagenet dataset for inference")
+        .action((x, c) => c.copy(folder = x))
+        .required()
+      opt[String]('m', "model")
+        .text("The path to the int8 quantized ResNet50 model snapshot")
+        .action((x, c) => c.copy(model = x))
+        .required()
+      opt[Int]('b', "batchSize")
+        .text("batch size")
+        .action((x, c) => c.copy(batchSize = x))
+    }
+    parser.parse(args, ImageNetInferenceParams()).map(param => {
+      val sc = NNContext.initNNContext("ImageNet2012 with Int8 Inference Example")
+      val images = ImageSet.readSeqFiles(param.folder, sc)
+      val model = ImageClassifier.loadModel[Float](param.model, quantize = true)
+      val result = model.evaluateImageSet(images, param.batchSize,
+        Array(new Top1Accuracy[Float], new Top5Accuracy[Float]))
+
+      result.foreach(r => println(s"${r._2} is ${r._1}"))
+
+      sc.stop()
+    })
+  }
+}

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/ImageNetInference.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/ImageNetInference.scala
@@ -38,7 +38,7 @@ object ImageNetInference {
   def main(args: Array[String]): Unit = {
     System.setProperty("bigdl.engineType", "mkldnn")
 
-    val parser = new OptionParser[ImageNetInferenceParams]("ImageNet Int8 Example") {
+    val parser = new OptionParser[ImageNetInferenceParams]("ImageNet Int8 Inference Example") {
       opt[String]('f', "folder")
         .text("The folder path that contains ImageNet no-resize sequence files")
         .action((x, c) => c.copy(folder = x))
@@ -55,11 +55,9 @@ object ImageNetInference {
       val sc = NNContext.initNNContext("ImageNet2012 with Int8 Inference Example")
       val images = ImageSet.readSequenceFiles(param.folder, sc)
       val model = ImageClassifier.loadModel[Float](param.model)
-      val result = model.evaluateImageSet(images, param.batchSize,
-        Array(new Top1Accuracy[Float], new Top5Accuracy[Float]))
-
+      val result = model.evaluateImageSet(images,
+        Array(new Top1Accuracy[Float], new Top5Accuracy[Float]), param.batchSize)
       result.foreach(r => println(s"${r._2} is ${r._1}"))
-
       sc.stop()
     })
   }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/ImageNetInference.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/ImageNetInference.scala
@@ -25,7 +25,6 @@ import com.intel.analytics.zoo.models.image.imageclassification.ImageClassifier
 import org.apache.log4j.{Level, Logger}
 import scopt.OptionParser
 
-
 case class ImageNetInferenceParams(folder: String = "./",
                                    model: String = "",
                                    batchSize: Int = 128)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Perf.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Perf.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018 Analytics Zoo Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.zoo.examples.vnni.bigdl
+
+import com.intel.analytics.bigdl.numeric.NumericFloat
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.Engine
+import com.intel.analytics.zoo.models.image.imageclassification.ImageClassifier
+import org.apache.log4j.Logger
+import scopt.OptionParser
+
+
+case class ResNet50PerfParams(model: String = "",
+                              batchSize: Int = 32,
+                              iteration: Int = 1000)
+
+object Perf {
+
+  val logger: Logger = Logger.getLogger(getClass)
+
+  def main(args: Array[String]): Unit = {
+    System.setProperty("bigdl.localMode", "true")
+    System.setProperty("bigdl.engineType", "mkldnn")
+
+    val parser = new OptionParser[ResNet50PerfParams]("ResNet50 Int8 Performance Test") {
+      opt[String]('m', "model")
+        .text("The path to the int8 quantized ResNet50 model snapshot")
+        .action((v, p) => p.copy(model = v))
+        .required()
+      opt[Int]('b', "batchSize")
+        .text("Batch size of input data")
+        .action((v, p) => p.copy(batchSize = v))
+      opt[Int]('i', "iteration")
+        .text("Iteration of perf test. The result will be average of each iteration time cost")
+        .action((v, p) => p.copy(iteration = v))
+    }
+
+    parser.parse(args, ResNet50PerfParams()).foreach { param =>
+      val batchSize = param.batchSize
+      val batchInput = Tensor(Array(batchSize, 3, 224, 224)).rand()
+      val singleInput = Tensor(Array(1, 3, 224, 224)).rand()
+      Engine.init
+
+      val model = ImageClassifier.loadModel[Float](param.model, quantize = true)
+      model.setEvaluateStatus()
+
+      var iteration = 0
+      while (iteration < param.iteration) {
+        val start = System.nanoTime()
+        model.forward(batchInput)
+        val timeUsed = System.nanoTime() - start
+        val throughput = "%.2f".format(batchSize.toFloat / (timeUsed / 1e9))
+        logger.info(s"Iteration $iteration, takes $timeUsed ns, throughput is $throughput imgs/sec")
+
+        iteration += 1
+      }
+
+      val model2 = ImageClassifier.loadModel[Float](param.model, quantize = true)
+      model2.setEvaluateStatus()
+
+      iteration = 0
+      while (iteration < param.iteration) {
+        val start = System.nanoTime()
+        model2.forward(singleInput)
+        val latency = System.nanoTime() - start
+        logger.info(s"Iteration $iteration, latency is ${latency / 1e6} ms")
+
+        iteration += 1
+      }
+    }
+  }
+}

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Perf.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Perf.scala
@@ -24,9 +24,9 @@ import org.apache.log4j.Logger
 import scopt.OptionParser
 
 
-case class ResNet50PerfParams(model: String = "",
-                              batchSize: Int = 32,
-                              iteration: Int = 1000)
+case class PerfParams(model: String = "",
+                      batchSize: Int = 32,
+                      iteration: Int = 1000)
 
 object Perf {
 
@@ -36,7 +36,7 @@ object Perf {
     System.setProperty("bigdl.localMode", "true")
     System.setProperty("bigdl.engineType", "mkldnn")
 
-    val parser = new OptionParser[ResNet50PerfParams]("ResNet50 Int8 Performance Test") {
+    val parser = new OptionParser[PerfParams]("ResNet50 Int8 Performance Test") {
       opt[String]('m', "model")
         .text("The path to the int8 quantized ResNet50 model snapshot")
         .action((v, p) => p.copy(model = v))
@@ -49,7 +49,7 @@ object Perf {
         .action((v, p) => p.copy(iteration = v))
     }
 
-    parser.parse(args, ResNet50PerfParams()).foreach { param =>
+    parser.parse(args, PerfParams()).foreach { param =>
       val batchSize = param.batchSize
       val batchInput = Tensor(Array(batchSize, 3, 224, 224)).rand()
       val singleInput = Tensor(Array(1, 3, 224, 224)).rand()

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Perf.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Perf.scala
@@ -55,7 +55,7 @@ object Perf {
       val singleInput = Tensor(Array(1, 3, 224, 224)).rand()
       Engine.init
 
-      val model = ImageClassifier.loadModel[Float](param.model, quantize = true)
+      val model = ImageClassifier.loadModel[Float](param.model)
       model.setEvaluateStatus()
 
       var iteration = 0
@@ -69,7 +69,7 @@ object Perf {
         iteration += 1
       }
 
-      val model2 = ImageClassifier.loadModel[Float](param.model, quantize = true)
+      val model2 = ImageClassifier.loadModel[Float](param.model)
       model2.setEvaluateStatus()
 
       iteration = 0

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Perf.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Perf.scala
@@ -37,14 +37,15 @@ object Perf {
 
     val parser = new OptionParser[PerfParams]("ResNet50 Int8 Performance Test") {
       opt[String]('m', "model")
-        .text("The path to the int8 quantized ResNet50 model snapshot")
+        .text("The path to the pre-trained int8 ResNet50 model snapshot")
         .action((v, p) => p.copy(model = v))
         .required()
       opt[Int]('b', "batchSize")
-        .text("Batch size of input data")
+        .text("The batch size of input data")
         .action((v, p) => p.copy(batchSize = v))
       opt[Int]('i', "iteration")
-        .text("Iteration of perf test. The result will be average of each iteration time cost")
+        .text("The number of iterations to run the perf test. " +
+          "The result will be the average of each iteration time cost")
         .action((v, p) => p.copy(iteration = v))
     }
 
@@ -63,8 +64,8 @@ object Perf {
         model.forward(batchInput)
         val timeUsed = System.nanoTime() - start
         val throughput = "%.2f".format(batchSize.toFloat / (timeUsed / 1e9))
-        logger.info(s"Iteration $iteration, takes $timeUsed ns, throughput is $throughput imgs/sec")
-
+        logger.info(s"Iteration $iteration, batch $batchSize, takes $timeUsed ns, " +
+          s"throughput is $throughput imgs/sec")
         iteration += 1
       }
 
@@ -76,8 +77,7 @@ object Perf {
         val start = System.nanoTime()
         model2.forward(singleInput)
         val latency = System.nanoTime() - start
-        logger.info(s"Iteration $iteration, latency is ${latency / 1e6} ms")
-
+        logger.info(s"Iteration $iteration, latency for a single image is ${latency / 1e6} ms")
         iteration += 1
       }
     }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Perf.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Perf.scala
@@ -23,7 +23,6 @@ import com.intel.analytics.zoo.models.image.imageclassification.ImageClassifier
 import org.apache.log4j.Logger
 import scopt.OptionParser
 
-
 case class PerfParams(model: String = "",
                       batchSize: Int = 32,
                       iteration: Int = 1000)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Predict.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Predict.scala
@@ -56,7 +56,7 @@ object Predict {
     parser.parse(args, ImageClassificationParams()).map(param => {
       val sc = NNContext.initNNContext("ResNet50 Int8 Inference Example")
       val images = ImageSet.read(param.folder)
-      val model = ImageClassifier.loadModel[Float](param.model, quantize = true)
+      val model = ImageClassifier.loadModel[Float](param.model)
       val output = model.predictImageSet(images)
       val labelOutput = LabelOutput(model.getConfig().labelMap, "clses",
         "probs", probAsInput = false)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Predict.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Predict.scala
@@ -22,10 +22,10 @@ import com.intel.analytics.zoo.models.image.imageclassification.{ImageClassifier
 import org.apache.log4j.{Level, Logger}
 import scopt.OptionParser
 
-case class ImageClassificationParams(folder: String = "./",
-                                     model: String = "",
-                                     topN: Int = 5,
-                                     partitionNum: Int = 4)
+case class PredictParams(folder: String = "./",
+                         model: String = "",
+                         topN: Int = 5,
+                         partitionNum: Int = 4)
 
 object Predict {
   Logger.getLogger("org").setLevel(Level.ERROR)
@@ -37,7 +37,7 @@ object Predict {
 
   def main(args: Array[String]): Unit = {
     System.setProperty("bigdl.engineType", "mkldnn")
-    val parser = new OptionParser[ImageClassificationParams]("ResNet50 Int8 Inference Example") {
+    val parser = new OptionParser[PredictParams]("ResNet50 Int8 Inference Example") {
       opt[String]('f', "folder")
         .text("The path to the image data")
         .action((x, c) => c.copy(folder = x))
@@ -53,7 +53,7 @@ object Predict {
         .text("The number of partitions to cut the dataset into")
         .action((x, c) => c.copy(partitionNum = x))
     }
-    parser.parse(args, ImageClassificationParams()).map(param => {
+    parser.parse(args, PredictParams()).map(param => {
       val sc = NNContext.initNNContext("ResNet50 Int8 Inference Example")
       val images = ImageSet.read(param.folder)
       val model = ImageClassifier.loadModel[Float](param.model)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Predict.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Predict.scala
@@ -68,7 +68,7 @@ object Predict {
         val clses = imageFeature("clses").asInstanceOf[Array[String]]
         val probs = imageFeature("probs").asInstanceOf[Array[Float]]
         for (i <- 0 until param.topN) {
-          logger.info(s"\t class : ${clses(i)}, credit : ${probs(i)}")
+          logger.info(s"\t class: ${clses(i)}, credit: ${probs(i)}")
         }
       })
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Predict.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Predict.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 Analytics Zoo Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.zoo.examples.vnni.bigdl
+
+import com.intel.analytics.zoo.common.NNContext
+import com.intel.analytics.zoo.feature.image.ImageSet
+import com.intel.analytics.zoo.models.image.imageclassification.{ImageClassifier, LabelOutput}
+import org.apache.log4j.{Level, Logger}
+import scopt.OptionParser
+
+case class ImageClassificationParams(folder: String = "./",
+                                     model: String = "",
+                                     topN: Int = 5,
+                                     partitionNum: Int = 4)
+
+object Predict {
+  Logger.getLogger("org").setLevel(Level.ERROR)
+  Logger.getLogger("akka").setLevel(Level.ERROR)
+  Logger.getLogger("breeze").setLevel(Level.ERROR)
+  Logger.getLogger("com.intel.analytics.zoo").setLevel(Level.INFO)
+
+  val logger: Logger = Logger.getLogger(getClass)
+
+  def main(args: Array[String]): Unit = {
+    System.setProperty("bigdl.engineType", "mkldnn")
+    val parser = new OptionParser[ImageClassificationParams]("ResNet50 Int8 Inference Example") {
+      opt[String]('f', "folder")
+        .text("The path to the image data")
+        .action((x, c) => c.copy(folder = x))
+        .required()
+      opt[String]('m', "model")
+        .text("The path to the int8 quantized ResNet50 model snapshot")
+        .action((x, c) => c.copy(model = x))
+        .required()
+      opt[Int]("topN")
+        .text("top N number")
+        .action((x, c) => c.copy(topN = x))
+      opt[Int]("partitionNum")
+        .text("The number of partitions to cut the dataset into")
+        .action((x, c) => c.copy(partitionNum = x))
+    }
+    parser.parse(args, ImageClassificationParams()).map(param => {
+      val sc = NNContext.initNNContext("ResNet50 Int8 Inference Example")
+      val images = ImageSet.read(param.folder)
+      val model = ImageClassifier.loadModel[Float](param.model, quantize = true)
+      val output = model.predictImageSet(images)
+      val labelOutput = LabelOutput(model.getConfig().labelMap, "clses",
+        "probs", probAsInput = false)
+      val result = labelOutput(output).toLocal().array
+
+      logger.info(s"Prediction result")
+      result.foreach(imageFeature => {
+        logger.info(s"image : ${imageFeature.uri}, top ${param.topN}")
+        val clses = imageFeature("clses").asInstanceOf[Array[String]]
+        val probs = imageFeature("probs").asInstanceOf[Array[Float]]
+        for (i <- 0 until param.topN) {
+          logger.info(s"\t class : ${clses(i)}, credit : ${probs(i)}")
+        }
+      })
+
+      sc.stop()
+    })
+  }
+}

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageChannelScaledNormalizer.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageChannelScaledNormalizer.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Analytics Zoo Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.zoo.feature.image
+
+import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
+import com.intel.analytics.bigdl.transform.vision.image.augmentation.ChannelScaledNormalizer
+
+
+class ImageChannelScaledNormalizer(meanR: Int, meanG: Int,
+                                   meanB: Int, scale: Double) extends ImageProcessing {
+
+  private val internalChannelScaledNormalizer = InternalChannelScaledNormalizer(meanR,
+    meanG, meanB, scale)
+  override def apply(prev: Iterator[ImageFeature]): Iterator[ImageFeature] = {
+    internalChannelScaledNormalizer.apply(prev)
+  }
+
+  override def transformMat(feature: ImageFeature): Unit = {
+    internalChannelScaledNormalizer.transformMat(feature)
+  }
+}
+
+object ImageChannelScaledNormalizer {
+  def apply(meanR: Int, meanG: Int,
+            meanB: Int, scale: Double): ImageChannelScaledNormalizer =
+    new ImageChannelScaledNormalizer(meanR, meanG, meanB, scale)
+
+}
+
+// transformMat in BigDL RandomCropper is protected and can't be directly accessed.
+class InternalChannelScaledNormalizer(meanR: Int, meanG: Int, meanB: Int, scale: Double)
+  extends ChannelScaledNormalizer(meanR, meanG, meanB, scale) {
+
+  override def transformMat(feature: ImageFeature): Unit = {
+    super.transformMat(feature)
+  }
+}
+
+object InternalChannelScaledNormalizer {
+  def apply(meanR: Int, meanG: Int, meanB: Int, scale: Double): InternalChannelScaledNormalizer = {
+    new InternalChannelScaledNormalizer(meanR, meanG, meanB, scale)
+  }
+}

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageChannelScaledNormalizer.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageChannelScaledNormalizer.scala
@@ -19,12 +19,19 @@ package com.intel.analytics.zoo.feature.image
 import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
 import com.intel.analytics.bigdl.transform.vision.image.augmentation.ChannelScaledNormalizer
 
-
+/**
+ * Channel normalization with scale factor.
+ *
+ * @param meanR Integer. The mean value for channel R.
+ * @param meanG Integer. The mean value for channel G.
+ * @param meanB Integer. The mean value for channel R.
+ * @param scale Double. The scale value applied for all channels.
+ */
 class ImageChannelScaledNormalizer(meanR: Int, meanG: Int,
                                    meanB: Int, scale: Double) extends ImageProcessing {
-
-  private val internalTransformer = InternalChannelScaledNormalizer(meanR,
+  private val internalTransformer = new InternalChannelScaledNormalizer(meanR,
     meanG, meanB, scale)
+
   override def apply(prev: Iterator[ImageFeature]): Iterator[ImageFeature] = {
     internalTransformer.apply(prev)
   }
@@ -36,22 +43,18 @@ class ImageChannelScaledNormalizer(meanR: Int, meanG: Int,
 
 object ImageChannelScaledNormalizer {
   def apply(meanR: Int, meanG: Int,
-            meanB: Int, scale: Double): ImageChannelScaledNormalizer =
+            meanB: Int, scale: Double): ImageChannelScaledNormalizer = {
     new ImageChannelScaledNormalizer(meanR, meanG, meanB, scale)
-
+  }
 }
 
 // transformMat in BigDL RandomCropper is protected and can't be directly accessed.
-class InternalChannelScaledNormalizer(meanR: Int, meanG: Int, meanB: Int, scale: Double)
+// Thus add an InternalChannelScaledNormalizer here to override transformMat and make it accessible.
+private[image] class InternalChannelScaledNormalizer(meanR: Int, meanG: Int,
+                                                     meanB: Int, scale: Double)
   extends ChannelScaledNormalizer(meanR, meanG, meanB, scale) {
 
   override def transformMat(feature: ImageFeature): Unit = {
     super.transformMat(feature)
-  }
-}
-
-object InternalChannelScaledNormalizer {
-  def apply(meanR: Int, meanG: Int, meanB: Int, scale: Double): InternalChannelScaledNormalizer = {
-    new InternalChannelScaledNormalizer(meanR, meanG, meanB, scale)
   }
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageChannelScaledNormalizer.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageChannelScaledNormalizer.scala
@@ -23,14 +23,14 @@ import com.intel.analytics.bigdl.transform.vision.image.augmentation.ChannelScal
 class ImageChannelScaledNormalizer(meanR: Int, meanG: Int,
                                    meanB: Int, scale: Double) extends ImageProcessing {
 
-  private val internalChannelScaledNormalizer = InternalChannelScaledNormalizer(meanR,
+  private val internalTransformer = InternalChannelScaledNormalizer(meanR,
     meanG, meanB, scale)
   override def apply(prev: Iterator[ImageFeature]): Iterator[ImageFeature] = {
-    internalChannelScaledNormalizer.apply(prev)
+    internalTransformer.apply(prev)
   }
 
   override def transformMat(feature: ImageFeature): Unit = {
-    internalChannelScaledNormalizer.transformMat(feature)
+    internalTransformer.transformMat(feature)
   }
 }
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageRandomCropper.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageRandomCropper.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Analytics Zoo Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.zoo.feature.image
+
+import com.intel.analytics.bigdl.dataset.image.{CropRandom, CropperMethod}
+import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
+import com.intel.analytics.bigdl.transform.vision.image.augmentation.RandomCropper
+
+class ImageRandomCropper(cropWidth: Int, cropHeight: Int,
+                         mirror: Boolean, cropperMethod: CropperMethod = CropRandom,
+                         channels: Int = 3) extends ImageProcessing {
+
+  private val internalRandomCropper = InternalRandomCropper(cropWidth, cropHeight,
+    mirror, cropperMethod, channels)
+  override def apply(prev: Iterator[ImageFeature]): Iterator[ImageFeature] = {
+    internalRandomCropper.apply(prev)
+  }
+
+  override def transformMat(feature: ImageFeature): Unit = {
+    internalRandomCropper.transformMat(feature)
+  }
+}
+
+object ImageRandomCropper {
+  def apply(cropWidth: Int, cropHeight: Int,
+            mirror: Boolean, cropperMethod: CropperMethod = CropRandom,
+            channels: Int = 3): ImageRandomCropper =
+    new ImageRandomCropper(cropWidth, cropHeight, mirror, cropperMethod, channels)
+}
+
+// transformMat in BigDL RandomCropper is protected and can't be directly accessed.
+class InternalRandomCropper(cropWidth: Int, cropHeight: Int,
+                            mirror: Boolean, cropperMethod: CropperMethod = CropRandom,
+                            channels: Int = 3)
+  extends RandomCropper(cropWidth, cropHeight, mirror, cropperMethod, channels) {
+
+  override def transformMat(feature: ImageFeature): Unit = {
+    super.transformMat(feature)
+  }
+}
+
+object InternalRandomCropper {
+  def apply(cropWidth: Int, cropHeight: Int,
+            mirror: Boolean, cropperMethod: CropperMethod = CropRandom,
+            channels: Int = 3): InternalRandomCropper =
+    new InternalRandomCropper(cropHeight, cropWidth, mirror, cropperMethod, channels)
+}

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageRandomCropper.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageRandomCropper.scala
@@ -20,12 +20,20 @@ import com.intel.analytics.bigdl.dataset.image.{CropRandom, CropperMethod}
 import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
 import com.intel.analytics.bigdl.transform.vision.image.augmentation.RandomCropper
 
+/**
+ * Random cropper on uniform distribution with fixed height and width.
+ *
+ * @param cropWidth Integer. Width to be cropped to.
+ * @param cropHeight Integer. Height to be cropped to.
+ * @param mirror Boolean. Whether to do mirror.
+ * @param cropperMethod An instance of [[CropperMethod]]. Default is [[CropRandom]].
+ */
 class ImageRandomCropper(cropWidth: Int, cropHeight: Int,
                          mirror: Boolean, cropperMethod: CropperMethod = CropRandom,
                          channels: Int = 3) extends ImageProcessing {
-
-  private val internalTransformer = InternalRandomCropper(cropWidth, cropHeight,
+  private val internalTransformer = new InternalRandomCropper(cropWidth, cropHeight,
     mirror, cropperMethod, channels)
+
   override def apply(prev: Iterator[ImageFeature]): Iterator[ImageFeature] = {
     internalTransformer.apply(prev)
   }
@@ -38,12 +46,14 @@ class ImageRandomCropper(cropWidth: Int, cropHeight: Int,
 object ImageRandomCropper {
   def apply(cropWidth: Int, cropHeight: Int,
             mirror: Boolean, cropperMethod: CropperMethod = CropRandom,
-            channels: Int = 3): ImageRandomCropper =
+            channels: Int = 3): ImageRandomCropper = {
     new ImageRandomCropper(cropWidth, cropHeight, mirror, cropperMethod, channels)
+  }
 }
 
 // transformMat in BigDL RandomCropper is protected and can't be directly accessed.
-class InternalRandomCropper(cropWidth: Int, cropHeight: Int,
+// Thus add an InternalRandomCropper here to override transformMat and make it accessible.
+private[image] class InternalRandomCropper(cropWidth: Int, cropHeight: Int,
                             mirror: Boolean, cropperMethod: CropperMethod = CropRandom,
                             channels: Int = 3)
   extends RandomCropper(cropWidth, cropHeight, mirror, cropperMethod, channels) {
@@ -51,11 +61,4 @@ class InternalRandomCropper(cropWidth: Int, cropHeight: Int,
   override def transformMat(feature: ImageFeature): Unit = {
     super.transformMat(feature)
   }
-}
-
-object InternalRandomCropper {
-  def apply(cropWidth: Int, cropHeight: Int,
-            mirror: Boolean, cropperMethod: CropperMethod = CropRandom,
-            channels: Int = 3): InternalRandomCropper =
-    new InternalRandomCropper(cropHeight, cropWidth, mirror, cropperMethod, channels)
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageRandomCropper.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageRandomCropper.scala
@@ -24,14 +24,14 @@ class ImageRandomCropper(cropWidth: Int, cropHeight: Int,
                          mirror: Boolean, cropperMethod: CropperMethod = CropRandom,
                          channels: Int = 3) extends ImageProcessing {
 
-  private val internalRandomCropper = InternalRandomCropper(cropWidth, cropHeight,
+  private val internalTransformer = InternalRandomCropper(cropWidth, cropHeight,
     mirror, cropperMethod, channels)
   override def apply(prev: Iterator[ImageFeature]): Iterator[ImageFeature] = {
-    internalRandomCropper.apply(prev)
+    internalTransformer.apply(prev)
   }
 
   override def transformMat(feature: ImageFeature): Unit = {
-    internalRandomCropper.transformMat(feature)
+    internalTransformer.transformMat(feature)
   }
 }
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageRandomResize.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageRandomResize.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Analytics Zoo Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.zoo.feature.image
+
+import com.intel.analytics.bigdl.transform.vision.image.augmentation.RandomResize
+import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
+
+class ImageRandomResize(minSize: Int, maxSize : Int) extends ImageProcessing {
+
+  private val internalRandomResize = RandomResize(minSize, maxSize)
+  override def apply(prev: Iterator[ImageFeature]): Iterator[ImageFeature] = {
+    internalRandomResize.apply(prev)
+  }
+
+  override def transformMat(feature: ImageFeature): Unit = {
+    internalRandomResize.transformMat(feature)
+  }
+}
+
+object ImageRandomResize {
+  def apply(minSize: Int, maxSize : Int): ImageRandomResize =
+    new ImageRandomResize(minSize, maxSize)
+}

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageRandomResize.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageRandomResize.scala
@@ -21,13 +21,13 @@ import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
 
 class ImageRandomResize(minSize: Int, maxSize : Int) extends ImageProcessing {
 
-  private val internalRandomResize = RandomResize(minSize, maxSize)
+  private val internalTransformer = RandomResize(minSize, maxSize)
   override def apply(prev: Iterator[ImageFeature]): Iterator[ImageFeature] = {
-    internalRandomResize.apply(prev)
+    internalTransformer.apply(prev)
   }
 
   override def transformMat(feature: ImageFeature): Unit = {
-    internalRandomResize.transformMat(feature)
+    internalTransformer.transformMat(feature)
   }
 }
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageRandomResize.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageRandomResize.scala
@@ -19,9 +19,16 @@ package com.intel.analytics.zoo.feature.image
 import com.intel.analytics.bigdl.transform.vision.image.augmentation.RandomResize
 import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
 
+/**
+ * Randomly resize an image between minSize and maxSize and
+ * scale height and width to each other.
+ *
+ * @param minSize Integer. The minimum size to resize to.
+ * @param maxSize Integer. The maximum size to resize to.
+ */
 class ImageRandomResize(minSize: Int, maxSize : Int) extends ImageProcessing {
-
   private val internalTransformer = RandomResize(minSize, maxSize)
+
   override def apply(prev: Iterator[ImageFeature]): Iterator[ImageFeature] = {
     internalTransformer.apply(prev)
   }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageSet.scala
@@ -18,13 +18,16 @@ package com.intel.analytics.zoo.feature.image
 
 import java.io.File
 
+import java.nio.ByteBuffer
+
 import com.intel.analytics.bigdl.DataSet
-import com.intel.analytics.bigdl.dataset.DataSet.ImageFolder
+import com.intel.analytics.bigdl.dataset.DataSet.SeqFileFolder.readLabel
 import com.intel.analytics.bigdl.dataset._
 import com.intel.analytics.bigdl.transform.vision.image._
 import com.intel.analytics.zoo.common.Utils
 import com.intel.analytics.zoo.feature.common.Preprocessing
 import org.apache.commons.io.FileUtils
+import org.apache.hadoop.io.Text
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.opencv.imgcodecs.Imgcodecs
@@ -35,9 +38,7 @@ import java.nio.file.{Files, Paths}
 
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.T
-import org.apache.hadoop.fs.{LocatedFileStatus, Path}
-
-import scala.collection.mutable.ArrayBuffer
+import org.apache.hadoop.fs.Path
 
 /**
  * ImageSet wraps a set of ImageFeature
@@ -315,6 +316,24 @@ object ImageSet {
       ImageSet.array(images)
     }
 
+  }
+
+  def readSeqFiles(path: String, sc: SparkContext,
+                   minPartitions: Int = 1, classNum: Int = 1000): DistributedImageSet = {
+    val images = sc.sequenceFile(path, classOf[Text], classOf[Text], minPartitions).map(image => {
+      val rawBytes = image._2.copyBytes()
+      val label = Tensor[Float](T(readLabel(image._1).toFloat))
+      val imgBuffer = ByteBuffer.wrap(rawBytes)
+      val width = imgBuffer.getInt
+      val height = imgBuffer.getInt
+      val bytes = new Array[Byte](3 * width * height)
+      System.arraycopy(imgBuffer.array(), 8, bytes, 0, bytes.length)
+      val imf = ImageFeature(bytes, label)
+      imf(ImageFeature.originalSize) = (height, width, 3)
+      imf
+    }).filter(_[Tensor[Float]](ImageFeature.label).valueAt(1) <= classNum)
+    val imageSet = ImageSet.rdd(images)
+    (imageSet -> ImagePixelBytesToMat()).toDistributed()
   }
 
   /**

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageSet.scala
@@ -318,8 +318,19 @@ object ImageSet {
 
   }
 
-  def readSeqFiles(path: String, sc: SparkContext,
-                   minPartitions: Int = 1, classNum: Int = 1000): DistributedImageSet = {
+  /**
+   * Read images (with labels) from Hadoop SequenceFiles as ImageSet.
+   *
+   * @param path The folder path that contains sequence files.
+   *             Local or distributed file system (such as HDFS) are supported.
+   * @param sc An instance of SparkContext.
+   * @param minPartitions Integer. A suggestion value of the minimal partition number for input
+   *                      texts. Default is 1.
+   * @param classNum Integer. The number of image categories. Default is 1000 for ImageNet.
+   * @return DistributedImageSet.
+   */
+  def readSequenceFiles(path: String, sc: SparkContext,
+                        minPartitions: Int = 1, classNum: Int = 1000): DistributedImageSet = {
     val images = sc.sequenceFile(path, classOf[Text], classOf[Text], minPartitions).map(image => {
       val rawBytes = image._2.copyBytes()
       val label = Tensor[Float](T(readLabel(image._1).toFloat))

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageSetToSample.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageSetToSample.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.zoo.feature.image
 import com.intel.analytics.bigdl.dataset.ArraySample
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
-import com.intel.analytics.bigdl.transform.vision.image.{FeatureTransformer, ImageFeature}
+import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
 import org.apache.log4j.Logger
 
 import scala.reflect.ClassTag

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageSetToSample.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageSetToSample.scala
@@ -48,6 +48,10 @@ class ImageSetToSample[T: ClassTag](inputKeys: Array[String] = Array(ImageFeatur
       val sample = if (targetKeys == null) {
         ArraySample[T](inputs)
       } else {
+        // If an ImageFeature doesn't contain the specified target(s), the result Sample
+        // won't contain labels.
+        // In this case the same preprocessor for ImageModels can both handle images with labels
+        // (for evaluation) or without labels (for inference).
         val targets = targetKeys.flatMap(key => {
           if (feature.contains(key)) {
             val target = feature[Tensor[T]](key)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/image/common/ImageModel.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/image/common/ImageModel.scala
@@ -16,8 +16,10 @@
 
 package com.intel.analytics.zoo.models.image.common
 
+import com.intel.analytics.bigdl.dataset.SampleToMiniBatch
 import com.intel.analytics.bigdl.nn.Module
 import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.optim.{ValidationMethod, ValidationResult}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.zoo.feature.image.ImageSet
 import com.intel.analytics.zoo.models.common.ZooModel
@@ -47,7 +49,7 @@ abstract class ImageModel[T: ClassTag]()(implicit ev: TensorNumeric[T])
     val predictConfig = if (null == configure) config else configure
 
     val result = if (predictConfig == null) {
-      ImageSet.fromImageFrame(predictImage(image.toImageFrame()))
+      ImageSet.fromImageFrame(model.predictImage(image.toImageFrame()))
     } else {
       // apply preprocessing if preProcessor is defined
       val data = if (null != predictConfig.preProcessor) {
@@ -56,8 +58,9 @@ abstract class ImageModel[T: ClassTag]()(implicit ev: TensorNumeric[T])
         image
       }
 
-      val imageSet = ImageSet.fromImageFrame(predictImage(data.toImageFrame(), batchPerPartition =
-        predictConfig.batchPerPartition, featurePaddingParam = predictConfig.featurePaddingParam))
+      val imageSet = ImageSet.fromImageFrame(model.predictImage(data.toImageFrame(),
+        batchPerPartition = predictConfig.batchPerPartition,
+        featurePaddingParam = predictConfig.featurePaddingParam))
 
       if (null != predictConfig.postProcessor) {
         imageSet -> predictConfig.postProcessor
@@ -65,6 +68,26 @@ abstract class ImageModel[T: ClassTag]()(implicit ev: TensorNumeric[T])
       else imageSet
     }
     result
+  }
+
+  def evaluateImageSet(
+     image: ImageSet,
+     batchSize: Int,
+     vMethods: Array[_ <:ValidationMethod[T]],
+     configure: ImageConfigure[T] = null): Array[(ValidationResult, ValidationMethod[T])] = {
+    val evalConfig = if (null == configure) config else configure
+
+    if (evalConfig == null) {
+      model.evaluateImage(image.toImageFrame(), vMethods, Some(batchSize))
+    } else {
+      val data = if (null != evalConfig.preProcessor) {
+        image -> evalConfig.preProcessor
+      } else {
+        image
+      }
+      val dataset = data.toDataSet[T]() -> SampleToMiniBatch[T](batchSize)
+      model.evaluate(dataset.toDistributed().data(train = false), vMethods)
+    }
   }
 
   def getConfig(): ImageConfigure[T] = config
@@ -85,9 +108,12 @@ object ImageModel {
    * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now.
    * @return
    */
-  def loadModel[T: ClassTag](path: String, weightPath: String = null, modelType: String = "")
+  def loadModel[T: ClassTag](path: String, weightPath: String = null, modelType: String = "",
+                             quantize: Boolean = false)
     (implicit ev: TensorNumeric[T]): ImageModel[T] = {
-    val model = Module.loadModule[T](path, weightPath)
+    var model = Module.loadModule[T](path, weightPath)
+    val modelName = model.getName()
+    if (quantize) model = model.quantize()
     val imageModel = if (model.isInstanceOf[ImageModel[T]]) {
       model.asInstanceOf[ImageModel[T]]
     } else {
@@ -101,9 +127,9 @@ object ImageModel {
               s"Only 'imageclassification' and 'objectdetection' are currently supported.")
       }
       specificModel.addModel(model)
-      specificModel.setName(model.getName())
+      specificModel.setName(modelName)
     }
-    imageModel.config = ImageConfigure.parse(model.getName())
+    imageModel.config = ImageConfigure.parse(modelName)
     imageModel
   }
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationConfig.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationConfig.scala
@@ -18,6 +18,7 @@ package com.intel.analytics.zoo.models.image.imageclassification
 
 import java.net.URL
 
+import com.intel.analytics.bigdl.dataset.image.CropCenter
 import com.intel.analytics.bigdl.numeric.NumericFloat
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
@@ -37,6 +38,7 @@ object ImageClassificationConfig {
     "inception-v3-quantize",
     "resnet-50",
     "resnet-50-quantize",
+    "resnet-50-int8",
     "vgg-16",
     "vgg-16-quantize",
     "vgg-19",
@@ -79,6 +81,8 @@ object ImagenetConfig {
         labelMap = imagenetLabelMap)
       case "resnet-50" |
            "resnet-50-quantize" => ImageConfigure(preProcessor = resnetPreprocessor,
+        labelMap = imagenetLabelMap)
+      case "resnet-50-int8" => ImageConfigure(preProcessor = resnetNewPreprocessor,
         labelMap = imagenetLabelMap)
       case "vgg-16" |
            "vgg-16-quantize" => ImageConfigure(preProcessor = vggPreprocessor,
@@ -127,6 +131,13 @@ object ImagenetConfig {
 
   def resnetPreprocessor() : Preprocessing[ImageFeature, ImageFeature] = {
     commonPreprocessor(Consts.IMAGENET_RESIZE, 224, 123, 117, 104)
+  }
+
+  def resnetNewPreprocessor(): Preprocessing[ImageFeature, ImageFeature] = {
+      ImageRandomResize(256, 256) ->
+      ImageRandomCropper(224, 224, false, CropCenter) ->
+      ImageChannelScaledNormalizer(104, 117, 123, 0.0078125) ->
+      ImageMatToTensor() -> ImageSetToSample(targetKeys = Array("label"))
   }
 
   def vggPreprocessor(): Preprocessing[ImageFeature, ImageFeature] = {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationConfig.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationConfig.scala
@@ -82,7 +82,7 @@ object ImagenetConfig {
       case "resnet-50" |
            "resnet-50-quantize" => ImageConfigure(preProcessor = resnetPreprocessor,
         labelMap = imagenetLabelMap)
-      case "resnet-50-int8" => ImageConfigure(preProcessor = resnetNewPreprocessor,
+      case "resnet-50-int8" => ImageConfigure(preProcessor = bigdlResNetPreprocessor,
         labelMap = imagenetLabelMap)
       case "vgg-16" |
            "vgg-16-quantize" => ImageConfigure(preProcessor = vggPreprocessor,
@@ -129,15 +129,17 @@ object ImagenetConfig {
     commonPreprocessor(320, 299, 128, 128, 128, 128, 128, 128)
   }
 
+  // Preprocessor for ResNet50 pre-trained in Caffe
   def resnetPreprocessor() : Preprocessing[ImageFeature, ImageFeature] = {
     commonPreprocessor(Consts.IMAGENET_RESIZE, 224, 123, 117, 104)
   }
 
-  def resnetNewPreprocessor(): Preprocessing[ImageFeature, ImageFeature] = {
+  // Preprocessor for ResNet50 pre-trained in BigDL
+  def bigdlResNetPreprocessor(): Preprocessing[ImageFeature, ImageFeature] = {
       ImageRandomResize(256, 256) ->
-      ImageRandomCropper(224, 224, false, CropCenter) ->
+      ImageRandomCropper(224, 224, mirror = false, cropperMethod = CropCenter) ->
       ImageChannelScaledNormalizer(104, 117, 123, 0.0078125) ->
-      ImageMatToTensor() -> ImageSetToSample(targetKeys = Array("label"))
+      ImageMatToTensor() -> ImageSetToSample()
   }
 
   def vggPreprocessor(): Preprocessing[ImageFeature, ImageFeature] = {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassifier.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassifier.scala
@@ -47,9 +47,10 @@ object ImageClassifier {
    * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now.
    * @return
    */
-  def loadModel[T: ClassTag](path: String, weightPath: String = null)
+  def loadModel[T: ClassTag](path: String, weightPath: String = null, quantize: Boolean = false)
                             (implicit ev: TensorNumeric[T]): ImageClassifier[T] = {
-    ImageModel.loadModel(path, weightPath, "imageclassification").asInstanceOf[ImageClassifier[T]]
+    ImageModel.loadModel(path, weightPath, "imageclassification", quantize)
+      .asInstanceOf[ImageClassifier[T]]
   }
 
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassifier.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassifier.scala
@@ -16,12 +16,10 @@
 
 package com.intel.analytics.zoo.models.image.imageclassification
 
-import com.intel.analytics.bigdl.nn.Module
-
 import scala.reflect.ClassTag
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
-import com.intel.analytics.zoo.models.image.common.{ImageConfigure, ImageModel}
+import com.intel.analytics.zoo.models.image.common.ImageModel
 
 /**
  * An Image Classification model.
@@ -49,8 +47,7 @@ object ImageClassifier {
    */
   def loadModel[T: ClassTag](path: String, weightPath: String = null)
                             (implicit ev: TensorNumeric[T]): ImageClassifier[T] = {
-    ImageModel.loadModel(path, weightPath, "imageclassification")
-      .asInstanceOf[ImageClassifier[T]]
+    ImageModel.loadModel(path, weightPath, "imageclassification").asInstanceOf[ImageClassifier[T]]
   }
 
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassifier.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassifier.scala
@@ -47,9 +47,9 @@ object ImageClassifier {
    * @tparam T Numeric type of parameter(e.g. weight, bias). Only support float/double now.
    * @return
    */
-  def loadModel[T: ClassTag](path: String, weightPath: String = null, quantize: Boolean = false)
+  def loadModel[T: ClassTag](path: String, weightPath: String = null)
                             (implicit ev: TensorNumeric[T]): ImageClassifier[T] = {
-    ImageModel.loadModel(path, weightPath, "imageclassification", quantize)
+    ImageModel.loadModel(path, weightPath, "imageclassification")
       .asInstanceOf[ImageClassifier[T]]
   }
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/utils/Reflection.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/utils/Reflection.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.zoo.pipeline.api.keras.layers.utils
 
-import com.intel.analytics.bigdl.nn.Graph
+import com.intel.analytics.bigdl.nn.{Graph, MklInt8Convertible}
 import com.intel.analytics.bigdl.nn.Graph.ModuleNode
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
 import com.intel.analytics.bigdl.nn.keras.KerasLayer
@@ -24,6 +24,7 @@ import com.intel.analytics.bigdl.utils.{Engine, EngineType, Shape, Table}
 import com.intel.analytics.zoo.pipeline.api.keras.optimizers.Adam
 
 import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 
 object KerasLayerRef {
@@ -92,5 +93,11 @@ object EngineRef {
 object SGDRef {
   def getstate[T: ClassTag](instance: Adam[T]): Table = {
     KerasUtils.invokeMethod(instance, "state").asInstanceOf[Table]
+  }
+}
+
+object MklInt8ConvertibleRef {
+  def getWeightScalesBuffer(instance: MklInt8Convertible): ArrayBuffer[Array[Float]] = {
+    KerasUtils.invokeMethod(instance, "weightScalesBuffer").asInstanceOf[ArrayBuffer[Array[Float]]]
   }
 }

--- a/zoo/src/test/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationSpec.scala
@@ -170,7 +170,7 @@ class ImageClassifierSerialTest extends ModuleSerializationTest {
 
     val model = ImageClassifier.loadModel[Float](dirName + "/" + modelFileName)
     val input = Tensor[Float](Array(1, 3, 224, 224)).rand()
-    ZooSpecHelper.testZooModelLoadSave(model.asInstanceOf[ZooModel[Tensor[Float], Tensor[Float],
-     Float]], input, ImageClassifier.loadModel[Float])
+//    ZooSpecHelper.testZooModelLoadSave(model.asInstanceOf[ZooModel[Tensor[Float], Tensor[Float],
+//     Float]], input, ImageClassifier.loadModel[Float])
   }
 }

--- a/zoo/src/test/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationSpec.scala
@@ -170,7 +170,7 @@ class ImageClassifierSerialTest extends ModuleSerializationTest {
 
     val model = ImageClassifier.loadModel[Float](dirName + "/" + modelFileName)
     val input = Tensor[Float](Array(1, 3, 224, 224)).rand()
-//    ZooSpecHelper.testZooModelLoadSave(model.asInstanceOf[ZooModel[Tensor[Float], Tensor[Float],
-//     Float]], input, ImageClassifier.loadModel[Float])
+    ZooSpecHelper.testZooModelLoadSave(model.asInstanceOf[ZooModel[Tensor[Float], Tensor[Float],
+     Float]], input, ImageClassifier.loadModel[Float])
   }
 }


### PR DESCRIPTION
- Run calcScales with `resnet-50.bigdl` to get `resnet-50.quantized.bigdl`
- Convert to ZooModel `analytics-zoo_resnet-50-int8_imagenet_0.5.0.model` and add corresponding preprocessor in ImageClassifier.
- ImageNetInference example for accuracy test.
- Perf for performance test. Throughput should be correct accoriding to @i8run 
- Predict example, which is the same as ImageClassification except here we use int8 model.

Here for BigDL int8 example: https://github.com/intel-analytics/BigDL/tree/branch-0.8/spark/dl/src/main/scala/com/intel/analytics/bigdl/example/mkldnn/int8