### PR TITLE
[backport 0.6] Upgrade bigdl python dependency to 0.9.1

### DIFF
--- a/docs/docs/PythonUserGuide/install.md
+++ b/docs/docs/PythonUserGuide/install.md
@@ -7,8 +7,8 @@ For Python users, Analytics Zoo can be installed either [from pip](#install-from
 You can use the following command to install the latest release version of __analytics-zoo__ via pip easily:
 
 ```bash
-pip install analytics-zoo==0.6.0     # for Python 2.7
-pip3 install analytics-zoo==0.6.0    # for Python 3.5 and Python 3.6
+pip install analytics-zoo==0.6.0 bigdl==0.9.1     # for Python 2.7
+pip3 install analytics-zoo==0.6.0 bigdl==0.9.1    # for Python 3.5 and Python 3.6
 ```
 
 * Note that you might need to add `sudo` if you don't have the permission for installation.
@@ -28,7 +28,7 @@ sc = init_nncontext()
 1. We've tested this package with pip 9.0.1. `pip install --upgrade pip` if necessary.
 2. Pip install supports __Mac__ and __Linux__ platforms.
 3. You need to install Java __>= JDK8__ before running Analytics Zoo, which is required by `pyspark`.
-4. `pyspark==2.4.3`, `bigdl==0.9.1` and their dependencies will automatically be installed if they haven't been detected in the current Python environment.
+4. `analytics-zoo==0.6.0` depends on `bigdl==0.9.1`. Also, `pyspark==2.4.3`, `conda-pack==0.3.1` and their dependencies will automatically be installed if they haven't been detected in the current Python environment.
 
 ---
 ## **Install from pip for yarn cluster**

--- a/pyzoo/setup.py
+++ b/pyzoo/setup.py
@@ -94,7 +94,7 @@ def setup_package():
         license='Apache License, Version 2.0',
         url='https://github.com/intel-analytics/analytics-zoo',
         packages=packages,
-        install_requires=['pyspark==2.4.3', 'bigdl==0.9.0', 'conda-pack==0.3.1'],
+        install_requires=['pyspark==2.4.3', 'bigdl==0.9.1', 'conda-pack==0.3.1'],
         dependency_links=['https://d3kbcqa49mib13.cloudfront.net/spark-2.0.0-bin-hadoop2.7.tgz'],
         include_package_data=True,
         package_data={"zoo.share": ['lib/analytics-zoo*with-dependencies.jar', 'conf/*', 'bin/*',


### PR DESCRIPTION
Also update doc to guide users to install bigdl 0.9.1 manually as a fix.