### PR TITLE
Change RandomResize to Resize in ResNet50 preprocessor

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationConfig.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationConfig.scala
@@ -135,7 +135,7 @@ object ImagenetConfig {
 
   // Preprocessor for ResNet50 pre-trained in BigDL
   def bigdlResNetPreprocessor(): Preprocessing[ImageFeature, ImageFeature] = {
-      ImageRandomResize(256, 256) ->
+      ImageResize(256, 256) ->
       ImageCenterCrop(224, 224) ->
       ImageChannelScaledNormalizer(104, 117, 123, 0.0078125) ->
       ImageMatToTensor() -> ImageSetToSample()


### PR DESCRIPTION
Top1Accuracy is Accuracy(correct: 37902, count: 50000, accuracy: 0.75804)
Top5Accuracy is Accuracy(correct: 46357, count: 50000, accuracy: 0.92714)

Overall preprocessing latency is <2ms around 1.8ms.