### PR TITLE
Support setting core number from python side

### DIFF
--- a/pyzoo/test/zoo/common/__init__.py
+++ b/pyzoo/test/zoo/common/__init__.py
@@ -1,0 +1,15 @@
+#
+# Copyright 2018 Analytics Zoo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/pyzoo/test/zoo/common/test_util.py
+++ b/pyzoo/test/zoo/common/test_util.py
@@ -1,0 +1,43 @@
+#
+# Copyright 2018 Analytics Zoo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from bigdl.util.common import get_node_and_core_number
+from test.zoo.pipeline.utils.test_utils import ZooTestCase
+from zoo.common import set_core_num
+
+
+class TestUtil(ZooTestCase):
+
+    def test_set_core_num(self):
+        _, core_num = get_node_and_core_number()
+
+        set_core_num(core_num + 1)
+
+        _, new_core_num = get_node_and_core_number()
+
+        if new_core_num == core_num + 1:
+            # set it back
+            set_core_num(core_num)
+        else:
+            assert new_core_num == core_num + 1,\
+                "set_core_num failed, set the core" \
+                " number to be {} but got {}".format(core_num + 1, new_core_num)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/pyzoo/test/zoo/common/test_util.py
+++ b/pyzoo/test/zoo/common/test_util.py
@@ -18,7 +18,7 @@ import pytest
 
 from bigdl.util.common import get_node_and_core_number
 from test.zoo.pipeline.utils.test_utils import ZooTestCase
-from zoo.common import set_core_num
+from zoo.common import set_core_number
 
 
 class TestUtil(ZooTestCase):
@@ -26,17 +26,15 @@ class TestUtil(ZooTestCase):
     def test_set_core_num(self):
         _, core_num = get_node_and_core_number()
 
-        set_core_num(core_num + 1)
+        set_core_number(core_num + 1)
 
         _, new_core_num = get_node_and_core_number()
 
-        if new_core_num == core_num + 1:
-            # set it back
-            set_core_num(core_num)
-        else:
-            assert new_core_num == core_num + 1,\
-                "set_core_num failed, set the core" \
-                " number to be {} but got {}".format(core_num + 1, new_core_num)
+        assert new_core_num == core_num + 1, \
+            "set_core_num failed, set the core" \
+            " number to be {} but got {}".format(core_num + 1, new_core_num)
+
+        set_core_number(core_num)
 
 
 if __name__ == "__main__":

--- a/pyzoo/zoo/common/utils.py
+++ b/pyzoo/zoo/common/utils.py
@@ -38,7 +38,7 @@ def to_list_of_numpy(elements):
     return results
 
 
-def set_core_num(num):
+def set_core_number(num):
     callBigDlFunc("float", "setCoreNumber", num)
 
 

--- a/pyzoo/zoo/common/utils.py
+++ b/pyzoo/zoo/common/utils.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from bigdl.util.common import Sample as BSample, JTensor as BJTensor
+from bigdl.util.common import Sample as BSample, JTensor as BJTensor, callBigDlFunc
 import numpy as np
 
 
@@ -36,6 +36,10 @@ def to_list_of_numpy(elements):
             raise ValueError("Wrong type: %s" % type(element))
 
     return results
+
+
+def set_core_num(num):
+    callBigDlFunc("float", "setCoreNumber", num)
 
 
 class JTensor(BJTensor):

--- a/pyzoo/zoo/pipeline/api/net/tf_optimizer.py
+++ b/pyzoo/zoo/pipeline/api/net/tf_optimizer.py
@@ -48,7 +48,7 @@ class TFValidationMethod(JavaValue):
 class TFTrainingHelper(Layer):
     def __init__(self, path, configProto):
         if configProto is not None:
-            byte_arr = configProto.SerializeToString()
+            byte_arr = bytearray(configProto.SerializeToString())
         else:
             byte_arr = None
         super(TFTrainingHelper, self).__init__(None, "float", path, byte_arr)
@@ -97,6 +97,11 @@ class TFOptimizer:
         self.dataset = dataset
         self.inputs = inputs + additional_inputs
         self.graph = graph
+        if session_config is not None:
+            import tensorflow as tf
+            assert isinstance(session_config, tf.ConfigProto),\
+                "session_config should be a tf.ConfigProto"
+            session_config.use_per_session_threads = True
         self.session_config = session_config
 
         self.clip_norm = clip_norm

--- a/zoo/src/main/scala/com/intel/analytics/zoo/common/PythonZoo.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/common/PythonZoo.scala
@@ -30,6 +30,7 @@ import com.intel.analytics.bigdl.optim.LocalPredictor
 import com.intel.analytics.bigdl.utils.Table
 import com.intel.analytics.zoo.feature.image.ImageSet
 import com.intel.analytics.zoo.feature.text.TextSet
+import com.intel.analytics.zoo.pipeline.api.keras.layers.utils.EngineRef
 
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
@@ -189,6 +190,11 @@ class PythonZoo[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonBigDLK
                          batchPerThread: Int,
                          zeroBasedLabel: Boolean = true): JavaRDD[Int] = {
     module.predictClasses(toJSample(x), batchPerThread, zeroBasedLabel).toJavaRDD()
+  }
+
+
+  def setCoreNumber(num: Int): Unit = {
+    EngineRef.setCoreNumber(num)
   }
 
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/utils/Reflection.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/utils/Reflection.scala
@@ -88,6 +88,12 @@ object EngineRef {
   def getEngineType(): EngineType = {
     KerasUtils.invokeMethod(Engine, "getEngineType").asInstanceOf[EngineType]
   }
+
+  def setCoreNumber(num: Int): Unit = {
+    val field = Engine.getClass.getDeclaredField("physicalCoreNumber")
+    field.setAccessible(true)
+    field.setInt(Engine, num)
+  }
 }
 
 object SGDRef {


### PR DESCRIPTION
Setting core number in Engine can control the number of model replica in each node.

This is a temporary support and more user friendly api will be added after pr #1488 

Example Usage:
Say you running on a spark cluster with executor core number is 28, and you want to run two tensorflow model on each executor and each of the model using 14 threads.

Then you can you can do the following to achieve this:
1. export OMP_NUM_THREADS=14 before submitting spark job
2. set core number to change the value in engine and make DistriOptimizer only copy 2 model in each executor.

    ```python
    from zoo.common import set_core_number
    set_core_number(core_num)
    ```
3. set the session_config parameter in TFOptimizer to make each model using 14 threads
    ```
    TFOptimizer.from_loss(..., session_config=tf.ConfigProto(inter_op_parallelism_threads=1, intra_op_parallelism_threads=14))
    ```
