### PR TITLE
Fix Net.load

### DIFF
--- a/pyzoo/test/zoo/pipeline/api/keras/test_net.py
+++ b/pyzoo/test/zoo/pipeline/api/keras/test_net.py
@@ -21,6 +21,7 @@ from keras.models import Sequential as KSequential
 from test.zoo.pipeline.utils.test_utils import ZooTestCase
 import zoo.pipeline.api.keras.layers as ZLayer
 from zoo.pipeline.api.keras.models import Model as ZModel
+from zoo.pipeline.api.keras.models import Sequential as ZSequential
 from zoo.pipeline.api.net import Net, TFNet
 from bigdl.nn.layer import Linear, Sigmoid, SoftMax, Model as BModel
 from bigdl.util.common import *
@@ -52,16 +53,47 @@ class TestLayer(ZooTestCase):
         model2.freeze_up_to(["conv2"])
         model2.unfreeze()
 
+    def test_deprecated_save(self):
+        with pytest.raises(Exception) as e_info:
+            input = ZLayer.Input(shape=(5,))
+            output = ZLayer.Dense(10)(input)
+            zmodel = ZModel(input, output, name="graph1")
+            zmodel.save(create_tmp_path())
+
+    def test_save_load_Model(self):
+        input = ZLayer.Input(shape=(5,))
+        output = ZLayer.Dense(10)(input)
+        zmodel = ZModel(input, output, name="graph1")
+        tmp_path = create_tmp_path()
+        zmodel.saveModel(tmp_path, None, True)
+        model_reloaded = Net.load(tmp_path)
+        input_data = np.random.random([10, 5])
+        y = np.random.random([10, 10])
+        model_reloaded.compile(optimizer="adam",
+                      loss="mse")
+        model_reloaded.fit(x=input_data, y=y, batch_size=8, nb_epoch=2)
+
+    def test_save_load_Sequential(self):
+        zmodel = ZSequential()
+        dense = ZLayer.Dense(10, input_dim=5)
+        zmodel.add(dense)
+        tmp_path = create_tmp_path()
+        zmodel.saveModel(tmp_path, None, True)
+        model_reloaded = Net.load(tmp_path)
+        input_data = np.random.random([10, 5])
+        y = np.random.random([10, 10])
+        model_reloaded.compile(optimizer="adam",
+                      loss="mse")
+        model_reloaded.fit(x=input_data, y=y, batch_size=8, nb_epoch=1)
+
+
     def test_load(self):
         input = ZLayer.Input(shape=(5,))
         output = ZLayer.Dense(10)(input)
         zmodel = ZModel(input, output, name="graph1")
-
         tmp_path = create_tmp_path()
         zmodel.saveModel(tmp_path, None, True)
-
         model_reloaded = Net.load(tmp_path)
-
         input_data = np.random.random([3, 5])
         self.compare_output_and_grad_input(zmodel, model_reloaded, input_data)
 

--- a/pyzoo/test/zoo/pipeline/api/keras/test_net.py
+++ b/pyzoo/test/zoo/pipeline/api/keras/test_net.py
@@ -70,7 +70,7 @@ class TestLayer(ZooTestCase):
         input_data = np.random.random([10, 5])
         y = np.random.random([10, 10])
         model_reloaded.compile(optimizer="adam",
-                      loss="mse")
+                               loss="mse")
         model_reloaded.fit(x=input_data, y=y, batch_size=8, nb_epoch=2)
 
     def test_save_load_Sequential(self):
@@ -83,9 +83,8 @@ class TestLayer(ZooTestCase):
         input_data = np.random.random([10, 5])
         y = np.random.random([10, 10])
         model_reloaded.compile(optimizer="adam",
-                      loss="mse")
+                               loss="mse")
         model_reloaded.fit(x=input_data, y=y, batch_size=8, nb_epoch=1)
-
 
     def test_load(self):
         input = ZLayer.Input(shape=(5,))

--- a/pyzoo/zoo/pipeline/api/keras/engine/topology.py
+++ b/pyzoo/zoo/pipeline/api/keras/engine/topology.py
@@ -27,8 +27,7 @@ if sys.version >= '3':
 
 
 class KerasNet(ZooKerasLayer):
-
-    def save(self, path, over_write = False):
+    def save(self, path, over_write=False):
         raise Exception("This is a deprecated method. Please use saveModel instead.")
 
     def saveModel(self, modelPath, weightPath=None, over_write=False):

--- a/pyzoo/zoo/pipeline/api/keras/engine/topology.py
+++ b/pyzoo/zoo/pipeline/api/keras/engine/topology.py
@@ -27,6 +27,24 @@ if sys.version >= '3':
 
 
 class KerasNet(ZooKerasLayer):
+
+    def save(self, path, over_write = False):
+        raise Exception("This is a deprecated method. Please use saveModel instead.")
+
+    def saveModel(self, modelPath, weightPath=None, over_write=False):
+        """
+        Save this module to path with protobuf format.
+        :param modelPath: The path to save module, local file system,
+                          HDFS and Amazon S3 is supported.
+                          HDFS path should be like "hdfs://[host]:[port]/xxx"
+                          Amazon S3 path should be like "s3a://bucket/xxx"
+        :param weightPath: The Path for the parameters
+        :param over_write: override the existing model on modelPath or not.
+        """
+        super(KerasNet, self).saveModel(modelPath=modelPath,
+                                        weightPath=weightPath,
+                                        over_write=over_write)
+
     def compile(self, optimizer, loss, metrics=None):
         """
         Configure the learning process. It MUST be called before fit or evaluate.

--- a/pyzoo/zoo/pipeline/api/net.py
+++ b/pyzoo/zoo/pipeline/api/net.py
@@ -111,7 +111,7 @@ class GraphNet(BModel):
 
 
 class JavaToPython:
-
+    # TODO: Add more mapping here as it only support Model and Sequential for now.
     def __init__(self, jvalue, bigdl_type="float"):
         self.jvaule = jvalue
         self.jfullname = callBigDlFunc(bigdl_type,

--- a/pyzoo/zoo/pipeline/api/net.py
+++ b/pyzoo/zoo/pipeline/api/net.py
@@ -115,8 +115,8 @@ class JavaToPython:
     def __init__(self, jvalue, bigdl_type="float"):
         self.jvaule = jvalue
         self.jfullname = callBigDlFunc(bigdl_type,
-                                  "getRealClassNameOfJValue",
-                                  jvalue)
+                                       "getRealClassNameOfJValue",
+                                       jvalue)
 
     def get_python_class(self):
         """

--- a/pyzoo/zoo/pipeline/api/net.py
+++ b/pyzoo/zoo/pipeline/api/net.py
@@ -24,6 +24,7 @@ import json
 import numpy as np
 from py4j.protocol import Py4JJavaError
 from pyspark import RDD
+import importlib
 
 from bigdl.nn.criterion import Criterion
 from bigdl.nn.layer import Model as BModel
@@ -109,7 +110,52 @@ class GraphNet(BModel):
         return ZooKerasLayer.of(value, self.bigdl_type)
 
 
+class JavaToPython:
+
+    def __init__(self, jvalue, bigdl_type="float"):
+        self.jvaule = jvalue
+        self.jfullname = callBigDlFunc(bigdl_type,
+                                  "getRealClassNameOfJValue",
+                                  jvalue)
+
+    def get_python_class(self):
+        """
+        Redirect the jvalue to the proper python class.
+        :param jvalue: Java object create by Py4j
+        :return: A proper Python wrapper which would be a Model, Sequential...
+        """
+
+        jpackage_name = ".".join(self.jfullname.split(".")[:-1])
+        pclass_name = self._get_py_name(self.jfullname.split(".")[-1])
+        base_module = self._load_ppackage_by_jpackage(jpackage_name)
+        if pclass_name in dir(base_module):
+            pclass = getattr(base_module, pclass_name)
+            assert "from_jvalue" in dir(pclass), \
+                "pclass: {} should implement from_jvalue method".format(pclass)
+            return pclass
+        raise Exception("No proper python class for: {}".format(self.jfullname))
+
+    def _get_py_name(self, jclass_name):
+        if jclass_name == "Model":
+            return "Model"
+        elif jclass_name == "Sequential":
+            return "Sequential"
+        else:
+            raise Exception("Not supported type: {}".format(jclass_name))
+
+    def _load_ppackage_by_jpackage(self, jpackage_name):
+        if "com.intel.analytics.zoo.pipeline.api.keras.models":
+            return importlib.import_module('zoo.pipeline.api.keras.models')
+        raise Exception("Not supported package: {}".format(jpackage_name))
+
+
 class Net:
+
+    @staticmethod
+    def from_jvalue(jvalue, bigdl_type="float"):
+        pclass = JavaToPython(jvalue).get_python_class()
+        return getattr(pclass, "from_jvalue")(jvalue, bigdl_type)
+
     @staticmethod
     def load_bigdl(model_path, weight_path=None, bigdl_type="float"):
         """
@@ -135,7 +181,7 @@ class Net:
         :return: An Analytics Zoo model.
         """
         jmodel = callBigDlFunc(bigdl_type, "netLoad", model_path, weight_path)
-        return KerasNet.of(jmodel, bigdl_type)
+        return Net.from_jvalue(jmodel, bigdl_type)
 
     @staticmethod
     def load_torch(path, bigdl_type="float"):

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/DenseSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/DenseSpec.scala
@@ -19,7 +19,6 @@ package com.intel.analytics.zoo.pipeline.api.keras.layers
 import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
-import com.intel.analytics.zoo.pipeline.api.Net
 import com.intel.analytics.zoo.pipeline.api.keras.models.{Model, Sequential}
 import com.intel.analytics.zoo.pipeline.api.keras.serializer.ModuleSerializationTest
 
@@ -42,13 +41,9 @@ class DenseSpec extends KerasBaseSpec {
     seq.add(input)
     val dense = Dense[Float](2, activation = "relu")
     seq.add(dense)
-    val modelPath = "/tmp/hello.model"
-    seq.saveModule(modelPath, overWrite=true)
-    val reloadedModel = Net.load[Float](modelPath)
-    reloadedModel
-//    seq.getOutputShape().toSingle().toArray should be (Array(-1, 2))
-//    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
-//      kerasCode, weightConverter)
+    seq.getOutputShape().toSingle().toArray should be (Array(-1, 2))
+    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+      kerasCode, weightConverter)
   }
 
   "Dense nD input" should "be the same as Keras" in {

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/DenseSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/DenseSpec.scala
@@ -19,6 +19,7 @@ package com.intel.analytics.zoo.pipeline.api.keras.layers
 import com.intel.analytics.bigdl.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Shape
+import com.intel.analytics.zoo.pipeline.api.Net
 import com.intel.analytics.zoo.pipeline.api.keras.models.{Model, Sequential}
 import com.intel.analytics.zoo.pipeline.api.keras.serializer.ModuleSerializationTest
 
@@ -41,9 +42,13 @@ class DenseSpec extends KerasBaseSpec {
     seq.add(input)
     val dense = Dense[Float](2, activation = "relu")
     seq.add(dense)
-    seq.getOutputShape().toSingle().toArray should be (Array(-1, 2))
-    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
-      kerasCode, weightConverter)
+    val modelPath = "/tmp/hello.model"
+    seq.saveModule(modelPath, overWrite=true)
+    val reloadedModel = Net.load[Float](modelPath)
+    reloadedModel
+//    seq.getOutputShape().toSingle().toArray should be (Array(-1, 2))
+//    checkOutputAndGrad(seq.asInstanceOf[AbstractModule[Tensor[Float], Tensor[Float], Float]],
+//      kerasCode, weightConverter)
   }
 
   "Dense nD input" should "be the same as Keras" in {


### PR DESCRIPTION
1)  User should use `model.saveModel` and exception would be raised if they use `model.save` accidentally.
2) `Net.load` should return a correct python class(Model or Sequential) rather than `KerasLayer` as we cannot use `fit` or `compile` for this type.
