### PR TITLE
fix pytroch on yarn model output is NaN

### DIFF
--- a/pyzoo/zoo/examples/pytorch/train/resnet_finetune/README.md
+++ b/pyzoo/zoo/examples/pytorch/train/resnet_finetune/README.md
@@ -59,28 +59,28 @@ After training, you should see something like this in the console:
 +--------------------+------------+-----+----------+
 |               image|        name|label|prediction|
 +--------------------+------------+-----+----------+
-|[file:/tmp/zoo/do...|cat.7028.jpg|  1.0|       1.0|
-|[file:/tmp/zoo/do...|cat.7208.jpg|  1.0|       1.0|
-|[file:/tmp/zoo/do...|cat.7244.jpg|  1.0|       1.0|
-|[file:/tmp/zoo/do...|cat.7329.jpg|  1.0|       1.0|
-|[file:/tmp/zoo/do...|cat.7434.jpg|  1.0|       1.0|
-|[file:/tmp/zoo/do...| cat.744.jpg|  1.0|       1.0|
-|[file:/tmp/zoo/do...|cat.7489.jpg|  1.0|       1.0|
-|[file:/tmp/zoo/do...|cat.7511.jpg|  1.0|       1.0|
-|[file:/tmp/zoo/do...|cat.7653.jpg|  1.0|       1.0|
-|[file:/tmp/zoo/do...|cat.7770.jpg|  1.0|       1.0|
-|[file:/tmp/zoo/do...|cat.7946.jpg|  1.0|       1.0|
-|[file:/tmp/zoo/do...| dog.706.jpg|  2.0|       2.0|
-|[file:/tmp/zoo/do...|dog.7239.jpg|  2.0|       2.0|
-|[file:/tmp/zoo/do...|dog.7318.jpg|  2.0|       2.0|
-|[file:/tmp/zoo/do...|dog.7386.jpg|  2.0|       2.0|
-|[file:/tmp/zoo/do...|dog.7412.jpg|  2.0|       2.0|
-|[file:/tmp/zoo/do...|dog.7742.jpg|  2.0|       2.0|
-|[file:/tmp/zoo/do...|dog.7761.jpg|  2.0|       2.0|
-|[file:/tmp/zoo/do...|dog.7842.jpg|  2.0|       2.0|
-|[file:/tmp/zoo/do...|dog.7866.jpg|  2.0|       2.0|
+|[hdfs://localhost...|cat.7122.jpg|  1.0|       1.0|
+|[hdfs://localhost...| cat.723.jpg|  1.0|       1.0|
+|[hdfs://localhost...|cat.7311.jpg|  1.0|       1.0|
+|[hdfs://localhost...|cat.7357.jpg|  1.0|       1.0|
+|[hdfs://localhost...|cat.7379.jpg|  1.0|       1.0|
+|[hdfs://localhost...|cat.7382.jpg|  1.0|       0.0|
+|[hdfs://localhost...|cat.7484.jpg|  1.0|       1.0|
+|[hdfs://localhost...|cat.7564.jpg|  1.0|       1.0|
+|[hdfs://localhost...|cat.7577.jpg|  1.0|       1.0|
+|[hdfs://localhost...|cat.7612.jpg|  1.0|       1.0|
+|[hdfs://localhost...|cat.7664.jpg|  1.0|       1.0|
+|[hdfs://localhost...|cat.7683.jpg|  1.0|       1.0|
+|[hdfs://localhost...|cat.7728.jpg|  1.0|       1.0|
+|[hdfs://localhost...|cat.7952.jpg|  1.0|       1.0|
+|[hdfs://localhost...|cat.7985.jpg|  1.0|       1.0|
+|[hdfs://localhost...|dog.7061.jpg|  0.0|       0.0|
+|[hdfs://localhost...|dog.7254.jpg|  0.0|       0.0|
+|[hdfs://localhost...|dog.7259.jpg|  0.0|       0.0|
+|[hdfs://localhost...| dog.730.jpg|  0.0|       0.0|
+|[hdfs://localhost...|dog.7391.jpg|  0.0|       0.0|
 +--------------------+------------+-----+----------+
 only showing top 20 rows
 
-
+Validation accuracy = 0.962441 
 ```

--- a/pyzoo/zoo/examples/pytorch/train/resnet_finetune/README.md
+++ b/pyzoo/zoo/examples/pytorch/train/resnet_finetune/README.md
@@ -44,18 +44,11 @@ You can easily use the following commands to run this example:
     python resnet_finetune.py /tmp/zoo/dogs_cats/samples
     ```
 
-- Run with Yarn Client mode
-If you want to run on a yarn cluster(yarn-client mode only), upload data to hdfs first:
+- Run with Yarn Client mode, upload data to hdfs first, export env `HADOOP_CONF_DIR` and `ZOO_CONDA_NAME`:  
     ```bash
     hdfs dfs -put /tmp/zoo/dogs_cats dogs_cats 
-    ```
-then, export env `HADOOP_CONF_DIR` and `ZOO_CONDA_NAME`:
-    ```bash
     export HADOOP_CONF_DIR=[path to your hadoop conf directory]
     export ZOO_CONDA_NAME=[conda environment name you just prepared above]
-    ```
-run the following command: 
-    ```bash
     python resnet_finetune.py dogs_cats/samples
     ```
 

--- a/pyzoo/zoo/examples/pytorch/train/resnet_finetune/README.md
+++ b/pyzoo/zoo/examples/pytorch/train/resnet_finetune/README.md
@@ -3,9 +3,22 @@
 In this example we use a pre-trained ResNet model, adding an extra layer to the end, to train
 a dog-vs-cat image classification model.
 
-## Install or download Analytics Zoo
-Follow the instructions [here](https://analytics-zoo.github.io/master/#PythonUserGuide/install/)
-to install analytics-zoo via __pip__ or __download the prebuilt package__.
+## Requirements
+* Python 3.6
+* JDK 1.8
+* Pytorch & TorchVision 1.1.0
+* Apache Spark 2.4.3(pyspark)
+* Analytics-Zoo 0.6.0-SNAPSHOT.dev8 and above
+* Jupyter Notebook, matplotlib
+
+## Prepare environments
+We recommend you to use [Anaconda](https://www.anaconda.com/distribution/#linux) to prepare the enviroments, especially if you want to run on a yarn cluster(yarn-client mode only). 
+```
+conda create -n zoo python=3.6 #zoo is conda enviroment name, you can set another name you like.
+conda activate zoo
+pip install analytics-zoo==0.6.0.dev8 jupyter matplotlib
+conda install pytorch-cpu torchvision-cpu -c pytorch
+```
 
 ## Image Fine Tuning
 1. For this example we use kaggle [Dogs vs. Cats](https://www.kaggle.com/c/dogs-vs-cats/data) train
@@ -25,29 +38,28 @@ and dogs into `samples` folder.
 2. Run the image fine tuning:
 resnet_finetune.py takes 1 parameter: Path to the images.
 
-- Run after pip install
+- Run with Spark Local mode
 You can easily use the following commands to run this example:
     ```bash
-    export SPARK_DRIVER_MEMORY=10g
     python resnet_finetune.py /tmp/zoo/dogs_cats/samples
     ```
-    See [here](https://analytics-zoo.github.io/master/#PythonUserGuide/run/#run-after-pip-install) for more running guidance after pip install.
 
-- Run with prebuilt package
-Run the following command for Spark local mode (`MASTER=local[*]`) or cluster mode:
+- Run with Yarn Client mode
+If you want to run on a yarn cluster(yarn-client mode only), upload data to hdfs first:
     ```bash
-    export SPARK_HOME=the root directory of Spark
-    export ANALYTICS_ZOO_HOME=the folder where you extract the downloaded Analytics Zoo zip package
-
-    ${ANALYTICS_ZOO_HOME}/bin/spark-submit-python-with-zoo.sh \
-    --master local[2] \
-    --driver-memory 10g \
-    resnet_finetune.py \
-    /tmp/zoo/dogs_cats/samples
+    hdfs dfs -put /tmp/zoo/dogs_cats dogs_cats 
     ```
-    See [here](https://analytics-zoo.github.io/master/#PythonUserGuide/run/#run-without-pip-install) for more running guidance without pip install.
+then, export env `HADOOP_CONF_DIR` and `ZOO_CONDA_NAME`:
+    ```bash
+    export HADOOP_CONF_DIR=[path to your hadoop conf directory]
+    export ZOO_CONDA_NAME=[conda environment name you just prepared above]
+    ```
+run the following command: 
+    ```bash
+    python resnet_finetune.py dogs_cats/samples
+    ```
 
-4. see the result
+3. see the result
 After training, you should see something like this in the console:
 
 ```

--- a/pyzoo/zoo/examples/pytorch/train/resnet_finetune/resnet_finetune.py
+++ b/pyzoo/zoo/examples/pytorch/train/resnet_finetune/resnet_finetune.py
@@ -50,10 +50,30 @@ if __name__ == '__main__':
         print("Need parameters: <imagePath>")
         exit(-1)
 
-    sparkConf = init_spark_conf().setAppName("resnet").setMaster("local[2]") \
-        .set('spark.driver.memory', '10g')
-    sc = init_nncontext(sparkConf)
-    spark = SparkSession.builder.config(conf=sparkConf).getOrCreate()
+    hadoop_conf_dir = os.environ.get('HADOOP_CONF_DIR')
+
+    if hadoop_conf_dir:
+        num_executors = 2
+        num_cores_per_executor = 4
+        sc = init_spark_on_yarn(
+            hadoop_conf=hadoop_conf_dir,
+            conda_name=os.environ["ZOO_CONDA_NAME"],  # The name of the created conda-env
+            num_executor=num_executors,
+            executor_cores=num_cores_per_executor,
+            executor_memory="10g",
+            driver_memory="2g",
+            driver_cores=1)
+    else:
+        num_executors = 1
+        num_cores_per_executor = 4
+        sc = init_spark_on_local(cores=4, conf={"spark.driver.memory": "10g"})
+
+    # sparkConf = init_spark_conf().setAppName("resnet").setMaster("local[2]") \
+    #     .set('spark.driver.memory', '10g')
+    # sc = init_nncontext(sparkConf)
+    # spark = SparkSession.builder.config(conf=sparkConf).getOrCreate()
+
+    print('------------------------------------')
 
     torchnet = TorchNet.from_pytorch(CatDogModel(), [4, 3, 224, 224])
 

--- a/pyzoo/zoo/examples/pytorch/train/resnet_finetune/resnet_finetune.py
+++ b/pyzoo/zoo/examples/pytorch/train/resnet_finetune/resnet_finetune.py
@@ -60,7 +60,7 @@ if __name__ == '__main__':
             conda_name=os.environ["ZOO_CONDA_NAME"],  # The name of the created conda-env
             num_executor=num_executors,
             executor_cores=num_cores_per_executor,
-            executor_memory="10g",
+            executor_memory="8g",
             driver_memory="2g",
             driver_cores=1)
     else:
@@ -92,13 +92,12 @@ if __name__ == '__main__':
 
     classifier = NNClassifier(torchnet, torchcriterion, featureTransformer) \
         .setLearningRate(0.001) \
-        .setBatchSize(64) \
-        .setEndWhen(MaxIteration(10)) \
+        .setBatchSize(16) \
+        .setMaxEpoch(1) \
         .setFeaturesCol("image") \
         .setCachingSample(False) \
-        .setValidation(SeveralIteration(5), validationDF, [Accuracy()], 64)
+        .setValidation(EveryEpoch(), validationDF, [Accuracy()], 16)
 
-    # .setMaxEpoch(1) \
     catdogModel = classifier.fit(trainingDF)
 
     shift = udf(lambda p: p - 1, DoubleType())
@@ -111,5 +110,4 @@ if __name__ == '__main__':
     accuracy = correct * 1.0 / overall
 
     # expecting: accuracy > 96%
-    print(str(overall) + " " + str(correct) + "\n")
     print("Validation accuracy = %g " % accuracy)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/common/Ranker.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/common/Ranker.scala
@@ -46,9 +46,10 @@ trait Ranker[T] {
     val result = x match {
       case distributed: DistributedTextSet =>
         val rdd = distributed.rdd
-        val modelBroad = ModelBroadcast[T]().broadcast(rdd.sparkContext, model.evaluate())
+        val modelBroad = ModelBroadcast[T]().broadcast(rdd.sparkContext, model)
         rdd.mapPartitions(partition => {
           val localModel = modelBroad.value()
+          localModel.evaluate()
           partition.map(feature => {
             val input = feature.getSample.feature()
             val output = localModel.forward(input).toTensor[T]

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchNet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchNet.scala
@@ -58,7 +58,7 @@ class TorchNet private(private val modelHolder: TorchModelHolder)
     if (weights == null) {
       val w = PytorchModel.getWeightNative(ref).clone()
       weights = Tensor(w, Array(w.length))
-    } else if (weights.nElement() > 0) {
+    } else if (!weights.isEmpty) {
       PytorchModel.updateWeightNative(ref, weights.storage().array())
     }
 
@@ -66,6 +66,14 @@ class TorchNet private(private val modelHolder: TorchModelHolder)
       gradients = Tensor()
     }
     ref
+  }
+
+  override def evaluate(): this.type = {
+    super.evaluate()
+    if (!weights.isEmpty) {
+      PytorchModel.updateWeightNative(nativeRef, weights.storage().array())
+    }
+    this
   }
 
   override def parameters(): (Array[Tensor[Float]], Array[Tensor[Float]]) = {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchNet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchNet.scala
@@ -58,6 +58,8 @@ class TorchNet private(private val modelHolder: TorchModelHolder)
     if (weights == null) {
       val w = PytorchModel.getWeightNative(ref).clone()
       weights = Tensor(w, Array(w.length))
+    } else if (weights.nElement() > 0) {
+      PytorchModel.updateWeightNative(ref, weights.storage().array())
     }
 
     if (gradients == null) {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchNet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchNet.scala
@@ -58,8 +58,6 @@ class TorchNet private(private val modelHolder: TorchModelHolder)
     if (weights == null) {
       val w = PytorchModel.getWeightNative(ref).clone()
       weights = Tensor(w, Array(w.length))
-    } else {
-      PytorchModel.updateWeightNative(ref, weights.storage().array())
     }
 
     if (gradients == null) {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimator.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimator.scala
@@ -475,8 +475,6 @@ class NNEstimator[T: ClassTag] private[zoo] (
       validationMethods
     )
     wrapBigDLModel(model)
-    model.parameters()._1.foreach(println)
-    wrapBigDLModel(optimizedModel)
   }
 
   /**

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimator.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimator.scala
@@ -475,6 +475,8 @@ class NNEstimator[T: ClassTag] private[zoo] (
       validationMethods
     )
     wrapBigDLModel(model)
+    model.parameters()._1.foreach(println)
+    wrapBigDLModel(optimizedModel)
   }
 
   /**
@@ -689,6 +691,7 @@ class NNModel[T: ClassTag] private[zoo] (
     // concat the prediction and other columns in DF. avoid zip between RDD
     val resultRDD = dataFrame.rdd.mapPartitions { rowIter =>
       val localModel = modelBroadCast.value()
+      localModel.evaluate()
       val featureSteps = featureTransformersBC.value.cloneTransformer()
       val toBatch = toBatchBC.value.cloneTransformer()
 


### PR DESCRIPTION
ModelBroadcast will set weights to empty tensor(not null).
When clone model in executor, this unnecessary updateWeightNative will lead to out of bound access as this weights is an empty tensor. Just remove it to fix the NaN problem.