### PR TITLE
[Backport] Fix invalid cross-device and filesystem closed issues in Streaming examples

### DIFF
--- a/pyzoo/zoo/examples/streaming/objectdetection/README.md
+++ b/pyzoo/zoo/examples/streaming/objectdetection/README.md
@@ -15,6 +15,8 @@ So, there are two applications in this example: image_path_writer and streaming_
 ## Run this example
 Make sure all nodes can access image files, model and text files. Local file system/HDFS/Amazon S3 are supported.
 
+Pls ensure all paths exist and accessible, and `streaming_path` is empty. Note that `streaming_object_detection` and `image_path_writer` should use the same `streaming_path`.
+
 1. Start streaming_object_detection
 ```
 MASTER=...

--- a/pyzoo/zoo/examples/streaming/objectdetection/image_path_writer.py
+++ b/pyzoo/zoo/examples/streaming/objectdetection/image_path_writer.py
@@ -19,6 +19,7 @@ import random
 from time import sleep
 from os import listdir, rename, mkdir, remove
 from os.path import isfile, join
+import shutil
 
 
 def package_path_to_text(streaming_path, file_path, batch=10, delay=3):
@@ -49,8 +50,8 @@ def package_path_to_text(streaming_path, file_path, batch=10, delay=3):
         with open(join(tmpDir, str(index) + ".txt"), "w") as text_file:
             text_file.writelines(files[curr:last])
         # Move to streaming location
-        rename(text_file.name,
-               batch_file_name)
+        shutil.move(text_file.name,
+                    batch_file_name)
         print("Writing to " + batch_file_name)
         index += 1
         curr = last

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/streaming/objectdetection/README.md
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/streaming/objectdetection/README.md
@@ -14,6 +14,8 @@ So, there are two applications in this example: ImagePathWriter and StreamingObj
 ## Run this example
 Make sure all nodes can access image files, model and text files. Local file system/HDFS/Amazon S3 are supported.
 
+Pls ensure all paths exist and accessible, and `streamingPath` is empty. Note that `StreamingObjectDetection` and `ImagePathWriter` should use the same `streamingPath`.
+
 1. Start StreamingObjectDetection
 ```
 MASTER=...


### PR DESCRIPTION
* Fix Invalid cross-device link in image_path_writer.py.
* Fix HDFS filesystem closed issue in ImagePathWriter and StreamingObjectDetection.
* Modify document.