### PR TITLE
Update doc link of image classification documentation

### DIFF
--- a/docs/docs/ProgrammingGuide/image-classification.md
+++ b/docs/docs/ProgrammingGuide/image-classification.md
@@ -54,7 +54,7 @@ config = ImageConfigure(preprocessing)
 output = imc.predict_image_set(image_set)
 ```
 
-For preprocessors for Image Classification models, please check [Image Classification Config](https://github.com/intel-analytics/zoo/blob/master/zoo/src/main/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationConfig.scala)
+For preprocessors for Image Classification models, please check [Image Classification Config](https://github.com/intel-analytics/analytics-zoo/blob/master/zoo/src/main/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationConfig.scala)
 
 ## Download link
 


### PR DESCRIPTION
Change the link
"https://github.com/intel-analytics/zoo/blob/master/zoo/src/main/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationConfig.scala" to "https://github.com/intel-analytics/analytics-zoo/blob/master/zoo/src/main/scala/com/intel/analytics/zoo/models/image/imageclassification/ImageClassificationConfig.scala" in analytics-zoo/docs/docs/ProgrammingGuide/image-classification.md.

Related issue: https://github.com/intel-analytics/analytics-zoo/issues/1569