### PR TITLE
Incremental Training for imagenet

### DIFF
--- a/pyzoo/zoo/feature/common.py
+++ b/pyzoo/zoo/feature/common.py
@@ -222,9 +222,10 @@ class FeatureSet(DataSet):
         :param memory_type: string, DRAM, PMEM or a Int number.
                             If it's DRAM, will cache dataset into dynamic random-access memory
                             If it's PMEM, will cache dataset into Intel Optane DC Persistent Memory
-                            If it's a Int number n, will cache dataset into disk, and only hold 1/n of
-                              the data into memory during the training. After going through the 1/n,
-                              we will release the current cache, and load another 1/n into memory.
+                            If it's a Int number n, will cache dataset into disk, and only hold 1/n
+                              of the data into memory during the training. After going through the
+                              1/n, we will release the current cache, and load another 1/n into
+                              memory.
         :param bigdl_type: numeric type
         :return: A feature set
         """
@@ -240,9 +241,10 @@ class FeatureSet(DataSet):
         :param memory_type: string, DRAM, PMEM or a Int number.
                             If it's DRAM, will cache dataset into dynamic random-access memory
                             If it's PMEM, will cache dataset into Intel Optane DC Persistent Memory
-                            If it's a Int number n, will cache dataset into disk, and only hold 1/n of
-                              the data into memory during the training. After going through the 1/n,
-                              we will release the current cache, and load another 1/n into memory.
+                            If it's a Int number n, will cache dataset into disk, and only hold 1/n
+                              of the data into memory during the training. After going through the
+                              1/n, we will release the current cache, and load another 1/n into
+                              memory.
         :param bigdl_type:numeric type
         :return: A feature set
         """

--- a/pyzoo/zoo/feature/common.py
+++ b/pyzoo/zoo/feature/common.py
@@ -219,9 +219,12 @@ class FeatureSet(DataSet):
         """
         Create FeatureSet from ImageFrame.
         :param image_frame: ImageFrame
-        :param memory_type: string, DRAM or PMEM
+        :param memory_type: string, DRAM, PMEM or a Int number.
                             If it's DRAM, will cache dataset into dynamic random-access memory
                             If it's PMEM, will cache dataset into Intel Optane DC Persistent Memory
+                            If it's a Int number n, will cache dataset into disk, and only hold 1/n of
+                              the data into memory during the training. After going throught the 1/n,
+                              we will release the current cache, and load another 1/n into memory.
         :param bigdl_type: numeric type
         :return: A feature set
         """
@@ -234,9 +237,12 @@ class FeatureSet(DataSet):
         """
         Create FeatureSet from RDD.
         :param rdd: A RDD
-        :param memory_type: string, DRAM or PMEM
+        :param memory_type: string, DRAM, PMEM or a Int number.
                             If it's DRAM, will cache dataset into dynamic random-access memory
                             If it's PMEM, will cache dataset into Intel Optane DC Persistent Memory
+                            If it's a Int number n, will cache dataset into disk, and only hold 1/n of
+                              the data into memory during the training. After going throught the 1/n,
+                              we will release the current cache, and load another 1/n into memory.
         :param bigdl_type:numeric type
         :return: A feature set
         """

--- a/pyzoo/zoo/feature/common.py
+++ b/pyzoo/zoo/feature/common.py
@@ -223,7 +223,7 @@ class FeatureSet(DataSet):
                             If it's DRAM, will cache dataset into dynamic random-access memory
                             If it's PMEM, will cache dataset into Intel Optane DC Persistent Memory
                             If it's a Int number n, will cache dataset into disk, and only hold 1/n of
-                              the data into memory during the training. After going throught the 1/n,
+                              the data into memory during the training. After going through the 1/n,
                               we will release the current cache, and load another 1/n into memory.
         :param bigdl_type: numeric type
         :return: A feature set
@@ -241,7 +241,7 @@ class FeatureSet(DataSet):
                             If it's DRAM, will cache dataset into dynamic random-access memory
                             If it's PMEM, will cache dataset into Intel Optane DC Persistent Memory
                             If it's a Int number n, will cache dataset into disk, and only hold 1/n of
-                              the data into memory during the training. After going throught the 1/n,
+                              the data into memory during the training. After going through the 1/n,
                               we will release the current cache, and load another 1/n into memory.
         :param bigdl_type:numeric type
         :return: A feature set

--- a/zoo/src/main/scala/com/intel/analytics/zoo/common/Optim.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/common/Optim.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Analytics Zoo Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.intel.analytics.zoo.common
 
 import com.intel.analytics.bigdl.optim.SGD

--- a/zoo/src/main/scala/com/intel/analytics/zoo/common/Optim.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/common/Optim.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Analytics Zoo Authors.
+ * Copyright 2018 Analytics Zoo Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/zoo/src/main/scala/com/intel/analytics/zoo/common/Optim.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/common/Optim.scala
@@ -6,6 +6,11 @@ import com.intel.analytics.bigdl.utils.Table
 import com.intel.analytics.zoo.pipeline.api.keras.models.{InternalOptimizerUtil}
 
 object Optim {
+
+  /**
+   * A fixed learning rate scheduler, always return the same learning rate
+   * @param lr learning rate
+   */
   case class Fixed(lr: Double) extends LearningRateSchedule {
     override def updateHyperParameter(config: Table, state: Table): Unit = {
       val nevals = state.get[Int]("evalCounter").getOrElse(0)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/common/Optim.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/common/Optim.scala
@@ -1,0 +1,23 @@
+package com.intel.analytics.zoo.common
+
+import com.intel.analytics.bigdl.optim.SGD
+import com.intel.analytics.bigdl.optim.SGD.LearningRateSchedule
+import com.intel.analytics.bigdl.utils.Table
+import com.intel.analytics.zoo.pipeline.api.keras.models.{InternalOptimizerUtil}
+
+object Optim {
+  case class Fixed(lr: Double) extends LearningRateSchedule {
+    override def updateHyperParameter(config: Table, state: Table): Unit = {
+      val nevals = state.get[Int]("evalCounter").getOrElse(0)
+      state("evalCounter") = nevals + 1
+      config("clr") = lr
+    }
+
+    override def updateHyperParameter[T](optimMethod: SGD[T]): Unit = {
+      val state = InternalOptimizerUtil.getStateFromOptiMethod[T](optimMethod)
+      val nevals = state.get[Int]("evalCounter").getOrElse(0)
+      state("evalCounter") = nevals + 1
+      currentRate = lr
+    }
+  }
+}

--- a/zoo/src/main/scala/com/intel/analytics/zoo/common/ZooTrigger.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/common/ZooTrigger.scala
@@ -36,12 +36,16 @@ case class EveryEpoch() extends ZooTrigger{
       if (state[Int]("epoch") <= lastEpoch) {
         false
       } else {
-        if (zooState.contains("numSlice") && zooState.contains("currentSlice")
-          && zooState[Int]("currentSlice") % zooState[Int]("numSlice") == 0) {
+        if (zooState.contains("numSlice") && zooState.contains("currentSlice")) {
+          if (zooState[Int]("currentSlice") % zooState[Int]("numSlice") == 0) {
+            lastEpoch = state[Int]("epoch")
+            true
+          } else {
+            false
+          }
+        } else {
           lastEpoch = state[Int]("epoch")
           true
-        } else {
-          false
         }
       }
     }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/common/ZooTrigger.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/common/ZooTrigger.scala
@@ -3,14 +3,22 @@ package com.intel.analytics.zoo.common
 import com.intel.analytics.bigdl.optim.Trigger
 import com.intel.analytics.bigdl.utils.{T, Table}
 
+/**
+ * A trigger specifies a timespot or several timespots during training,
+ * and a corresponding action will be taken when the timespot(s)
+ * is reached.
+ */
 trait ZooTrigger extends Trigger {
   protected var zooState: Table = T()
 
-  def setZooState(zooState: Table): Unit = {
+  /**
+   * We also hold some training metrics to control trigger.
+   * @param zooState zoo state table
+   */
+  private[Zoo] def setZooState(zooState: Table): Unit = {
     this.zooState = zooState
   }
 }
-
 
 /**
  * A trigger that triggers an action when each epoch finishs.
@@ -48,7 +56,7 @@ case class EveryEpoch() extends ZooTrigger{
  */
 case class SeveralIteration(interval: Int) extends ZooTrigger{
   override def apply(state: Table): Boolean = {
-    val curIteration = state[Int]("neval")
+    val curIteration = state[Int]("neval") - 1
     curIteration != 0 && curIteration % interval == 0
   }
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/common/ZooTrigger.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/common/ZooTrigger.scala
@@ -105,7 +105,15 @@ case class MinLoss(min: Float) extends ZooTrigger {
  * @param first first trigger
  * @param others others triggers
  */
-case class And(first : Trigger, others : Trigger*) extends ZooTrigger {
+case class And(first : ZooTrigger, others : ZooTrigger*) extends ZooTrigger {
+  override def setZooState(zooState: Table): Unit = {
+    super.setZooState(zooState)
+    first.setZooState(zooState)
+    others.foreach{zt =>
+      zt.setZooState(zooState)
+    }
+  }
+
   override def apply(state: Table): Boolean = {
     first.apply(state) && others.forall(_.apply(state))
   }
@@ -116,7 +124,15 @@ case class And(first : Trigger, others : Trigger*) extends ZooTrigger {
  * @param first first trigger
  * @param others others triggers
  */
-case class Or(first : Trigger, others : Trigger*) extends ZooTrigger {
+case class Or(first : ZooTrigger, others : ZooTrigger*) extends ZooTrigger {
+  override def setZooState(zooState: Table): Unit = {
+    super.setZooState(zooState)
+    first.setZooState(zooState)
+    others.foreach{zt =>
+      zt.setZooState(zooState)
+    }
+  }
+
   override def apply(state: Table): Boolean = {
     first.apply(state) || others.exists(_.apply(state))
   }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/common/ZooTrigger.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/common/ZooTrigger.scala
@@ -15,7 +15,7 @@ trait ZooTrigger extends Trigger {
    * We also hold some training metrics to control trigger.
    * @param zooState zoo state table
    */
-  private[Zoo] def setZooState(zooState: Table): Unit = {
+  private[zoo] def setZooState(zooState: Table): Unit = {
     this.zooState = zooState
   }
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/common/ZooTrigger.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/common/ZooTrigger.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Analytics Zoo Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.intel.analytics.zoo.common
 
 import com.intel.analytics.bigdl.optim.Trigger

--- a/zoo/src/main/scala/com/intel/analytics/zoo/common/ZooTrigger.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/common/ZooTrigger.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Analytics Zoo Authors.
+ * Copyright 2018 Analytics Zoo Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/ImageNet2012.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/ImageNet2012.scala
@@ -26,7 +26,7 @@ import com.intel.analytics.bigdl.transform.vision.image._
 import com.intel.analytics.bigdl.utils.{Engine, T}
 import com.intel.analytics.zoo.feature.image._
 import com.intel.analytics.zoo.feature.{DistributedFeatureSet, FeatureSet}
-import com.intel.analytics.zoo.feature.pmem.{DRAM, MemoryType, PMEM}
+import com.intel.analytics.zoo.feature.pmem.{DRAM, Incremental, MemoryType, PMEM}
 import com.intel.analytics.zoo.pipeline.api.keras.layers.utils.EngineRef
 import org.apache.hadoop.io.Text
 import org.apache.log4j.Logger
@@ -88,7 +88,7 @@ object ImageNet2012 {
     } else {
       val rawData = readFromSeqFiles(path, sc, classNumber)
         .setName("ImageNet2012 Training Set")
-      val featureSet = FeatureSet.rdd(rawData, memoryType = memoryType)
+      val featureSet = FeatureSet.rdd(rawData, memoryType = memoryType, Incremental(3))
       featureSet.transform(
         MTLabeledBGRImgToBatch[ByteRecord](
           width = imageSize,

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/ImageNet2012.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/ImageNet2012.scala
@@ -124,7 +124,7 @@ object ImageNet2012 {
     val rawData = readFromSeqFiles(path, sc, classNumber)
       .map(byteRecordToImageFeature(_))
       .setName("ImageNet2012 Training Set")
-    val featureSet = FeatureSet.rdd(rawData, memoryType = memoryType, INCREMENTAL(20))
+    val featureSet = FeatureSet.rdd(rawData, memoryType = memoryType, dataStrategy)
     val transformer = ImagePixelBytesToMat() ->
       ImageRandomCrop(imageSize, imageSize) ->
       ImageChannelNormalize(0.485f, 0.456f, 0.406f, 0.229f, 0.224f, 0.225f) ->

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/ImageNet2012.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/ImageNet2012.scala
@@ -122,12 +122,11 @@ object ImageNet2012 {
         nodeNumber: Int,
         coresPerNode: Int,
         classNumber: Int,
-        memoryType: MemoryType = DRAM,
-        dataStrategy: DataStrategy = PARTITIONED): FeatureSet[MiniBatch[Float]] = {
+        memoryType: MemoryType = DRAM): FeatureSet[MiniBatch[Float]] = {
     val rawData = readFromSeqFiles(path, sc, classNumber)
       .map(byteRecordToImageFeature(_))
       .setName("ImageNet2012 Training Set")
-    val featureSet = FeatureSet.rdd(rawData, memoryType = memoryType, dataStrategy)
+    val featureSet = FeatureSet.rdd(rawData, memoryType = memoryType)
     val transformer = ImagePixelBytesToMat() ->
       ImageRandomCrop(imageSize, imageSize) ->
       ImageChannelNormalize(0.485f, 0.456f, 0.406f, 0.229f, 0.224f, 0.225f) ->

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/Options.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/Options.scala
@@ -101,7 +101,7 @@ object Options {
       .text("min gradient clipping by")
       .action((x, c) => c.copy(gradientMin = Some(x)))
     opt[String]("memoryType")
-      .text("memory type")
+      .text("memory type, DRAM, PMEM or a int number")
       .action((x, c) => c.copy(memoryType = x))
     opt[Unit]("opencv")
       .text("use opencv preprocessing")

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/Options.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/Options.scala
@@ -40,7 +40,8 @@ object Options {
     gradientMin: Option[Double] = None,
     gradientMax: Option[Double] = None,
     memoryType: String = "DRAM",
-    opencv: Boolean = false
+    opencv: Boolean = false,
+    cachePercentage: Double = 1
   )
 
   val trainParser = new OptionParser[TrainParams]("BigDL Inception Example") {
@@ -100,6 +101,9 @@ object Options {
     opt[Double]("gradientMin")
       .text("min gradient clipping by")
       .action((x, c) => c.copy(gradientMin = Some(x)))
+    opt[Double]("cachePercentage")
+      .text("percentage of train set in memory")
+      .action((x, c) => c.copy(cachePercentage = x))
     opt[String]("memoryType")
       .text("memory type")
       .action((x, c) => c.copy(memoryType = x))

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/Options.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/Options.scala
@@ -40,8 +40,7 @@ object Options {
     gradientMin: Option[Double] = None,
     gradientMax: Option[Double] = None,
     memoryType: String = "DRAM",
-    opencv: Boolean = false,
-    cachePercentage: Double = 1
+    opencv: Boolean = false
   )
 
   val trainParser = new OptionParser[TrainParams]("BigDL Inception Example") {
@@ -101,9 +100,6 @@ object Options {
     opt[Double]("gradientMin")
       .text("min gradient clipping by")
       .action((x, c) => c.copy(gradientMin = Some(x)))
-    opt[Double]("cachePercentage")
-      .text("percentage of train set in memory")
-      .action((x, c) => c.copy(cachePercentage = x))
     opt[String]("memoryType")
       .text("memory type")
       .action((x, c) => c.copy(memoryType = x))

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/README.md
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/README.md
@@ -75,4 +75,4 @@ policy.
 * --gradientL2NormThreshold: optional. Gradient L2-Norm threshold used for norm2 gradient clipping.
 * --gradientMin: optional. Max gradient clipping by value, used in constant gradient clipping.
 * --gradientMax: optional. Min gradient clipping by value, used in constant gradient clipping.
-* --memoryType: optional. The default value is `DRAM`, you can change it to `PMEM` if have AEP hardware.
+* --memoryType: optional. Excepted `DRAM`, `PMEM` or a Int number. The default value is `DRAM`, you can change it to `PMEM` if have AEP hardware. If you give `n`, we will cache the data into disk, and hold only `1/n` of the data in memory. After going through the `1/n`, we will release the current cache, and load another `1/n` into memory.

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/Train.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/Train.scala
@@ -21,7 +21,7 @@ import com.intel.analytics.bigdl.nn._
 import com.intel.analytics.bigdl.optim.SGD.{Poly, SequentialSchedule, Warmup}
 import com.intel.analytics.bigdl.optim._
 import com.intel.analytics.bigdl.utils.{Engine, LoggerFilter, T, Table}
-import com.intel.analytics.zoo.feature.pmem.{INCREMENTAL, MemoryType, PARTITIONED}
+import com.intel.analytics.zoo.feature.pmem.{MemoryType, PARTITIONED}
 import com.intel.analytics.zoo.pipeline.api.keras.layers.utils.EngineRef
 import com.intel.analytics.zoo.pipeline.estimator.{ConstantClipping, Estimator, L2NormClipping}
 import org.apache.spark.SparkContext
@@ -48,8 +48,7 @@ object TrainInceptionV1 {
         EngineRef.getCoreNumber(),
         param.classNumber,
         MemoryType.fromString(param.memoryType),
-        param.opencv,
-        if (param.cachePercentage != 1) INCREMENTAL(param.cachePercentage) else PARTITIONED
+        param.opencv
       )
       val valSet = ImageNet2012Val(
         param.folder + "/val",
@@ -105,10 +104,6 @@ object TrainInceptionV1 {
         estimator.setGradientClippingByL2Norm(param.gradientL2NormThreshold.get)
       } else if (param.gradientMin.isDefined && param.gradientMax.isDefined) {
         estimator.setConstantGradientClipping(param.gradientMin.get, param.gradientMax.get)
-      }
-
-      if (param.cachePercentage != 1) {
-        estimator.setCachePercentage(param.cachePercentage)
       }
 
       estimator.train(trainSet, ClassNLLCriterion[Float](),

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/Train.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/Train.scala
@@ -21,6 +21,8 @@ import com.intel.analytics.bigdl.nn._
 import com.intel.analytics.bigdl.optim.SGD.{Poly, SequentialSchedule, Warmup}
 import com.intel.analytics.bigdl.optim._
 import com.intel.analytics.bigdl.utils.{Engine, LoggerFilter, T, Table}
+import com.intel.analytics.zoo.common.Optim.Fixed
+import com.intel.analytics.zoo.common.{EveryEpoch, MaxEpoch, MaxIteration, SeveralIteration}
 import com.intel.analytics.zoo.feature.pmem.{MemoryType, PARTITIONED}
 import com.intel.analytics.zoo.pipeline.api.keras.layers.utils.EngineRef
 import com.intel.analytics.zoo.pipeline.estimator.{ConstantClipping, Estimator, L2NormClipping}
@@ -82,8 +84,13 @@ object TrainInceptionV1 {
         val warmupDelta = if (warmupIteration == 0) 0.0
         else (param.maxLr.getOrElse(param.learningRate) - param.learningRate) / warmupIteration
         val polyIteration = maxIteration - warmupIteration
+        // When you are using incremental training, the training iteration may exceed the polyIteration,
+        // if you are using MaxEpoch to end the training. So we add a very small fixed learning rate to
+        // avoid a error thrown by SequentialSchedule(iterationPerEpoch).
         val lrSchedule = SequentialSchedule(iterationPerEpoch)
-          .add(Warmup(warmupDelta), warmupIteration).add(Poly(0.5, maxIteration), polyIteration)
+          .add(Warmup(warmupDelta), warmupIteration)
+          .add(Poly(0.5, maxIteration), polyIteration)
+          .add(Fixed(1e-10), Int.MaxValue)
         new SGD[Float](learningRate = param.learningRate, learningRateDecay = 0.0,
           weightDecay = param.weightDecay, momentum = 0.9, dampening = 0.0, nesterov = false,
           learningRateSchedule = lrSchedule)
@@ -95,10 +102,10 @@ object TrainInceptionV1 {
       }
 
       val (checkpointTrigger, endTrigger) = if (param.maxEpoch.isDefined) {
-        (Trigger.everyEpoch, Trigger.maxEpoch(param.maxEpoch.get))
+        (EveryEpoch(), MaxEpoch(param.maxEpoch.get))
       } else {
-        (Trigger.severalIteration(param.checkpointIteration),
-          Trigger.maxIteration(param.maxIteration))
+        (SeveralIteration(param.checkpointIteration),
+          MaxIteration(param.maxIteration))
       }
       if (param.gradientL2NormThreshold.isDefined) {
         estimator.setGradientClippingByL2Norm(param.gradientL2NormThreshold.get)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/Train.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/Train.scala
@@ -116,6 +116,7 @@ object TrainInceptionV1 {
         checkPointTrigger = Some(checkpointTrigger),
         valSet, Array(new Top1Accuracy[Float], new Top5Accuracy[Float]))
 
+      estimator.close()
       sc.stop()
     })
   }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/Train.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/Train.scala
@@ -84,9 +84,9 @@ object TrainInceptionV1 {
         val warmupDelta = if (warmupIteration == 0) 0.0
         else (param.maxLr.getOrElse(param.learningRate) - param.learningRate) / warmupIteration
         val polyIteration = maxIteration - warmupIteration
-        // When you are using incremental training, the training iteration may exceed the polyIteration,
-        // if you are using MaxEpoch to end the training. So we add a very small fixed learning rate to
-        // avoid a error thrown by SequentialSchedule(iterationPerEpoch).
+        // When you are using incremental training, the training iteration may exceed the
+        // polyIteration, if you are using MaxEpoch to end the training. So we add a very
+        // small fixed learning rate to avoid a error thrown by SequentialSchedule.
         val lrSchedule = SequentialSchedule(iterationPerEpoch)
           .add(Warmup(warmupDelta), warmupIteration)
           .add(Poly(0.5, maxIteration), polyIteration)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/recommendation/CensusWideAndDeep.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/recommendation/CensusWideAndDeep.scala
@@ -21,7 +21,7 @@ import com.intel.analytics.bigdl.nn.ClassNLLCriterion
 import com.intel.analytics.bigdl.numeric.NumericFloat
 import com.intel.analytics.bigdl.optim._
 import com.intel.analytics.bigdl.utils.{RandomGenerator, T}
-import com.intel.analytics.zoo.common.NNContext
+import com.intel.analytics.zoo.common.{EveryEpoch, MaxEpoch, NNContext}
 import com.intel.analytics.zoo.feature.FeatureSet
 import com.intel.analytics.zoo.feature.pmem.DISK_AND_DRAM
 import com.intel.analytics.zoo.models.recommendation._
@@ -146,7 +146,7 @@ object CensusWideAndDeep {
     }
 
     val (checkpointTrigger, endTrigger) =
-      (Trigger.everyEpoch, Trigger.maxEpoch(maxEpoch))
+      (EveryEpoch(), MaxEpoch(maxEpoch))
 
     estimator.train(trainRdds, ClassNLLCriterion[Float](),
       Some(endTrigger),

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/recommendation/CensusWideAndDeep.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/recommendation/CensusWideAndDeep.scala
@@ -132,9 +132,9 @@ object CensusWideAndDeep {
     }
 
     val sample2batch = SampleToMiniBatch(batchSize)
-    val trainRdds = FeatureSet.rdd(trainpairFeatureRdds.map(x => x.sample).cache(), DISK_AND_DRAM(2)) ->
+    val trainRdds = FeatureSet.rdd(trainpairFeatureRdds.map(x => x.sample), DISK_AND_DRAM(2)) ->
       sample2batch
-    val validationRdds = FeatureSet.rdd(validationpairFeatureRdds.map(x => x.sample).cache()) ->
+    val validationRdds = FeatureSet.rdd(validationpairFeatureRdds.map(x => x.sample)) ->
       sample2batch
 
     val estimator = if (params.logDir.isDefined) {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/recommendation/CensusWideAndDeep.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/recommendation/CensusWideAndDeep.scala
@@ -23,7 +23,7 @@ import com.intel.analytics.bigdl.optim._
 import com.intel.analytics.bigdl.utils.{RandomGenerator, T}
 import com.intel.analytics.zoo.common.{EveryEpoch, MaxEpoch, NNContext}
 import com.intel.analytics.zoo.feature.FeatureSet
-import com.intel.analytics.zoo.feature.pmem.DISK_AND_DRAM
+import com.intel.analytics.zoo.feature.pmem.{DISK_AND_DRAM, MemoryType}
 import com.intel.analytics.zoo.models.recommendation._
 import com.intel.analytics.zoo.pipeline.estimator.Estimator
 import org.apache.log4j.{Level, Logger}
@@ -131,8 +131,10 @@ object CensusWideAndDeep {
       throw new IllegalArgumentException(s"Unkown modelType ${modelType}")
     }
 
+    val memoryType = MemoryType.fromString(params.memoryType)
+
     val sample2batch = SampleToMiniBatch(batchSize)
-    val trainRdds = FeatureSet.rdd(trainpairFeatureRdds.map(x => x.sample), DISK_AND_DRAM(2)) ->
+    val trainRdds = FeatureSet.rdd(trainpairFeatureRdds.map(x => x.sample), memoryType) ->
       sample2batch
     val validationRdds = FeatureSet.rdd(validationpairFeatureRdds.map(x => x.sample)) ->
       sample2batch

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/recommendation/CensusWideAndDeep.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/recommendation/CensusWideAndDeep.scala
@@ -17,12 +17,13 @@
 package com.intel.analytics.zoo.examples.recommendation
 
 import com.intel.analytics.bigdl.dataset.{Sample, SampleToMiniBatch}
-import com.intel.analytics.bigdl.nn.{ClassNLLCriterion}
+import com.intel.analytics.bigdl.nn.ClassNLLCriterion
 import com.intel.analytics.bigdl.numeric.NumericFloat
 import com.intel.analytics.bigdl.optim._
 import com.intel.analytics.bigdl.utils.{RandomGenerator, T}
 import com.intel.analytics.zoo.common.NNContext
 import com.intel.analytics.zoo.feature.FeatureSet
+import com.intel.analytics.zoo.feature.pmem.DISK_AND_DRAM
 import com.intel.analytics.zoo.models.recommendation._
 import com.intel.analytics.zoo.pipeline.estimator.Estimator
 import org.apache.log4j.{Level, Logger}
@@ -131,7 +132,7 @@ object CensusWideAndDeep {
     }
 
     val sample2batch = SampleToMiniBatch(batchSize)
-    val trainRdds = FeatureSet.rdd(trainpairFeatureRdds.map(x => x.sample).cache()) ->
+    val trainRdds = FeatureSet.rdd(trainpairFeatureRdds.map(x => x.sample).cache(), DISK_AND_DRAM(2)) ->
       sample2batch
     val validationRdds = FeatureSet.rdd(validationpairFeatureRdds.map(x => x.sample).cache()) ->
       sample2batch
@@ -144,8 +145,8 @@ object CensusWideAndDeep {
       Estimator[Float](wideAndDeep, optimMethods)
     }
 
-    val (checkpointTrigger, testTrigger, endTrigger) =
-      (Trigger.everyEpoch, Trigger.everyEpoch, Trigger.maxEpoch(maxEpoch))
+    val (checkpointTrigger, endTrigger) =
+      (Trigger.everyEpoch, Trigger.maxEpoch(maxEpoch))
 
     estimator.train(trainRdds, ClassNLLCriterion[Float](),
       Some(endTrigger),

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/recommendation/WideAndDeepExample.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/recommendation/WideAndDeepExample.scala
@@ -23,7 +23,8 @@ case class WNDParams(dataset: String = "ml-1m",
                      inputDir: String = "./data/ml-1m/",
                      batchSize: Int = 2048,
                      maxEpoch: Int = 10,
-                     logDir: Option[String] = None)
+                     logDir: Option[String] = None,
+                     memoryType: String = "DRAM")
 
 object WideAndDeepExample {
   def main(args: Array[String]): Unit = {
@@ -48,6 +49,9 @@ object WideAndDeepExample {
       opt[String]("logDir")
         .text(s"logDir")
         .action((x, c) => c.copy(logDir = Some(x)))
+      opt[String]("memoryType")
+        .text("memory type, DRAM, PMEM or a int number")
+        .action((x, c) => c.copy(memoryType = x))
     }
     parser.parse(args, defaultParams).map {
       params =>

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
@@ -359,6 +359,7 @@ class DiskFeatureSet[T: ClassTag]
           newSample()
         }
         currentFeatureSet.cache()
+        currentFeatureSet.shuffle()
         trained = true
         currentFeatureSet.data(train)
       } else {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
@@ -421,6 +421,7 @@ object FeatureSet {
             logger.info("~~~~~~~ Caching with DIRECT ~~~~~~~")
             PmemFeatureSet.rdd[T](repartitionedData, DIRECT)
           case diskM: DISK_AND_DRAM =>
+            logger.info(s"~~~~~~~ Caching with DISK_AND_DRAM(${diskM.numSlice}) ~~~~~~~")
             new DiskFeatureSet[T](data, diskM.numSlice)
           case _ =>
             throw new IllegalArgumentException(

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
@@ -320,6 +320,7 @@ class IncrementalFeatureSet[T: ClassTag]
       currentSlice = buffer.sample(false, cachePercentage)
         .setName(s"${cachePercentage * 100}% of ${origin.name}")
       currentFeatureSet = DRAMFeatureSet.rdd(currentSlice)
+      currentFeatureSet.cache()
       currentFeatureSet.data(train)
     } else {
       buffer

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
@@ -292,6 +292,7 @@ class CachedDistributedFeatureSet[T: ClassTag]
   }
 
   override def unpersist(): Unit = {
+    FeatureSet.logger.info(s"Unpersisting ${buffer.name}.")
     buffer.map(_.free()).count()
     buffer.unpersist()
     indexes.unpersist()
@@ -353,14 +354,17 @@ class DiskFeatureSet[T: ClassTag]
       }
     } else {
       if (train) {
-        if (currentFeatureSet != null && trained) {
-          currentFeatureSet.unpersist()
+        if (trained) {
+          if (currentFeatureSet != null) {
+            currentFeatureSet.unpersist()
+          }
           newSample()
         }
         currentFeatureSet.shuffle()
         trained = true
         currentFeatureSet.data(train)
       } else {
+        trained = false
         currentFeatureSet.data(train)
       }
     }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
@@ -286,13 +286,12 @@ class CachedDistributedFeatureSet[T: ClassTag]
   override def originRDD(): RDD[_] = buffer
 
   override def cache(): Unit = {
-    buffer.count()
-    indexes.count()
+    buffer.cache().count()
+    indexes.cache().count()
     isCached = true
   }
 
   override def unpersist(): Unit = {
-    FeatureSet.logger.info(s"Unpersisting ${buffer.name}.")
     buffer.map(_.free()).count()
     buffer.unpersist()
     indexes.unpersist()
@@ -358,7 +357,6 @@ class DiskFeatureSet[T: ClassTag]
           currentFeatureSet.unpersist()
           newSample()
         }
-        currentFeatureSet.cache()
         currentFeatureSet.shuffle()
         trained = true
         currentFeatureSet.data(train)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
@@ -332,7 +332,9 @@ class DiskFeatureSet[T: ClassTag]
   protected var currentSlice: RDD[T] = null
   protected var currentFeatureSet: DistributedFeatureSet[T] = null
   protected var trained: Boolean = false
-  newSample()
+  if (numSlice != 0) {
+    newSample()
+  }
 
   private def newSample() = {
     currentSlice = buffer.sample(false, 1.0 / numSlice)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
@@ -323,7 +323,7 @@ class IncrementalFeatureSet[T: ClassTag]
       currentFeatureSet.cache()
       currentFeatureSet.data(train)
     } else {
-      buffer
+      currentFeatureSet.data(train)
     }
   }
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/pmem/NativeArray.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/pmem/NativeArray.scala
@@ -26,13 +26,13 @@ case object DRAM extends MemoryType
 
 case object DIRECT extends MemoryType
 
+case class DISK_AND_DRAM(dramPercentage: Double) extends MemoryType
+
 sealed trait DataStrategy
 
 case object PARTITIONED extends DataStrategy
 
 case object REPLICATED extends DataStrategy
-
-case class INCREMENTAL(cachePercentage: Double) extends DataStrategy
 
 object MemoryType {
   def fromString(str: String): MemoryType = {
@@ -40,6 +40,18 @@ object MemoryType {
       case "PMEM" => PMEM
       case "DRAM" => DRAM
       case "DIRECT" => DIRECT
+      case default =>
+        try {
+          val dramPercentage = default.toDouble
+          require(dramPercentage > 0 && dramPercentage < 1,
+            "DISK_AND_DRAM excepted a number in (0, 1).")
+          DISK_AND_DRAM(dramPercentage)
+        } catch {
+          case nfe: NumberFormatException =>
+            throw new IllegalArgumentException(s"Unknown memory type $default," +
+              s"excepted PMEM, DRAM, DIRECT or a number in (0, 1).")
+        }
+
     }
   }
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/pmem/NativeArray.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/pmem/NativeArray.scala
@@ -26,7 +26,7 @@ case object DRAM extends MemoryType
 
 case object DIRECT extends MemoryType
 
-case class DISK_AND_DRAM(cachePercentage: Double) extends MemoryType
+case class DISK_AND_DRAM(numSlice: Int) extends MemoryType
 
 sealed trait DataStrategy
 
@@ -42,11 +42,11 @@ object MemoryType {
       case "DIRECT" => DIRECT
       case default =>
         try {
-          DISK_AND_DRAM(str.toDouble)
+          DISK_AND_DRAM(str.toInt)
         } catch {
           case nfe: NumberFormatException =>
             throw new IllegalArgumentException(s"Unknown memory type $default," +
-              s"excepted PMEM, DRAM, DIRECT or a number in [0, 1).")
+              s"excepted PMEM, DRAM, DIRECT or a int number.")
         }
 
     }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/pmem/NativeArray.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/pmem/NativeArray.scala
@@ -26,7 +26,7 @@ case object DRAM extends MemoryType
 
 case object DIRECT extends MemoryType
 
-case class DISK_AND_DRAM(dramPercentage: Double) extends MemoryType
+case class DISK_AND_DRAM(cachePercentage: Double) extends MemoryType
 
 sealed trait DataStrategy
 
@@ -42,14 +42,11 @@ object MemoryType {
       case "DIRECT" => DIRECT
       case default =>
         try {
-          val dramPercentage = default.toDouble
-          require(dramPercentage > 0 && dramPercentage < 1,
-            "DISK_AND_DRAM excepted a number in (0, 1).")
-          DISK_AND_DRAM(dramPercentage)
+          DISK_AND_DRAM(str.toDouble)
         } catch {
           case nfe: NumberFormatException =>
             throw new IllegalArgumentException(s"Unknown memory type $default," +
-              s"excepted PMEM, DRAM, DIRECT or a number in (0, 1).")
+              s"excepted PMEM, DRAM, DIRECT or a number in [0, 1).")
         }
 
     }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/pmem/NativeArray.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/pmem/NativeArray.scala
@@ -32,6 +32,8 @@ case object PARTITIONED extends DataStrategy
 
 case object REPLICATED extends DataStrategy
 
+case class Incremental(nRdds: Int) extends DataStrategy
+
 object MemoryType {
   def fromString(str: String): MemoryType = {
     str.toUpperCase() match {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/pmem/NativeArray.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/pmem/NativeArray.scala
@@ -32,7 +32,7 @@ case object PARTITIONED extends DataStrategy
 
 case object REPLICATED extends DataStrategy
 
-case class Incremental(nRdds: Int) extends DataStrategy
+case class INCREMENTAL(cachePercentage: Double) extends DataStrategy
 
 object MemoryType {
   def fromString(str: String): MemoryType = {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
@@ -943,10 +943,11 @@ private[zoo] object InternalOptimizerUtil {
   }
 
   def initThreadModels[T: ClassTag](
-      args: Object*)(implicit ev: TensorNumeric[T]): (RDD[DistriOptimizer.Cache[T]], ModelBroadcast[T]) = {
+      args: Object*)(
+      implicit ev: TensorNumeric[T]): (RDD[DistriOptimizer.Cache[T]], ModelBroadcast[T]) = {
     KerasUtils.invokeMethodWithEv(DistriOptimizer,
       "com$intel$analytics$bigdl$optim$DistriOptimizer$$initThreadModels",
-      args:_*).asInstanceOf[(RDD[DistriOptimizer.Cache[T]], ModelBroadcast[T])]
+      args: _*).asInstanceOf[(RDD[DistriOptimizer.Cache[T]], ModelBroadcast[T])]
   }
 
   def clearState[T: ClassTag](
@@ -959,18 +960,20 @@ private[zoo] object InternalOptimizerUtil {
       args: Object*
       )(implicit ev: TensorNumeric[T]): Unit = {
     KerasUtils.invokeMethodWithEv(DistriOptimizer, "optimize",
-      args:_*)
+      args: _*)
   }
 
   def getModel[T: ClassTag](
       args: Object*)(implicit ev: TensorNumeric[T]): Unit = {
     KerasUtils.invokeMethodWithEv(DistriOptimizer, "getModel",
-      args:_*)
+      args: _*)
   }
 
   def releaseBroadcast[T: ClassTag](
         uuid: String)(implicit ev: TensorNumeric[T]): Unit = {
-    KerasUtils.invokeMethodWithEv("com.intel.analytics.bigdl.models.utils.CachedModels", "deleteKey",
+    KerasUtils.invokeMethodWithEv(
+      "com.intel.analytics.bigdl.models.utils.CachedModels",
+      "deleteKey",
       uuid)
   }
 
@@ -1048,7 +1051,8 @@ private[zoo] class InternalDistriOptimizer[T: ClassTag] (
             .getParametersFromModel(subModule.get)._1
           (subModuleName, subModuleWeights)
         }
-        val sortedWeights = p.values.toArray.sortWith((a, b) => a.storageOffset() < b.storageOffset())
+        val sortedWeights = p.values.toArray.sortWith(
+          (a, b) => a.storageOffset() < b.storageOffset())
         val compactWeights = Module.isCompact(sortedWeights)
         require(modelParameters._1 == compactWeights,
           s"InternDistriOptimizer: All subModules should have an OptimMethod.")
@@ -1067,8 +1071,9 @@ private[zoo] class InternalDistriOptimizer[T: ClassTag] (
 //        parameterProcessors.append(new LarsProcessor(parameterSplits, weightDecay))
 //      )
 
-      val modelsAndBroadcast = InternalOptimizerUtil.initThreadModels[T](trainingModel, distDataset, criterion,
-        state, Int.box(nodeNumber), Int.box(coresPerNode), Boolean.box(checkSingleton),
+      val modelsAndBroadcast = InternalOptimizerUtil.initThreadModels[T](
+        trainingModel, distDataset, criterion, state,
+        Int.box(nodeNumber), Int.box(coresPerNode), Boolean.box(checkSingleton),
         allReduceParameter, parameterSplits, validationMethods, optimMethods, parameterProcessors)
       cachedModels = modelsAndBroadcast._1
       modelBroadcast = modelsAndBroadcast._2
@@ -1156,8 +1161,9 @@ private[zoo] class InternalDistriOptimizer[T: ClassTag] (
               newOptimMethod.clearHistory()
               (moduleName, newOptimMethod)
             }
-            val modelsAndBroadcast = InternalOptimizerUtil.initThreadModels[T](newModel, distDataset,
-              criterion, state, Int.box(nodeNumber), Int.box(coresPerNode), Boolean.box(checkSingleton),
+            val modelsAndBroadcast = InternalOptimizerUtil.initThreadModels[T](
+              newModel, distDataset, criterion, state,
+              Int.box(nodeNumber), Int.box(coresPerNode), Boolean.box(checkSingleton),
               allReduceParameter, parameterSplits, validationMethods, optimMethods)
             cachedModels = modelsAndBroadcast._1
             modelBroadcast = modelsAndBroadcast._2
@@ -1249,10 +1255,11 @@ private[zoo] class InternalDistriOptimizer[T: ClassTag] (
       val state = InternalOptimizerUtil.getStateFromOptiMethod(
         optimMethods.values.head)
       if (checkPointTrigger.isDefined) {
-        if(checkPointTrigger.get.isInstanceOf[ZooTrigger]) {
+        if (checkPointTrigger.get.isInstanceOf[ZooTrigger]) {
           checkPointTrigger.get.asInstanceOf[ZooTrigger].setZooState(state)
         } else {
-          throw new IllegalArgumentException(s"Excepted com.intel.analytics.zoo.common.ZooTrigger." +
+          throw new IllegalArgumentException(
+            s"Excepted com.intel.analytics.zoo.common.ZooTrigger." +
             s" Please change your trigger to an instance of ZooTrigger.")
         }
       }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
@@ -37,7 +37,7 @@ import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils._
 import com.intel.analytics.bigdl.utils.serializer.{DeserializeContext, ModuleData, ModuleSerializer, SerializeContext}
 import com.intel.analytics.bigdl.visualization.{TrainSummary, ValidationSummary}
-import com.intel.analytics.zoo.feature.{DistributedFeatureSet, FeatureSet, IncrementalFeatureSet}
+import com.intel.analytics.zoo.feature.{DistributedFeatureSet, FeatureSet, DiskFeatureSet}
 import com.intel.analytics.zoo.feature.image.ImageSet
 import com.intel.analytics.zoo.feature.text._
 import com.intel.analytics.zoo.pipeline.api.{Net, Predictable}

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
@@ -1006,7 +1006,7 @@ private[zoo] class InternalDistriOptimizer[T: ClassTag] (
   protected var modelBroadcast: ModelBroadcast[T] = null
   protected var parameters: Map[String, AllReduceParameter[T]] = null
 
-  def optimize2(): Module[T] = {
+  def train(): Module[T] = {
     val distDataset = dataset.toDistributed()
     val trainingModel = if (EngineRef.getEngineType() == MklDnn && !model.isInstanceOf[MklDnnModule]
       && !model.isInstanceOf[Graph[T]]) {
@@ -1246,7 +1246,6 @@ private[zoo] class InternalDistriOptimizer[T: ClassTag] (
         EngineRef.getNodeNumber()
       val counts = trainSet.size()
       val iterations = Math.ceil(counts.toDouble * cachePercentage / batchSize).toInt
-      println(s"$counts $cachePercentage $batchSize $iterations")
 
       var i = if (state.contains("neval")) {
         // resume training
@@ -1266,11 +1265,11 @@ private[zoo] class InternalDistriOptimizer[T: ClassTag] (
           // as BigDL will overwrite checkpointPath to its subfolder.
           this.setCheckpoint(checkpointDir.get, checkPointTrigger.get)
         }
-        this.optimize2()
+        this.train()
         i += 1
       }
     } else {
-      this.optimize2()
+      this.train()
     }
     this
   }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
@@ -1255,6 +1255,12 @@ private[zoo] class InternalDistriOptimizer[T: ClassTag] (
         state("numSlice") = numSlice
         state("currentSlice") = 0
       }
+      if (!state.contains("Loss")) {
+        state.update("Loss", Float.PositiveInfinity)
+      }
+      if (!state.contains("score")) {
+        state.update("score", 0f)
+      }
 
       while(!endWhen(state)) {
         val trueEpoch = Math.floor(state[Int]("currentSlice").toDouble / numSlice).toInt + 1

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
@@ -1349,43 +1349,6 @@ private[zoo] class InternalDistriOptimizer[T: ClassTag] (
 object InternalDistriOptimizer {
   val logger = Logger.getLogger(this.getClass)
 
-  protected def getEpoch(s: Table, trigger: Trigger): Trigger = {
-    try {
-      val clazz = trigger.getClass()
-      // use reflection to make sure if the trigger is every epoch.
-      clazz.getDeclaredField("lastEpoch")
-    } catch {
-      case e: NoSuchFieldException =>
-        return trigger
-    }
-    Trigger.and(trigger, endEpoch(s))
-  }
-
-  protected def endEpoch(s: Table): Trigger = {
-    new Trigger() {
-      private var lastEpoch = -1
-
-      override def apply(state: Table): Boolean = {
-        if (lastEpoch == -1) {
-          lastEpoch = state[Int]("epoch")
-          false
-        } else {
-          if (state[Int]("epoch") <= lastEpoch) {
-            false
-          } else {
-            if (s.contains("numSlice") && s.contains("currentSlice")
-              && s[Int]("currentSlice") % s[Int]("numSlice") == 0) {
-              lastEpoch = state[Int]("epoch")
-              true
-            } else {
-              false
-            }
-          }
-        }
-      }
-    }
-  }
-
   protected def validate[T](validationFeatureSet: FeatureSet[MiniBatch[T]],
                             validationMethods: Array[ValidationMethod[T]],
                             models: RDD[Cache[T]],

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/estimator/Estimator.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/estimator/Estimator.scala
@@ -127,7 +127,7 @@ class Estimator[T: ClassTag] private[zoo](
           internalEstimator = new InternalDistriOptimizer[T](model, null, criterion)
             .setCheckpointDir(modelDir)
             .setOptimMethods(optimMethods)
-            .setCachePercentage(d.memoryPercentage)
+            .setNumOfSlice(d.numOfSlice)
         }
       case _ => throw new IllegalArgumentException("Unsupported FeatureSet type.")
     }
@@ -259,5 +259,6 @@ object Estimator {
         model: Module[T])(implicit ev: TensorNumeric[T]): Estimator[T] = {
     new Estimator[T](model, Map())
   }
+
 
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/estimator/Estimator.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/estimator/Estimator.scala
@@ -127,15 +127,8 @@ class Estimator[T: ClassTag] private[zoo](
           internalEstimator = new InternalDistriOptimizer[T](model, null, criterion)
             .setCheckpointDir(modelDir)
             .setOptimMethods(optimMethods)
+            .setCachePercentage(d.memoryPercentage)
         }
-        if (d.originSet().isInstanceOf[DiskFeatureSet[Any]]) {
-          // set cache percentage
-          val cachePercentage =  d.originSet()
-            .asInstanceOf[DiskFeatureSet[Any]].cachePercentage
-          internalEstimator.asInstanceOf[InternalDistriOptimizer[T]]
-            .setCachePercentage(cachePercentage)
-        }
-
       case _ => throw new IllegalArgumentException("Unsupported FeatureSet type.")
     }
     if (gradientClipping.nonEmpty) {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/estimator/Estimator.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/estimator/Estimator.scala
@@ -42,6 +42,7 @@ trait AbstractEstimator[T]{
                validationMethod: Array[ValidationMethod[T]]
               ): Map[ValidationMethod[T], ValidationResult]
 
+  def close(): Unit
 }
 
 private[estimator] trait GradientClipping
@@ -186,6 +187,12 @@ class Estimator[T: ClassTag] private[zoo](
       }
     }
     internalEstimator.evaluate(validationSet, validationMethod)
+  }
+
+  override def close(): Unit = {
+    if (internalEstimator != null) {
+      internalEstimator.close()
+    }
   }
 }
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/estimator/Estimator.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/estimator/Estimator.scala
@@ -71,6 +71,19 @@ class Estimator[T: ClassTag] private[zoo](
   protected val gradientClipping: ArrayBuffer[GradientClipping] =
     new ArrayBuffer[GradientClipping]()
 
+  protected var cachePercentage: Double = 1.0
+
+  def setCachePercentage(percentage: Double): this.type = {
+    require(percentage > 0 && percentage <= 1, s"excepted percentage in (0, 1]," +
+      s" but got $percentage")
+    cachePercentage = percentage
+    this
+  }
+
+  def getCachePercentage(): Double = {
+    cachePercentage
+  }
+
   /**
    * Clear gradient clipping parameters. In this case, gradient clipping will not be applied.
    * In order to take effect, it needs to be called before fit.
@@ -126,6 +139,7 @@ class Estimator[T: ClassTag] private[zoo](
           new InternalDistriOptimizer[T](model, null, criterion)
             .setCheckpointDir(modelDir)
             .setOptimMethods(optimMethods)
+            .setCachePercentage(cachePercentage)
         case _ => throw new IllegalArgumentException("Unsupported FeatureSet type.")
       }
     }
@@ -167,6 +181,7 @@ class Estimator[T: ClassTag] private[zoo](
           new InternalDistriOptimizer[T](model, null, null)
             .setCheckpointDir(modelDir)
             .setOptimMethods(optimMethods)
+            .setCachePercentage(cachePercentage)
         case _ => throw new IllegalArgumentException("Unsupported FeatureSet type.")
       }
     }

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/estimator/DistriEstimatorSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/estimator/DistriEstimatorSpec.scala
@@ -257,7 +257,7 @@ class DistriEstimatorSpec extends ZooSpecHelper {
   "Estimator" should "works fine with DiskFeatureSet" in {
     val rdd = sc.parallelize(1 to (256 * nodeNumber), nodeNumber)
       .map(_ => Sample[Double](Tensor[Double](4).rand(), Tensor[Double](1).rand()))
-    val dset = FeatureSet.rdd(rdd, DISK_AND_DRAM(0.5)) -> SampleToMiniBatch(batchSize = batchSize)
+    val dset = FeatureSet.rdd(rdd, DISK_AND_DRAM(2)) -> SampleToMiniBatch(batchSize = batchSize)
     val mm = EstimatorSpecModel.mse
     mm.parameters()._1.foreach(_.fill(0.125))
     val sgd = new SGD[Double](20)
@@ -273,7 +273,7 @@ class DistriEstimatorSpec extends ZooSpecHelper {
   "Estimator" should "works fine with DiskFeatureSet2" in {
     val rdd = sc.parallelize(1 to (1024 * nodeNumber), nodeNumber)
       .map(_ => Sample[Double](Tensor[Double](4).rand(), Tensor[Double](1).rand()))
-    val dset = FeatureSet.rdd(rdd, DISK_AND_DRAM(0.2)) -> SampleToMiniBatch(batchSize = batchSize)
+    val dset = FeatureSet.rdd(rdd, DISK_AND_DRAM(5)) -> SampleToMiniBatch(batchSize = batchSize)
     val mm = EstimatorSpecModel.mse
     mm.parameters()._1.foreach(_.fill(0.125))
     val sgd = new SGD[Double](20)
@@ -289,7 +289,7 @@ class DistriEstimatorSpec extends ZooSpecHelper {
   "Estimator" should "works fine with DiskFeatureSet3" in {
     val rdd = sc.parallelize(1 to (1024 * nodeNumber), nodeNumber)
       .map(_ => Sample[Double](Tensor[Double](4).rand(), Tensor[Double](1).rand()))
-    val dset = FeatureSet.rdd(rdd, DISK_AND_DRAM(0.2)) -> SampleToMiniBatch(batchSize = batchSize)
+    val dset = FeatureSet.rdd(rdd, DISK_AND_DRAM(5)) -> SampleToMiniBatch(batchSize = batchSize)
     val mm = EstimatorSpecModel.mse
     mm.parameters()._1.foreach(_.fill(0.125))
     val sgd = new SGD[Double](20)

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/estimator/DistriEstimatorSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/estimator/DistriEstimatorSpec.scala
@@ -266,7 +266,6 @@ class DistriEstimatorSpec extends ZooSpecHelper {
     val state = InternalOptimizerUtil.getStateFromOptiMethod(sgd)
     estimator.train(dset, mse, endTrigger = Some(MaxEpoch(2)))
 
-    state[Int]("neval") should be >= 64
     state[Int]("epoch") should be (3)
   }
 
@@ -282,7 +281,6 @@ class DistriEstimatorSpec extends ZooSpecHelper {
     val state = InternalOptimizerUtil.getStateFromOptiMethod(sgd)
     estimator.train(dset, mse, endTrigger = Some(MaxEpoch(2)))
 
-    state[Int]("neval") should be >= 256
     state[Int]("epoch") should be (3)
   }
 


### PR DESCRIPTION
With incremental training, we can use less DRAM during the training.
The training workload is like this:
1. Persist origin data on disk
2. Sample a piece of data to memory
3. train these cached samples
4. unpersist these cached samples
5. Goto 2.