### PR TITLE
Support iterate a dataset in sequential order when training

### DIFF
--- a/pyzoo/zoo/feature/common.py
+++ b/pyzoo/zoo/feature/common.py
@@ -224,7 +224,9 @@ class FeatureSet(DataSet):
             self.value = jvalue
 
     @classmethod
-    def image_frame(cls, image_frame, memory_type="DRAM", bigdl_type="float"):
+    def image_frame(cls, image_frame, memory_type="DRAM",
+                    sequential_order=False,
+                    shuffle=True, bigdl_type="float"):
         """
         Create FeatureSet from ImageFrame.
         :param image_frame: ImageFrame
@@ -235,15 +237,21 @@ class FeatureSet(DataSet):
                               of the data into memory during the training. After going through the
                               1/n, we will release the current cache, and load another 1/n into
                               memory.
+        :param sequential_order: whether to iterate the elements in the feature set
+                                 in sequential order for training.
+        :param shuffle: whether to shuffle the elements in each partition before each epoch
+                        when training
         :param bigdl_type: numeric type
         :return: A feature set
         """
         jvalue = callBigDlFunc(bigdl_type, "createFeatureSetFromImageFrame",
-                               image_frame, memory_type)
+                               image_frame, memory_type, sequential_order, shuffle)
         return cls(jvalue=jvalue)
 
     @classmethod
-    def image_set(cls, imageset, memory_type="DRAM", bigdl_type="float"):
+    def image_set(cls, imageset, memory_type="DRAM",
+                  sequential_order=False,
+                  shuffle=True, bigdl_type="float"):
         """
         Create FeatureSet from ImageFrame.
         :param imageset: ImageSet
@@ -254,15 +262,22 @@ class FeatureSet(DataSet):
                               of the data into memory during the training. After going through the
                               1/n, we will release the current cache, and load another 1/n into
                               memory.
+        :param sequential_order: whether to iterate the elements in the feature set
+                                 in sequential order for training.
+        :param shuffle: whether to shuffle the elements in each partition before each epoch
+                        when training
         :param bigdl_type: numeric type
         :return: A feature set
         """
         jvalue = callBigDlFunc(bigdl_type, "createFeatureSetFromImageFrame",
-                               imageset.to_image_frame(), memory_type)
+                               imageset.to_image_frame(), memory_type,
+                               sequential_order, shuffle)
         return cls(jvalue=jvalue)
 
     @classmethod
-    def sample_rdd(cls, rdd, memory_type="DRAM", bigdl_type="float"):
+    def sample_rdd(cls, rdd, memory_type="DRAM",
+                   sequential_order=False,
+                   shuffle=True, bigdl_type="float"):
         """
         Create FeatureSet from RDD[Sample].
         :param rdd: A RDD[Sample]
@@ -273,14 +288,20 @@ class FeatureSet(DataSet):
                               of the data into memory during the training. After going through the
                               1/n, we will release the current cache, and load another 1/n into
                               memory.
+        :param sequential_order: whether to iterate the elements in the feature set
+                                 in sequential order when training.
+        :param shuffle: whether to shuffle the elements in each partition before each epoch
+                        when training
         :param bigdl_type:numeric type
         :return: A feature set
         """
-        jvalue = callBigDlFunc(bigdl_type, "createSampleFeatureSetFromRDD", rdd, memory_type)
+        jvalue = callBigDlFunc(bigdl_type, "createSampleFeatureSetFromRDD", rdd,
+                               memory_type, sequential_order, shuffle)
         return cls(jvalue=jvalue)
 
     @classmethod
-    def rdd(cls, rdd, memory_type="DRAM", bigdl_type="float"):
+    def rdd(cls, rdd, memory_type="DRAM", sequential_order=False,
+            shuffle=True, bigdl_type="float"):
         """
         Create FeatureSet from RDD.
         :param rdd: A RDD
@@ -291,10 +312,15 @@ class FeatureSet(DataSet):
                               of the data into memory during the training. After going through the
                               1/n, we will release the current cache, and load another 1/n into
                               memory.
+        :param sequential_order: whether to iterate the elements in the feature set
+                                 in sequential order when training.
+        :param shuffle: whether to shuffle the elements in each partition before each epoch
+                        when training
         :param bigdl_type:numeric type
         :return: A feature set
         """
-        jvalue = callBigDlFunc(bigdl_type, "createFeatureSetFromRDD", rdd, memory_type)
+        jvalue = callBigDlFunc(bigdl_type, "createFeatureSetFromRDD", rdd,
+                               memory_type, sequential_order, shuffle)
         return cls(jvalue=jvalue)
 
     def transform(self, transformer):

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
@@ -220,7 +220,9 @@ private[zoo] class DistributedDataSetWrapper[T: ClassTag](featureSet: Distribute
  */
 // T is the returning value type. like ByteRecord
 class CachedDistributedFeatureSet[T: ClassTag]
-(buffer: RDD[ArrayLike[T]])
+(buffer: RDD[ArrayLike[T]],
+ sequentialOrder: Boolean = false,
+ shouldShuffle: Boolean = true)
   extends DistributedFeatureSet[T]{
 
   protected lazy val count: Long = buffer.mapPartitions(iter => {
@@ -230,24 +232,37 @@ class CachedDistributedFeatureSet[T: ClassTag]
     Iterator.single(array.length)
   }).reduce(_ + _)
 
-  protected var indexes: RDD[Array[Int]] = buffer.mapPartitions(iter => {
-    Iterator.single[Array[Int]]((0 until iter.next().length).toArray[Int])
+  protected var indexes: RDD[(Array[Int], AtomicInteger)] = buffer.mapPartitions(iter => {
+    Iterator.single[(Array[Int], AtomicInteger)](((0 until iter.next().length).toArray[Int],
+      new AtomicInteger(0)))
   }).setName(s"origin index of ${buffer.name}").cache()
+
+
+  protected var offsets: RDD[AtomicInteger] = buffer.mapPartitions(iter => {
+    Iterator.single[AtomicInteger](new AtomicInteger(0))
+  }).setName(s"offsets of ${buffer.name}")
 
 
   override def data(train: Boolean): RDD[T] = {
     val _train = train
+    val _seq = sequentialOrder
     buffer.zipPartitions(indexes)((dataIter, indexIter) => {
-      val indexes = indexIter.next()
-      val indexOffset = math.max(1, indexes.length)
+      val (indexes, seqOffset) = indexIter.next()
+
+
+      val maxOffset = math.max(1, indexes.length)
       val localData = dataIter.next()
-      val offset = if (_train) {
-        RandomGenerator.RNG.uniform(0, indexOffset).toInt
+      val offset = if (_train && !_seq) {
+        RandomGenerator.RNG.uniform(0, maxOffset).toInt
+      } else if (_train && _seq) {
+        seqOffset.get()
       } else {
         0
       }
+      seqOffset.set(offset)
+
       new Iterator[T] {
-        private val _offset = new AtomicInteger(offset)
+        private val _offset = seqOffset
 
         override def hasNext: Boolean = {
           if (_train) true else _offset.get() < localData.length
@@ -255,6 +270,14 @@ class CachedDistributedFeatureSet[T: ClassTag]
 
         override def next(): T = {
           val i = _offset.getAndIncrement()
+          if (i >= localData.length) {
+            this.synchronized {
+              val value = _offset.get()
+              if (value >= localData.length) {
+                _offset.set(value % localData.length)
+              }
+            }
+          }
           if (_train) {
             // indexes is an Array, we should improve this
             // as the maximum length is limited by Int.max
@@ -274,10 +297,13 @@ class CachedDistributedFeatureSet[T: ClassTag]
   override def size(): Long = count
 
   override def shuffle(): Unit = {
-    indexes.unpersist()
-    indexes = buffer.mapPartitions(iter => {
-      Iterator.single(RandomGenerator.shuffle((0 until iter.next().length).toArray))
-    }).setName(s"shuffled index of ${buffer.name}").cache()
+    if (shouldShuffle) {
+      indexes.unpersist()
+      indexes = buffer.mapPartitions(iter => {
+        Iterator.single((RandomGenerator.shuffle((0 until iter.next().length).toArray),
+          new AtomicInteger(0)))
+      }).setName(s"shuffled index of ${buffer.name}").cache()
+    }
   }
 
   override def originRDD(): RDD[_] = buffer
@@ -389,12 +415,14 @@ class DiskFeatureSet[T: ClassTag]
 }
 
 object DRAMFeatureSet {
-  def rdd[T: ClassTag](data: RDD[T]): DistributedFeatureSet[T] = {
+  def rdd[T: ClassTag](data: RDD[T],
+                       sequentialOrder: Boolean = false,
+                       shuffle: Boolean = true): DistributedFeatureSet[T] = {
     val arrayLikeRDD = data.mapPartitions(iter => {
       Iterator.single(new ArrayLikeWrapper(iter.toArray))
     }).setName(s"cached feature set: ${data.name} in DRAM" )
       .cache().asInstanceOf[RDD[ArrayLike[T]]]
-    new CachedDistributedFeatureSet[T](arrayLikeRDD)
+    new CachedDistributedFeatureSet[T](arrayLikeRDD, sequentialOrder, shuffle)
   }
 }
 
@@ -403,22 +431,36 @@ object FeatureSet {
   def rdd[T: ClassTag](
        data: RDD[T],
        memoryType: MemoryType = DRAM,
-       dataStrategy: DataStrategy = PARTITIONED): DistributedFeatureSet[T] = {
+       dataStrategy: DataStrategy = PARTITIONED,
+       sequentialOrder: Boolean = false,
+       shuffle: Boolean = true): DistributedFeatureSet[T] = {
     dataStrategy match {
       case PARTITIONED =>
         val nodeNumber = EngineRef.getNodeNumber()
-        val repartitionedData = data.coalesce(nodeNumber, true).setName(data.name)
+        val repartitionedData = if (sequentialOrder && data.partitions.length == nodeNumber) {
+          data
+        } else {
+          data.coalesce(nodeNumber, true).setName(data.name)
+        }
         memoryType match {
           case DRAM =>
-            DRAMFeatureSet.rdd(repartitionedData)
+            DRAMFeatureSet.rdd(repartitionedData, sequentialOrder, shuffle)
           case PMEM =>
             logger.info("~~~~~~~ Caching with AEP ~~~~~~~")
-            PmemFeatureSet.rdd(repartitionedData, PMEM)
+            PmemFeatureSet.rdd(repartitionedData, PMEM, sequentialOrder, shuffle)
           case DIRECT =>
             logger.info("~~~~~~~ Caching with DIRECT ~~~~~~~")
-            PmemFeatureSet.rdd[T](repartitionedData, DIRECT)
+            PmemFeatureSet.rdd[T](repartitionedData, DIRECT, sequentialOrder, shuffle)
           case diskM: DISK_AND_DRAM =>
             logger.info(s"~~~~~~~ Caching with DISK_AND_DRAM(${diskM.numSlice}) ~~~~~~~")
+            if (sequentialOrder) {
+              throw new IllegalArgumentException("DiskFeatureSet does not support" +
+                " sequentialOrder.")
+            }
+
+            if (!shuffle) {
+              throw new IllegalArgumentException("DiskFeatureSet must use shuffle.")
+            }
             new DiskFeatureSet[T](data, diskM.numSlice)
           case _ =>
             throw new IllegalArgumentException(

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
@@ -270,7 +270,7 @@ class CachedDistributedFeatureSet[T: ClassTag]
 
         override def next(): T = {
           val i = _offset.getAndIncrement()
-          if (i >= localData.length) {
+          if (_train && i >= localData.length) {
             this.synchronized {
               val value = _offset.get()
               if (value >= localData.length) {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/pmem/FeatureSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/pmem/FeatureSet.scala
@@ -171,7 +171,9 @@ private[zoo] case class ImageFeatureArray(
 object PmemFeatureSet {
 
   private def rdd[T: ClassTag](data: RDD[T],
-      nativeArrayConverter: NativeArrayConverter[T]):
+      nativeArrayConverter: NativeArrayConverter[T],
+      sequentialOrder: Boolean,
+      shuffle: Boolean):
   DistributedFeatureSet[T] = {
     val countPerPartition = data.mapPartitions { iter =>
       require(iter.hasNext)
@@ -192,22 +194,28 @@ object PmemFeatureSet {
       nativeArrayConverter.toArray(dataIter, countIter)
     }.setName(s"FeatureSet: ${data.name} cached in PMEM")
       .cache()
-    new CachedDistributedFeatureSet[T](arrayRDD.asInstanceOf[RDD[ArrayLike[T]]])
+    new CachedDistributedFeatureSet[T](arrayRDD.asInstanceOf[RDD[ArrayLike[T]]],
+      sequentialOrder, shuffle)
   }
 
   def rdd[T: ClassTag](data: RDD[T],
-      memoryType: MemoryType = PMEM): DistributedFeatureSet[T] = {
+      memoryType: MemoryType = PMEM,
+      sequentialOrder: Boolean = false,
+      shuffle: Boolean = true): DistributedFeatureSet[T] = {
     var clazz: ClassTag[T] = implicitly[ClassTag[T]]
     implicitly[ClassTag[T]].runtimeClass match {
       case t if t == classOf[ByteRecord] =>
         rdd[ByteRecord](data.asInstanceOf[RDD[ByteRecord]],
-          new ByteRecordConverter(memoryType)).asInstanceOf[DistributedFeatureSet[T]]
+          new ByteRecordConverter(memoryType),
+          sequentialOrder, shuffle).asInstanceOf[DistributedFeatureSet[T]]
       case t if t == classOf[Sample[Float]] =>
         rdd[Sample[Float]](data.asInstanceOf[RDD[Sample[Float]]],
-          new SampleConverter(memoryType)).asInstanceOf[DistributedFeatureSet[T]]
+          new SampleConverter(memoryType),
+          sequentialOrder, shuffle).asInstanceOf[DistributedFeatureSet[T]]
       case t if t == classOf[ImageFeature] =>
         rdd[ImageFeature](data.asInstanceOf[RDD[ImageFeature]],
-          new ImageFeatureConverter(memoryType)).asInstanceOf[DistributedFeatureSet[T]]
+          new ImageFeatureConverter(memoryType),
+          sequentialOrder, shuffle).asInstanceOf[DistributedFeatureSet[T]]
       case _ =>
         throw new IllegalArgumentException(
           s"${implicitly[ClassTag[T]].runtimeClass} is not supported for now")

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/python/PythonFeatureSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/python/PythonFeatureSet.scala
@@ -38,20 +38,31 @@ object PythonFeatureSet {
 class PythonFeatureSet[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonZoo[T] {
   def createFeatureSetFromImageFrame(
         imageFrame: ImageFrame,
-        memoryType: String): FeatureSet[ImageFeature] = {
+        memoryType: String,
+        sequentialOrder: Boolean, shuffle: Boolean): FeatureSet[ImageFeature] = {
     require(imageFrame.isDistributed(), "Only support distributed ImageFrame")
-    FeatureSet.rdd(imageFrame.toDistributed().rdd, MemoryType.fromString(memoryType))
+    FeatureSet.rdd(imageFrame.toDistributed().rdd, MemoryType.fromString(memoryType),
+      sequentialOrder = sequentialOrder, shuffle = shuffle)
   }
 
   def createFeatureSetFromRDD(
         data: JavaRDD[Any],
-        memoryType: String): FeatureSet[Any] = {
-    FeatureSet.rdd(data, MemoryType.fromString(memoryType))
+        memoryType: String,
+        sequentialOrder: Boolean,
+        shuffle: Boolean): FeatureSet[Any] = {
+    FeatureSet.rdd(data, MemoryType.fromString(memoryType),
+      sequentialOrder = sequentialOrder, shuffle = shuffle)
   }
 
-  def createSampleFeatureSetFromRDD(data: JavaRDD[Sample], memoryType: String)
+  def createSampleFeatureSetFromRDD(data: JavaRDD[Sample],
+                                    memoryType: String,
+                                    sequentialOrder: Boolean,
+                                    shuffle: Boolean)
   : FeatureSet[JSample[T]] = {
-    FeatureSet.rdd(toJSample(data), MemoryType.fromString(memoryType))
+    FeatureSet.rdd(toJSample(data),
+      MemoryType.fromString(memoryType),
+      sequentialOrder = sequentialOrder,
+      shuffle = shuffle)
   }
 
   def transformFeatureSet(featureSet: FeatureSet[Any],

--- a/zoo/src/test/scala/com/intel/analytics/zoo/feature/FeatureSetSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/feature/FeatureSetSpec.scala
@@ -47,6 +47,7 @@ class FeatureSetSpec extends FlatSpec with Matchers with BeforeAndAfter {
     }
 
     assert(seq == (0 until 10))
+    fs.unpersist()
   }
 
 
@@ -67,5 +68,6 @@ class FeatureSetSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
     assert(firstRound != (0 until 10))
     assert(set.isEmpty)
+    fs.unpersist()
   }
 }

--- a/zoo/src/test/scala/com/intel/analytics/zoo/feature/FeatureSetSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/feature/FeatureSetSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Analytics Zoo Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.zoo.feature
+
+import com.intel.analytics.zoo.common.NNContext
+import org.apache.spark.{SparkConf, SparkContext}
+import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
+
+
+
+class FeatureSetSpec extends FlatSpec with Matchers with BeforeAndAfter {
+  var sc : SparkContext = _
+
+  before {
+    val conf = new SparkConf().setAppName("Test Feature Set").setMaster("local[1]")
+    sc = NNContext.initNNContext(conf)
+  }
+
+  after {
+    if (sc != null) {
+      sc.stop()
+    }
+  }
+
+  "FeatureSet" should "iterate in sequential order without shuffle" in {
+
+    val rdd = sc.parallelize(0 until 10, numSlices = 1)
+
+    val fs = FeatureSet.rdd(rdd, sequentialOrder = true, shuffle = false)
+
+    val data = fs.data(train = true)
+    val seq = for (i <- 0 until 10) yield {
+      data.first()
+    }
+
+    assert(seq == (0 until 10))
+  }
+
+
+  "FeatureSet" should "iterate in sequential order with shuffle" in {
+    val rdd = sc.parallelize(0 until 10, numSlices = 1)
+
+    val fs = FeatureSet.rdd(rdd, sequentialOrder = true)
+    fs.shuffle()
+    val data = fs.data(train = true)
+    val set = scala.collection.mutable.Set[Int]()
+    set ++= (0 until 10)
+
+    val firstRound = for (i <- 0 until 10) yield {
+      val value = data.first()
+
+      set -= value
+    }
+
+    assert(firstRound != (0 until 10))
+    assert(set.isEmpty)
+  }
+}


### PR DESCRIPTION
It is more common to iterate a dataset in sequential order than to random sample with replacement.