### PR TITLE
Clarify errormsg in ImageModel.scala

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/image/common/ImageModel.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/image/common/ImageModel.scala
@@ -20,7 +20,6 @@ import com.intel.analytics.bigdl.nn.{MklInt8Convertible, Module, SpatialConvolut
 import com.intel.analytics.bigdl.nn.abstractnn.Activity
 import com.intel.analytics.bigdl.optim.{ValidationMethod, ValidationResult}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
-import com.intel.analytics.bigdl.transform.vision.image.{DistributedImageFrame, LocalImageFrame}
 import com.intel.analytics.zoo.feature.image.{DistributedImageSet, ImageSet, LocalImageSet}
 import com.intel.analytics.zoo.models.common.ZooModel
 import com.intel.analytics.zoo.models.image.imageclassification.ImageClassifier

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/image/common/ImageModel.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/image/common/ImageModel.scala
@@ -21,7 +21,7 @@ import com.intel.analytics.bigdl.nn.abstractnn.Activity
 import com.intel.analytics.bigdl.optim.{ValidationMethod, ValidationResult}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.transform.vision.image.{DistributedImageFrame, LocalImageFrame}
-import com.intel.analytics.zoo.feature.image.{DistributedImageSet, ImageSet}
+import com.intel.analytics.zoo.feature.image.{DistributedImageSet, ImageSet, LocalImageSet}
 import com.intel.analytics.zoo.models.common.ZooModel
 import com.intel.analytics.zoo.models.image.imageclassification.ImageClassifier
 import com.intel.analytics.zoo.models.image.objectdetection.ObjectDetector
@@ -47,12 +47,11 @@ abstract class ImageModel[T: ClassTag]()(implicit ev: TensorNumeric[T])
    */
   def predictImageSet(image: ImageSet, configure: ImageConfigure[T] = null):
   ImageSet = {
-    val imageFrame = image.toImageFrame()
-    val dataLength = imageFrame match {
-      case distributedImageFrame: DistributedImageFrame =>
-        distributedImageFrame.toDistributed().rdd.partitions.length
-      case localImageFrame: LocalImageFrame =>
-        localImageFrame.toLocal().array.length
+    val dataLength = image match {
+      case distributedImageSet: DistributedImageSet =>
+        distributedImageSet.toDistributed().rdd.partitions.length
+      case localImageSet: LocalImageSet =>
+        localImageSet.toLocal().array.length
     }
 
     require(dataLength > 0,

--- a/zoo/src/test/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationSpec.scala
@@ -194,8 +194,7 @@ class ImageClassifierSerialTest extends ModuleSerializationTest {
     val cmd = s"wget -P $dirName $url"
     val cmd_result = cmd !
 
-    //val model = ImageClassifier.loadModel[Float](dirName + "/" + modelFileName)
-    val model = ImageClassifier.loadModel[Float]("/home/yina/Documents/intel/model/analytics-zoo_resnet-50_imagenet_0.1.0.model")
+    val model = ImageClassifier.loadModel[Float](dirName + "/" + modelFileName)
     val input = Tensor[Float](Array(1, 3, 224, 224)).rand()
     ZooSpecHelper.testZooModelLoadSave(model.asInstanceOf[ZooModel[Tensor[Float], Tensor[Float],
      Float]], input, ImageClassifier.loadModel[Float])

--- a/zoo/src/test/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationSpec.scala
@@ -156,30 +156,27 @@ class ImageClassificationSpec extends ZooSpecHelper {
   }
 
   "ImageClassifier" should "throw exception if input is empty locally" in {
-    val path = "./tempEmpty"
-    "mkdir " + path !!
+    val tempDir = Files.createTempDir()
     val thrown = intercept[Exception]{
       predictLocal("https://s3-ap-southeast-1.amazonaws.com/analytics-zoo-models/" +
         "imageclassification/imagenet/analytics-zoo_inception-v1-quantize_imagenet_0.1.0.model",
-        "analytics-zoo", path)
+        "analytics-zoo", tempDir.getAbsolutePath)
     }
     assert("requirement failed: ImageModel.predictImageSet: input is empty, please check your " +
       "image path." == thrown.getMessage)
-    "rm -rf " +  path +  " ./imc.model" !!
+    "rm -rf ./imc.model" !!
   }
 
   "ImageClassifier" should "throw exception if input is empty" in {
-    val path = "./tempEmpty"
-    "mkdir " + path !!
+    val tempDir = Files.createTempDir()
     val thrown = intercept[Exception]{
       predict("https://s3-ap-southeast-1.amazonaws.com/analytics-zoo-models/" +
         "imageclassification/imagenet/analytics-zoo_inception-v1-quantize_imagenet_0.1.0.model",
-        "analytics-zoo", path)
+        "analytics-zoo", tempDir.getAbsolutePath)
     }
     assert("requirement failed: ImageModel.predictImageSet: input is empty, please check your " +
       "image path." == thrown.getMessage)
-
-    "rm -rf " +  path +  " ./imc.model" !!
+    "rm -rf ./imc.model" !!
   }
 }
 

--- a/zoo/src/test/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationSpec.scala
@@ -29,8 +29,6 @@ import com.intel.analytics.zoo.models.image.common.ImageConfigure
 import com.intel.analytics.zoo.pipeline.api.keras.ZooSpecHelper
 import com.intel.analytics.zoo.pipeline.api.keras.serializer.ModuleSerializationTest
 import org.apache.commons.io.FileUtils
-import org.apache.spark.{SparkConf, SparkContext}
-import org.scalatest.{FlatSpec, Matchers}
 
 import scala.language.postfixOps
 import sys.process._
@@ -38,7 +36,7 @@ import sys.process._
 class ImageClassificationSpec extends ZooSpecHelper {
   val resource = getClass.getClassLoader.getResource("imagenet/n04370456/")
 
-  def predictLocal(url: String, publisher: String): Unit = {
+  def predictLocal(url: String, publisher: String, path: String): Unit = {
     val tmpFile = Files.createTempDir()
     val dir = new File(tmpFile.toString + "/models")
     val dirName = dir.getCanonicalPath
@@ -50,7 +48,7 @@ class ImageClassificationSpec extends ZooSpecHelper {
     System.setProperty("bigdl.localMode", "true")
     Engine.init
 
-    val image = ImageSet.read(resource.getFile)
+    val image = ImageSet.read(path)
     val model = ImageClassifier.loadModel[Float](dirName + "/" + modelFileName)
     model.saveModel("./imc.model", overWrite = true)
     var result = null.asInstanceOf[ImageSet]
@@ -65,7 +63,7 @@ class ImageClassificationSpec extends ZooSpecHelper {
     }
     val predicted = result.toLocal().array.map(_ (ImageFeature.predict).toString)
 
-    val image2 = ImageSet.read(resource.getFile)
+    val image2 = ImageSet.read(path)
     val model2 = ImageClassifier.loadModel[Float]("./imc.model")
     var result2 = null.asInstanceOf[ImageSet]
     if (!publisher.equalsIgnoreCase("analytics-zoo")) {
@@ -85,7 +83,7 @@ class ImageClassificationSpec extends ZooSpecHelper {
     "rm -rf ./imc.model" !!
   }
 
-  def predict(url: String, publisher: String): Unit = {
+  def predict(url: String, publisher: String, path: String): Unit = {
     val tmpFile = Files.createTempDir()
     val dir = new File(tmpFile.toString + "/models")
     val dirName = dir.getCanonicalPath
@@ -99,7 +97,7 @@ class ImageClassificationSpec extends ZooSpecHelper {
 
     val model = ImageClassifier.loadModel[Float](dirName + "/" + modelFileName)
     model.saveModel("./imc.model", overWrite = true)
-    val image = ImageSet.read(resource.getFile, sc)
+    val image = ImageSet.read(path, sc)
     var result = null.asInstanceOf[ImageSet]
     var config = null.asInstanceOf[ImageConfigure[Float]]
     if (!publisher.equalsIgnoreCase("analytics-zoo")) {
@@ -113,7 +111,7 @@ class ImageClassificationSpec extends ZooSpecHelper {
     val predicted = result.toDistributed().rdd.collect()
 
     val model2 = ImageClassifier.loadModel[Float]("./imc.model")
-    val image2 = ImageSet.read(resource.getFile, sc)
+    val image2 = ImageSet.read(path, sc)
     var result2 = null.asInstanceOf[ImageSet]
     if (!publisher.equalsIgnoreCase("analytics-zoo"))
     {
@@ -138,22 +136,50 @@ class ImageClassificationSpec extends ZooSpecHelper {
   "ImageClassifier" should "predict inception-v1-quantize locally" in {
     predictLocal("https://s3-ap-southeast-1.amazonaws.com/analytics-zoo-models/" +
       "imageclassification/imagenet/analytics-zoo_inception-v1-quantize_imagenet_0.1.0.model",
-      "analytics-zoo")
+      "analytics-zoo", resource.getFile)
   }
 
   "ImageClassifier" should "predict inception-v1-quantize" in {
     predict("https://s3-ap-southeast-1.amazonaws.com/analytics-zoo-models/imageclassification/" +
-      "imagenet/analytics-zoo_inception-v1-quantize_imagenet_0.1.0.model", "analytics-zoo")
+      "imagenet/analytics-zoo_inception-v1-quantize_imagenet_0.1.0.model", "analytics-zoo",
+      resource.getFile)
   }
 
   "ImageClassifier" should "predict bigdl inception-v1-quantize locally" in {
     predictLocal("https://s3-ap-southeast-1.amazonaws.com/bigdl-models/imageclassification/" +
-      "imagenet/bigdl_inception-v1-quantize_imagenet_0.4.0.model", "bigdl")
+      "imagenet/bigdl_inception-v1-quantize_imagenet_0.4.0.model", "bigdl", resource.getFile)
   }
 
   "ImageClassifier" should "predict bigdl inception-v1-quantize" in {
     predict("https://s3-ap-southeast-1.amazonaws.com/bigdl-models/imageclassification/imagenet/" +
-      "bigdl_inception-v1-quantize_imagenet_0.4.0.model", "bigdl")
+      "bigdl_inception-v1-quantize_imagenet_0.4.0.model", "bigdl", resource.getFile)
+  }
+
+  "ImageClassifier" should "throw exception if input is empty locally" in {
+    val path = "./tempEmpty"
+    "mkdir " + path !!
+    val thrown = intercept[Exception]{
+      predictLocal("https://s3-ap-southeast-1.amazonaws.com/analytics-zoo-models/" +
+        "imageclassification/imagenet/analytics-zoo_inception-v1-quantize_imagenet_0.1.0.model",
+        "analytics-zoo", path)
+    }
+    assert("requirement failed: ImageModel.predictImageSet: input is empty, please check your " +
+      "image path." == thrown.getMessage)
+    "rm -rf " +  path +  " ./imc.model" !!
+  }
+
+  "ImageClassifier" should "throw exception if input is empty" in {
+    val path = "./tempEmpty"
+    "mkdir " + path !!
+    val thrown = intercept[Exception]{
+      predict("https://s3-ap-southeast-1.amazonaws.com/analytics-zoo-models/" +
+        "imageclassification/imagenet/analytics-zoo_inception-v1-quantize_imagenet_0.1.0.model",
+        "analytics-zoo", path)
+    }
+    assert("requirement failed: ImageModel.predictImageSet: input is empty, please check your " +
+      "image path." == thrown.getMessage)
+
+    "rm -rf " +  path +  " ./imc.model" !!
   }
 }
 
@@ -168,7 +194,8 @@ class ImageClassifierSerialTest extends ModuleSerializationTest {
     val cmd = s"wget -P $dirName $url"
     val cmd_result = cmd !
 
-    val model = ImageClassifier.loadModel[Float](dirName + "/" + modelFileName)
+    //val model = ImageClassifier.loadModel[Float](dirName + "/" + modelFileName)
+    val model = ImageClassifier.loadModel[Float]("/home/yina/Documents/intel/model/analytics-zoo_resnet-50_imagenet_0.1.0.model")
     val input = Tensor[Float](Array(1, 3, 224, 224)).rand()
     ZooSpecHelper.testZooModelLoadSave(model.asInstanceOf[ZooModel[Tensor[Float], Tensor[Float],
      Float]], input, ImageClassifier.loadModel[Float])


### PR DESCRIPTION
If the input is empty, throw an error message before calling model.predictImage.