### PR TITLE
Bug fix for Resize and change imagecodec in vnni predict

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/ImageNetEvaluation.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/ImageNetEvaluation.scala
@@ -53,7 +53,7 @@ object ImageNetEvaluation {
         .action((x, c) => c.copy(partitionNum = x))
     }
     parser.parse(args, ImageNetEvaluationParams()).map(param => {
-      val sc = NNContext.initNNContext("ImageNet2012 with Int8 Inference Example")
+      val sc = NNContext.initNNContext("ImageNet Evaluation Example with int8 quantized model")
       val images = ImageSet.readSequenceFiles(param.folder, sc, param.partitionNum)
       // If the actual partitionNum of sequence files is too large, then the
       // total batchSize we calculate (partitionNum * batchPerPartition) would be

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/ImageNetEvaluation.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/ImageNetEvaluation.scala
@@ -53,7 +53,7 @@ object ImageNetEvaluation {
         .action((x, c) => c.copy(partitionNum = x))
     }
     parser.parse(args, ImageNetEvaluationParams()).map(param => {
-      val sc = NNContext.initNNContext("ImageNet Evaluation Example with int8 quantized model")
+      val sc = NNContext.initNNContext("ImageNet evaluation example with int8 quantized model")
       val images = ImageSet.readSequenceFiles(param.folder, sc, param.partitionNum)
       // If the actual partitionNum of sequence files is too large, then the
       // total batchSize we calculate (partitionNum * batchPerPartition) would be

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Predict.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Predict.scala
@@ -20,6 +20,7 @@ import com.intel.analytics.bigdl.utils.Engine
 import com.intel.analytics.zoo.feature.image.ImageSet
 import com.intel.analytics.zoo.models.image.imageclassification.{ImageClassifier, LabelOutput}
 import org.apache.log4j.{Level, Logger}
+import org.opencv.imgcodecs.Imgcodecs
 import scopt.OptionParser
 
 case class PredictParams(folder: String = "./",
@@ -50,7 +51,7 @@ object Predict {
     }
     parser.parse(args, PredictParams()).map(param => {
       Engine.init
-      val images = ImageSet.read(param.folder)
+      val images = ImageSet.read(param.folder, imageCodec = Imgcodecs.CV_LOAD_IMAGE_UNCHANGED)
       val model = ImageClassifier.loadModel[Float](param.model)
       logger.info(s"Start inference on images under ${param.folder}...")
       val output = model.predictImageSet(images)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Predict.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Predict.scala
@@ -51,7 +51,7 @@ object Predict {
     }
     parser.parse(args, PredictParams()).map(param => {
       Engine.init
-      val images = ImageSet.read(param.folder, imageCodec = Imgcodecs.CV_LOAD_IMAGE_UNCHANGED)
+      val images = ImageSet.read(param.folder, imageCodec = Imgcodecs.CV_LOAD_IMAGE_COLOR)
       val model = ImageClassifier.loadModel[Float](param.model)
       logger.info(s"Start inference on images under ${param.folder}...")
       val output = model.predictImageSet(images)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageResize.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageResize.scala
@@ -25,7 +25,7 @@ class ImageResize(
     resizeMode: Int = Imgproc.INTER_LINEAR,
     useScaleFactor: Boolean = true) extends ImageProcessing {
 
-  private val internalResize = augmentation.Resize(resizeH, resizeW)
+  private val internalResize = augmentation.Resize(resizeH, resizeW, resizeMode, useScaleFactor)
   override def apply(prev: Iterator[ImageFeature]): Iterator[ImageFeature] = {
     internalResize.apply(prev)
   }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationConfig.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationConfig.scala
@@ -24,7 +24,6 @@ import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
 import com.intel.analytics.zoo.feature.common.Preprocessing
 import com.intel.analytics.zoo.feature.image._
 import com.intel.analytics.zoo.models.image.common.ImageConfigure
-import org.opencv.imgproc.Imgproc
 
 import scala.io.Source
 import scala.reflect.ClassTag

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationConfig.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationConfig.scala
@@ -136,7 +136,7 @@ object ImagenetConfig {
 
   // Preprocessor for ResNet50 pre-trained in BigDL
   def bigdlResNetPreprocessor(): Preprocessing[ImageFeature, ImageFeature] = {
-      ImageResize(256, 260, Imgproc.INTER_CUBIC) ->
+      ImageRandomResize(256, 256) ->
       ImageCenterCrop(224, 224) ->
       ImageChannelScaledNormalizer(104, 117, 123, 0.0078125) ->
       ImageMatToTensor() -> ImageSetToSample()

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationConfig.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationConfig.scala
@@ -24,6 +24,7 @@ import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
 import com.intel.analytics.zoo.feature.common.Preprocessing
 import com.intel.analytics.zoo.feature.image._
 import com.intel.analytics.zoo.models.image.common.ImageConfigure
+import org.opencv.imgproc.Imgproc
 
 import scala.io.Source
 import scala.reflect.ClassTag
@@ -135,7 +136,7 @@ object ImagenetConfig {
 
   // Preprocessor for ResNet50 pre-trained in BigDL
   def bigdlResNetPreprocessor(): Preprocessing[ImageFeature, ImageFeature] = {
-      ImageResize(256, 256) ->
+      ImageResize(256, 260, Imgproc.INTER_CUBIC) ->
       ImageCenterCrop(224, 224) ->
       ImageChannelScaledNormalizer(104, 117, 123, 0.0078125) ->
       ImageMatToTensor() -> ImageSetToSample()


### PR DESCRIPTION
- In ImageResize, resizeMode and useScaleFactor don't take effect.
- Change back to RandomResize... since @wzhongyuan said there's accuracy difference.
- Change Imagecodec to LOAD_IMAGE_COLOR so that both RGB and gray images can be supported by the model.