### PR TITLE
fix cdh6.2 on yarn

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/common/NNContext.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/common/NNContext.scala
@@ -234,10 +234,10 @@ object NNContext {
       }
     }
     // Set Spark Conf
-    zooConf.setExecutorEnv("spark.executorEnv.KMP_AFFINITY", kmpAffinity)
-    zooConf.setExecutorEnv("spark.executorEnv.KMP_BLOCKTIME", kmpBlockTime)
-    zooConf.setExecutorEnv("spark.executorEnv.KMP_SETTINGS", kmpSettings)
-    zooConf.setExecutorEnv("spark.executorEnv.OMP_NUM_THREADS", ompNumThreads)
+    zooConf.setExecutorEnv("KMP_AFFINITY", kmpAffinity)
+    zooConf.setExecutorEnv("KMP_BLOCKTIME", kmpBlockTime)
+    zooConf.setExecutorEnv("KMP_SETTINGS", kmpSettings)
+    zooConf.setExecutorEnv("OMP_NUM_THREADS", ompNumThreads)
 
   }
 


### PR DESCRIPTION
fix #1511 

As cdh will convert the spark env to shell script, but we set a illegal name.

Manual test on CDH 6.2.