### PR TITLE
TextSet.fromRelations support for ranking/classification purposes

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextSet.scala
@@ -609,16 +609,16 @@ object TextSet {
                     corpus1: TextSet,
                     corpus2: TextSet): DistributedTextSet = {
 
-    def createClassificationTextFeature(qtf: TextFeature, atf: TextFeature, labelValue: Float) = {
+    def createClassificationTextFeature(qtf: TextFeature, atf: TextFeature, labelValue: Int) = {
 
       val classificationIndices = qtf.getIndices ++ atf.getIndices
 
       val feature = Tensor(classificationIndices, Array(classificationIndices.length))
-      val label = Tensor(Array(labelValue), Array(1))
+      val label = Tensor(Array(labelValue.toFloat), Array(1))
       val sample = Sample(feature, label)
 
       val textFeature = TextFeature(null, qtf.getURI + atf.getURI)
-      textFeature(TextFeature.label) = labelValue.toInt
+      textFeature(TextFeature.label) = labelValue
       textFeature(TextFeature.sample) = sample
       textFeature
     }
@@ -636,7 +636,7 @@ object TextSet {
           createClassificationTextFeature(
             text1,
             text2,
-            rel.label.toFloat
+            rel.label
           )
         }
 


### PR DESCRIPTION
At the moment TextSet doesn't provide methods to support joining two corpuses for the classification mode to train K-NRM.
This PR is adding `TextSet.fromRelations` to support K-NRM training in the classification mode (addionally to exist `TextSet.fromRelationPairs`).

Look at for details here: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/bigdl-user-group/_iTV9b5xiD4