### PR TITLE
Support gradient clipping in TFPark

### DIFF
--- a/pyzoo/test/zoo/tfpark/test_tfpark_estimator.py
+++ b/pyzoo/test/zoo/tfpark/test_tfpark_estimator.py
@@ -238,6 +238,17 @@ class TestTFParkEstimator(ZooTestCase):
         estimator = TFEstimator(model_fn, tf.train.AdamOptimizer())
         estimator.train(input_fn, steps=1)
 
+    def test_gradient_clipping(self):
+
+        model_fn = self.create_model_fn()
+        input_fn = self.create_train_feature_set_input_fn()
+
+        estimator = TFEstimator(model_fn, tf.train.AdamOptimizer())
+        estimator.set_constant_gradient_clipping(-1e-8, 1e8)
+        estimator.train(input_fn, steps=1)
+
+        # todo add weights verification
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/pyzoo/test/zoo/tfpark/test_tfpark_model.py
+++ b/pyzoo/test/zoo/tfpark/test_tfpark_model.py
@@ -478,7 +478,7 @@ class TestTFParkModel(ZooTestCase):
 
         current_weight = model.get_weights()
 
-        np.all((current_weight[0] - pre_weights[0]) < 1e-7)
+        np.all(np.abs((current_weight[0] - pre_weights[0])) < 1e-7)
 
 
 if __name__ == "__main__":

--- a/pyzoo/test/zoo/tfpark/test_tfpark_model.py
+++ b/pyzoo/test/zoo/tfpark/test_tfpark_model.py
@@ -455,5 +455,31 @@ class TestTFParkModel(ZooTestCase):
         results = model.predict(predict_dataset).get_predict().collect()
         assert all(r[1] is not None for r in results)
 
+    def test_gradient_clipping(self):
+
+        data = tf.keras.layers.Input(shape=[10])
+
+        x = tf.keras.layers.Flatten()(data)
+        x = tf.keras.layers.Dense(10, activation='relu')(x)
+        predictions = tf.keras.layers.Dense(2, activation='softmax')(x)
+
+        model = tf.keras.models.Model(inputs=data, outputs=predictions)
+        model.compile(optimizer=tf.keras.optimizers.SGD(lr=1, clipvalue=1e-8),
+                      loss='sparse_categorical_crossentropy',
+                      metrics=['accuracy'])
+        model = KerasModel(model)
+
+        pre_weights = model.get_weights()
+
+        dataset = self.create_training_dataset()
+
+        # 5 iterations
+        model.fit(dataset)
+
+        current_weight = model.get_weights()
+
+        np.all((current_weight[0] - pre_weights[0]) < 1e-7)
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/pyzoo/zoo/pipeline/api/net/tf_optimizer.py
+++ b/pyzoo/zoo/pipeline/api/net/tf_optimizer.py
@@ -425,6 +425,24 @@ with variable_creator_scope():
     def set_val_summary(self, summary):
         self.optimizer.set_val_summary(summary)
 
+    def set_constant_gradient_clipping(self, min_value, max_value):
+        """
+        Configure constant clipping settings.
+
+
+        :param min_value: the minimum value to clip by
+        :param max_value: the maxmimum value to clip by
+        """
+        self.optimizer.set_gradclip_const(min_value, max_value)
+
+    def set_gradient_clipping_by_l2_norm(self, clip_norm):
+        """
+        Configure L2 norm clipping settings.
+
+
+        :param clip_norm: gradient L2-Norm threshold
+        """
+        self.optimizer.set_gradclip_l2norm(clip_norm)
 
     def optimize(self, end_trigger=None):
         if end_trigger is None:

--- a/pyzoo/zoo/pipeline/api/net/tf_optimizer.py
+++ b/pyzoo/zoo/pipeline/api/net/tf_optimizer.py
@@ -252,7 +252,8 @@ with variable_creator_scope():
 
             if not isinstance(clip_value, tuple):
                 raise ValueError("The clip_value argument should be" +
-                                 " a positive float/int which clips to (-clip_value, clip_value); " +
+                                 " a positive float/int which clips to" +
+                                 " (-clip_value, clip_value); " +
                                  "or a tuple which clips to (min_value, max_value)")
 
         return cls(*(args + [val_split]),

--- a/pyzoo/zoo/pipeline/api/net/tf_optimizer.py
+++ b/pyzoo/zoo/pipeline/api/net/tf_optimizer.py
@@ -310,8 +310,8 @@ with variable_creator_scope():
                    grads, variables, loss.graph, val_outputs, val_labels,
                    bigdl_val_methods, val_spilt,
                    tensors_with_value=tensor_with_value,
-                   clipnorm=clip_norm,
-                   clipvalue=clip_value, **kwargs)
+                   clip_norm=clip_norm,
+                   clip_value=clip_value, **kwargs)
 
     @staticmethod
     def to_bigdl_optim_method(koptim_method):

--- a/pyzoo/zoo/pipeline/api/net/tf_optimizer.py
+++ b/pyzoo/zoo/pipeline/api/net/tf_optimizer.py
@@ -98,7 +98,10 @@ class TFOptimizer:
         self.inputs = inputs + additional_inputs
         self.graph = graph
         self.session_config = session_config
+
         self.clip_norm = clip_norm
+        if clip_value is not None and not isinstance(clip_value, tuple):
+            raise ValueError("The clip_value argument should be a tuple (min_value, max_value)")
         self.clip_constant = clip_value
 
         from zoo.util.tf import process_grad
@@ -241,6 +244,16 @@ with variable_creator_scope():
         args = TFOptimizer._get_arguments_from_loss(loss, optim_method,
                                                     session, val_outputs,
                                                     val_labels, val_method)
+
+        if isinstance(clip_value, float) or isinstance(clip_value, int):
+            if clip_value <= 0:
+                ValueError("The clip_value argument should be positive number")
+            clip_value = (-float(clip_value), float(clip_value))
+
+        if not isinstance(clip_value, tuple):
+            raise ValueError("The clip_value argument should be" +
+                             " a positive float/int which clips to (-clip_value, clip_value); " +
+                             "or a tuple which clips to (min_value, max_value)")
 
         return cls(*(args + [val_split]),
                    clip_norm=clip_norm,

--- a/pyzoo/zoo/pipeline/api/net/tf_optimizer.py
+++ b/pyzoo/zoo/pipeline/api/net/tf_optimizer.py
@@ -244,16 +244,16 @@ with variable_creator_scope():
         args = TFOptimizer._get_arguments_from_loss(loss, optim_method,
                                                     session, val_outputs,
                                                     val_labels, val_method)
+        if clip_value is not None:
+            if isinstance(clip_value, float) or isinstance(clip_value, int):
+                if clip_value <= 0:
+                    ValueError("The clip_value argument should be positive number")
+                clip_value = (-float(clip_value), float(clip_value))
 
-        if isinstance(clip_value, float) or isinstance(clip_value, int):
-            if clip_value <= 0:
-                ValueError("The clip_value argument should be positive number")
-            clip_value = (-float(clip_value), float(clip_value))
-
-        if not isinstance(clip_value, tuple):
-            raise ValueError("The clip_value argument should be" +
-                             " a positive float/int which clips to (-clip_value, clip_value); " +
-                             "or a tuple which clips to (min_value, max_value)")
+            if not isinstance(clip_value, tuple):
+                raise ValueError("The clip_value argument should be" +
+                                 " a positive float/int which clips to (-clip_value, clip_value); " +
+                                 "or a tuple which clips to (min_value, max_value)")
 
         return cls(*(args + [val_split]),
                    clip_norm=clip_norm,

--- a/pyzoo/zoo/tfpark/estimator.py
+++ b/pyzoo/zoo/tfpark/estimator.py
@@ -232,12 +232,6 @@ class TFEstimator(object):
                                                 session=sess,
                                                 clip_norm=self.gradient_clipping_norm,
                                                 clip_value=self.gradient_clipping_constant)
-                    if self.gradient_clipping_constant:
-                        min_value, max_value = self.gradient_clipping_constant
-                        opt.set_constant_gradient_clipping(min_value, max_value)
-                    if self.gradient_clipping_norm:
-                        norm = self.gradient_clipping_norm
-                        opt.set_gradient_clipping_by_l2_norm(norm)
                     opt.optimize(MaxIteration(steps))
                     sess.run(assign_step, feed_dict={add_step_input: steps})
                     final_step = sess.run(global_step_tensor)

--- a/pyzoo/zoo/tfpark/estimator.py
+++ b/pyzoo/zoo/tfpark/estimator.py
@@ -140,6 +140,8 @@ class TFEstimator(object):
         self.config = config
         self.params = params
         self.tf_optimizer = None
+        self.gradient_clipping_norm = None
+        self.gradient_clipping_constant = None
 
     def _call_model_fn(self, features, labels, mode, config):
         model_fn_args = function_utils.fn_args(self._model_fn)
@@ -159,6 +161,29 @@ class TFEstimator(object):
             raise ValueError('model_fn should return an TFEstimatorSpec.')
 
         return model_fn_results
+
+    def clear_gradient_clipping(self):
+        self.gradient_clipping_constant = None
+        self.gradient_clipping_norm = None
+
+    def set_constant_gradient_clipping(self, min, max):
+        """
+        Configure constant clipping settings.
+
+
+        :param min_value: the minimum value to clip by
+        :param max_value: the maxmimum value to clip by
+        """
+        self.gradient_clipping_constant = (min, max)
+
+    def set_gradient_clipping_by_l2_norm(self, clip_norm):
+        """
+        Configure L2 norm clipping settings.
+
+
+        :param clip_norm: gradient L2-Norm threshold
+        """
+        self.gradient_clipping_norm = clip_norm
 
     def train(self, input_fn, steps=None):
         """Trains a model given training data `input_fn`.
@@ -202,7 +227,17 @@ class TFEstimator(object):
                     else:
                         sess.run(tf.global_variables_initializer())
 
-                    opt = TFOptimizer.from_loss(spec.loss, optim_method, session=sess)
+                    opt = TFOptimizer.from_loss(spec.loss,
+                                                optim_method,
+                                                session=sess,
+                                                clip_norm=self.gradient_clipping_norm,
+                                                clip_value=self.gradient_clipping_constant)
+                    if self.gradient_clipping_constant:
+                        min_value, max_value = self.gradient_clipping_constant
+                        opt.set_constant_gradient_clipping(min_value, max_value)
+                    if self.gradient_clipping_norm:
+                        norm = self.gradient_clipping_norm
+                        opt.set_gradient_clipping_by_l2_norm(norm)
                     opt.optimize(MaxIteration(steps))
                     sess.run(assign_step, feed_dict={add_step_input: steps})
                     final_step = sess.run(global_step_tensor)

--- a/pyzoo/zoo/tfpark/model.py
+++ b/pyzoo/zoo/tfpark/model.py
@@ -35,18 +35,6 @@ class KerasModel(object):
         :param model: a compiled keras model
         """
         self.model = model
-        metrics_tensors = [
-            self.model.metrics_tensors[m] for m in range(len(self.model.metrics_names) - 1)
-        ]
-
-        metrics_tensors = [self.model.total_loss] + metrics_tensors
-        batch_size = tf.shape(model.inputs[0])
-
-        def repeat(x, times):
-            return tf.tile(tf.expand_dims(x, 0), tf.expand_dims(times, 0))
-
-        self.metrics_tensors = [repeat(x, batch_size[0]) for x in metrics_tensors]
-
         self.tf_optimizer = None
         self.tf_optimizer_done_epochs = 0
 


### PR DESCRIPTION
fixed #1281
In the keras case, if user set `clipNorm` and/or `clipValue` in tf.keras.Optimizers, these values will be set automatically.
In the estimator case, user use
```
estimator.set_constant_gradient_clipping(min, max)
estimator.set_gradient_clipping_by_l2_norm(clip_norm)
```
