### PR TITLE
Start script support adding option which is a string with spaces

### DIFF
--- a/scripts/analytics-zoo-base.sh
+++ b/scripts/analytics-zoo-base.sh
@@ -26,4 +26,4 @@ ${SPARK_HOME}/bin/${SPARK_CMD} \
     --jars ${ANALYTICS_ZOO_JAR} \
     --conf spark.driver.extraClassPath=${ANALYTICS_ZOO_JAR} \
     --conf spark.executor.extraClassPath=${ANALYTICS_ZOO_JAR} \
-    $*
+    "$@"

--- a/scripts/jupyter-with-zoo.sh
+++ b/scripts/jupyter-with-zoo.sh
@@ -22,4 +22,4 @@ export SPARK_CMD=pyspark
 bash ${ANALYTICS_ZOO_HOME}/bin/analytics-zoo-base.sh \
     --conf spark.sql.catalogImplementation='in-memory' \
     --py-files ${ANALYTICS_ZOO_PY_ZIP} \
-    $*
+    "$@"

--- a/scripts/pyspark-shell-with-zoo.sh
+++ b/scripts/pyspark-shell-with-zoo.sh
@@ -17,4 +17,4 @@ export SPARK_CMD=pyspark
 
 bash ${ANALYTICS_ZOO_HOME}/bin/analytics-zoo-base.sh \
     --py-files ${ANALYTICS_ZOO_PY_ZIP} \
-    $*
+    "$@"

--- a/scripts/spark-shell-with-zoo.sh
+++ b/scripts/spark-shell-with-zoo.sh
@@ -15,4 +15,4 @@ source ${ANALYTICS_ZOO_HOME}/bin/analytics-zoo-env.sh
 
 export SPARK_CMD=spark-shell
 
-bash ${ANALYTICS_ZOO_HOME}/bin/analytics-zoo-base.sh $*
+bash ${ANALYTICS_ZOO_HOME}/bin/analytics-zoo-base.sh "$@"

--- a/scripts/spark-submit-python-with-zoo.sh
+++ b/scripts/spark-submit-python-with-zoo.sh
@@ -17,4 +17,4 @@ export SPARK_CMD=spark-submit
 
 bash ${ANALYTICS_ZOO_HOME}/bin/analytics-zoo-base.sh \
     --py-files ${ANALYTICS_ZOO_PY_ZIP} \
-    $*
+    "$@"

--- a/scripts/spark-submit-scala-with-zoo.sh
+++ b/scripts/spark-submit-scala-with-zoo.sh
@@ -16,4 +16,4 @@ source ${ANALYTICS_ZOO_HOME}/bin/analytics-zoo-env.sh
 export SPARK_CMD=spark-submit
 
 bash ${ANALYTICS_ZOO_HOME}/bin/analytics-zoo-base.sh \
-    $*
+    "$@"


### PR DESCRIPTION
Support adding option which is a string with spaces, e.g. `--option "a b c"`.

Iterating $* will result
```
--option
a
b
c
```

Iterating $@ will result
```
--option
a
b
c
```
Iterating "$*" will result
```
--option a b c
```
Iterating ”$@" will result
```
--option
a b c
```

