### PR TITLE
Utils modification for Cluster Serving

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/NetUtils.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/NetUtils.scala
@@ -52,6 +52,9 @@ class GraphNet[T](graph: Graph[T])(implicit val tag: ClassTag[T], implicit val e
   // need to refer this object to make the register effective
   GraphNet
 
+  def getGraph(startNodes: ModuleNode[T]*): Graph[T] = {
+    labor
+  }
   private val labor = graph
   modules.append(labor)
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/inference/ModelLoader.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/inference/ModelLoader.scala
@@ -19,7 +19,7 @@ package com.intel.analytics.zoo.pipeline.inference
 import com.intel.analytics.bigdl.nn.Graph
 import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
 import com.intel.analytics.bigdl.utils.Engine
-import com.intel.analytics.bigdl.utils.caffe.CaffeLoader
+import com.intel.analytics.zoo.models.caffe.CaffeLoader
 import com.intel.analytics.bigdl.utils.serializer.ModuleLoader
 import com.intel.analytics.zoo.pipeline.api.keras.layers.WordEmbedding
 import com.intel.analytics.zoo.pipeline.api.keras.models.{Model, Sequential}
@@ -46,7 +46,7 @@ object ModelLoader extends InferenceSupportive {
       logger.info(s"load model from $modelPath and $weightPath")
       val model = ModuleLoader.loadFromFile[Float](modelPath, weightPath)
       logger.info(s"loaded model as $model")
-      model
+      model.quantize()
     }
   }
 
@@ -56,7 +56,7 @@ object ModelLoader extends InferenceSupportive {
       logger.info(s"load model from $modelPath and $weightPath")
       val model = CaffeLoader.loadCaffe[Float](modelPath, weightPath)._1.asInstanceOf[Graph[Float]]
       logger.info(s"loaded model as $model")
-      model
+      model.quantize()
     }
   }
 


### PR DESCRIPTION
After confirmed with BigDL team, and comprehensive test, we found that,

1) If convert graph to IRGraph, used in mkldnn backend, but backend is mklblas, the converted graph would not slow down the inference
2) If using mkldnn backend, we need to quantize the graph to IRGraph, the `isInt8` params is hard coded to `True`, but if there is no `Scale`, it would down-grade to fp32 model, thus would not affect the correctness.

In brief, we decide to quantize the graph anyway when loading inference model (no correctness or performance drawback), and modification in `GraphNet` is just to get the original graph