### PR TITLE
Fix confusing scaler variable name

### DIFF
--- a/apps/anomaly-detection/anomaly-detection-nyc-taxi.ipynb
+++ b/apps/anomaly-detection/anomaly-detection-nyc-taxi.ipynb
@@ -365,8 +365,8 @@
    "source": [
     "#select and standardize data\n",
     "data_n = df[['value', 'hours', 'awake']]\n",
-    "min_max_scaler = preprocessing.StandardScaler()\n",
-    "np_scaled = min_max_scaler.fit_transform(data_n)\n",
+    "standard_scaler = preprocessing.StandardScaler()\n",
+    "np_scaled = standard_scaler.fit_transform(data_n)\n",
     "data_n = pd.DataFrame(np_scaled)\n",
     "\n",
     "#important parameters and train/test size\n",
@@ -628,7 +628,7 @@
     "axs.set_title('the predicted values and actual values (for the test data)')\n",
     "\n",
     "plt.xlabel('test data index')\n",
-    "plt.ylabel('number of taxi passengers after min_max_scalar')\n",
+    "plt.ylabel('number of taxi passengers after scaling')\n",
     "plt.legend(loc='upper left')\n",
     "plt.show()"
    ]
@@ -686,7 +686,7 @@
     "\n",
     "plt.hlines(threshold, 0, 1000, color='red', label='threshold')\n",
     "plt.xlabel('test data index')\n",
-    "plt.ylabel('difference value after min_max_scalar')\n",
+    "plt.ylabel('difference value after scaling')\n",
     "plt.legend(loc='upper left')\n",
     "plt.show()"
    ]


### PR DESCRIPTION
The notebook uses StandardScaler and stores it under variable name min_max_scaler, which is confusing.