### PR TITLE
Fix storage of Preprocessing objects in other filesystems

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimator.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimator.scala
@@ -16,18 +16,15 @@
 
 package com.intel.analytics.zoo.pipeline.nnframes
 
-import java.io.{FileInputStream, FileOutputStream, ObjectInputStream, ObjectOutputStream}
-
 import com.intel.analytics.bigdl.dataset.{SampleToMiniBatch, _}
 import com.intel.analytics.bigdl.models.utils.ModelBroadcast
 import com.intel.analytics.bigdl.optim._
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.tensor.{Tensor, DoubleType => TensorDouble, FloatType => TensorFloat}
-import com.intel.analytics.bigdl.utils.T
 import com.intel.analytics.bigdl.utils.serializer.ModuleLoader
+import com.intel.analytics.bigdl.utils.{File, T}
 import com.intel.analytics.bigdl.visualization.{TrainSummary, ValidationSummary}
 import com.intel.analytics.bigdl.{Criterion, DataSet, Module}
-import com.intel.analytics.zoo.common.CheckedObjectInputStream
 import com.intel.analytics.zoo.feature.common.{Preprocessing, _}
 import com.intel.analytics.zoo.pipeline.api.Net
 import com.intel.analytics.zoo.pipeline.api.keras.layers.utils.EngineRef
@@ -756,13 +753,8 @@ object NNModel extends MLReadable[NNModel[_]] {
         throw new Exception("Only support float and double for now")
     }
 
-    val ois = new CheckedObjectInputStream(classOf[Preprocessing[Any, Any]],
-      new FileInputStream(new Path(path, "samplePreprocessing").toString))
-    val featurePreprocessing = try {
-      ois.readObject.asInstanceOf[Preprocessing[Any, Any]]
-    } finally {
-      ois.close()
-    }
+    val featurePreprocessing =
+      File.load[Preprocessing[Any, Any]](new Path(path, "samplePreprocessing").toString)
 
     (meta, model, typeTag, featurePreprocessing)
   }
@@ -806,13 +798,8 @@ object NNModel extends MLReadable[NNModel[_]] {
     val (modulePath, weightPath) =
       new Path(path, "module").toString -> new Path(path, "weight").toString
     module.saveModule(modulePath, weightPath, isOverWrite)
-    val fos = new FileOutputStream(new Path(path, "samplePreprocessing").toString)
-    val oos = new ObjectOutputStream(fos)
-    try {
-      oos.writeObject(spCache)
-    } finally {
-      oos.close()
-    }
+
+    File.save(spCache, new Path(path, "samplePreprocessing").toString, isOverWrite)
   }
 
   override def read: MLReader[NNModel[_]] = new NNModelReader


### PR DESCRIPTION
Unit Tests of this fix should be implemented mocking HDFS or other FileSystem. For now, this feature its not implemented in any test and do it in this fix its out of task scope. In a future it should be tested propertly.
