### PR TITLE
[Pytorch] correct offset for inference

### DIFF
--- a/pyzoo/test/zoo/pipeline/api/test_torch_net.py
+++ b/pyzoo/test/zoo/pipeline/api/test_torch_net.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+import torch
 import torchvision
 import numpy as np
 import pytest
@@ -25,11 +26,15 @@ from zoo.pipeline.api.net.torch_net import TorchNet
 class TestTF(ZooTestCase):
 
     def test_torch_net_predict(self):
-        model = torchvision.models.resnet18()
+        model = torchvision.models.resnet18(pretrained=True).eval()
         net = TorchNet.from_pytorch(model, [1, 3, 224, 224])
 
-        result = net.predict(np.random.rand(1, 3, 224, 224))
-        print(result.collect())
+        dummpy_input = torch.ones(1, 3, 224, 224)
+        result = net.predict(dummpy_input.numpy()).collect()
+        assert np.allclose(result[0][0:5].tolist(),
+            np.asarray([-0.03913354128599167, 0.11446280777454376, -1.7967549562454224,
+                        -1.2342952489852905, -0.819004476070404]))
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/pyzoo/test/zoo/pipeline/api/test_torch_net.py
+++ b/pyzoo/test/zoo/pipeline/api/test_torch_net.py
@@ -24,7 +24,6 @@ from zoo.pipeline.api.net.torch_net import TorchNet
 
 
 class TestTF(ZooTestCase):
-
     def test_torch_net_predict(self):
         model = torchvision.models.resnet18(pretrained=True).eval()
         net = TorchNet.from_pytorch(model, [1, 3, 224, 224])
@@ -32,8 +31,9 @@ class TestTF(ZooTestCase):
         dummpy_input = torch.ones(1, 3, 224, 224)
         result = net.predict(dummpy_input.numpy()).collect()
         assert np.allclose(result[0][0:5].tolist(),
-            np.asarray([-0.03913354128599167, 0.11446280777454376, -1.7967549562454224,
-                        -1.2342952489852905, -0.819004476070404]))
+                           np.asarray(
+                               [-0.03913354128599167, 0.11446280777454376, -1.7967549562454224,
+                                -1.2342952489852905, -0.819004476070404]))
 
 
 if __name__ == "__main__":

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchNet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchNet.scala
@@ -63,7 +63,7 @@ class TorchNet private(private val modelHolder: TorchModelHolder)
     require(input.isContiguous())
     val data = input.storage().array()
     val size = input.size()
-    val offset = input.storageOffset()
+    val offset = input.storageOffset() - 1
     val result = forward(data, offset, size)
     val resultTensor = Tensor(result.getData, result.getShape)
     output.set(resultTensor)


### PR DESCRIPTION
BigDL Tensor offset starts from 1 by default.

fix issue https://github.com/intel-analytics/analytics-zoo/issues/1477 