### PR TITLE
[Automl]fix bug of predict_with_uncertainty and add MCDropout for seq2seq model

### DIFF
--- a/pyzoo/test/zoo/automl/model/test_VanillaLSTM.py
+++ b/pyzoo/test/zoo/automl/model/test_VanillaLSTM.py
@@ -98,6 +98,19 @@ class TestVanillaLSTM(ZooTestCase):
         prediction, uncertainty = self.model.predict_with_uncertainty(self.x_test, n_iter=10)
         assert prediction.shape == (self.x_test.shape[0], 1)
         assert uncertainty.shape == (self.x_test.shape[0], 1)
+        assert np.any(uncertainty)
+
+        new_model = VanillaLSTM(check_optional_config=False)
+        dirname = tempfile.mkdtemp(prefix="automl_test_feature")
+        try:
+            save(dirname, model=self.model)
+            restore(dirname, model=new_model, config=self.config)
+            prediction, uncertainty = new_model.predict_with_uncertainty(self.x_test, n_iter=2)
+            assert prediction.shape == (self.x_test.shape[0], 1)
+            assert uncertainty.shape == (self.x_test.shape[0], 1)
+            assert np.any(uncertainty)
+        finally:
+            shutil.rmtree(dirname)
 
 
 if __name__ == '__main__':

--- a/pyzoo/test/zoo/automl/model/test_VanillaLSTM.py
+++ b/pyzoo/test/zoo/automl/model/test_VanillaLSTM.py
@@ -57,6 +57,12 @@ class TestVanillaLSTM(ZooTestCase):
                                                self.y_train,
                                                **self.config))
 
+    def test_fit_eval_mc(self):
+        print("fit_eval:", self.model.fit_eval(self.x_train,
+                                               self.y_train,
+                                               mc=True,
+                                               **self.config))
+
     def test_evaluate(self):
         self.model.fit_eval(self.x_train, self.y_train, **self.config)
         mse, rs = self.model.evaluate(self.x_val,
@@ -86,6 +92,12 @@ class TestVanillaLSTM(ZooTestCase):
 
         finally:
             shutil.rmtree(dirname)
+
+    def test_predict_with_uncertainty(self,):
+        self.model.fit_eval(self.x_train, self.y_train, mc=True, **self.config)
+        prediction, uncertainty = self.model.predict_with_uncertainty(self.x_test, n_iter=10)
+        assert prediction.shape == (self.x_test.shape[0], 1)
+        assert uncertainty.shape == (self.x_test.shape[0], 1)
 
 
 if __name__ == '__main__':

--- a/pyzoo/test/zoo/automl/pipeline/test_time_sequence.py
+++ b/pyzoo/test/zoo/automl/pipeline/test_time_sequence.py
@@ -25,6 +25,7 @@ from zoo.automl.regression.time_sequence_predictor import *
 import numpy as np
 import pandas as pd
 import ray
+from pandas.util.testing import assert_frame_equal
 
 
 class TestTimeSequencePipeline(ZooTestCase):
@@ -169,8 +170,8 @@ class TestTimeSequencePipeline(ZooTestCase):
         # sample_num should > past_seq_len, the default value of which is 50
         y_pred_1 = self.pipeline_1.predict(test_df_list)
         assert len(y_pred_1) == 3
-        assert y_pred_1[0].equals(y_pred_1[1])
-        assert y_pred_1[1].equals(y_pred_1[2])
+        assert_frame_equal(y_pred_1[0], y_pred_1[1])
+        assert_frame_equal(y_pred_1[1], y_pred_1[2])
         assert y_pred_1[0].shape == (self.test_sample_num - self.default_past_seq_len + 1,
                                      self.future_seq_len_1 + 1)
 
@@ -187,8 +188,8 @@ class TestTimeSequencePipeline(ZooTestCase):
         self.pipeline_3 = self.tsp_3.fit(train_df_list, validation_df=val_df_list)
         y_pred_3 = self.pipeline_3.predict(test_df_list)
         assert len(y_pred_3) == 3
-        assert y_pred_3[0].equals(y_pred_3[1])
-        assert y_pred_3[0].equals(y_pred_3[2])
+        assert_frame_equal(y_pred_3[0], y_pred_3[1])
+        assert_frame_equal(y_pred_3[1], y_pred_3[2])
         assert y_pred_3[0].shape == (self.test_sample_num - self.default_past_seq_len + 1,
                                      self.future_seq_len_3 + 1)
 
@@ -492,6 +493,51 @@ class TestTimeSequencePipeline(ZooTestCase):
             shutil.rmtree(dirname)
 
     def test_predict_with_uncertainty(self):
+        # test future_seq_len = 1
+        self.pipeline_1 = self.tsp_1.fit(self.train_df, mc=True, validation_df=self.validation_df)
+        y_out, y_pred_uncertainty = self.pipeline_1.predict_with_uncertainty(self.test_df,
+                                                                             n_iter=2)
+        assert y_out.shape == (self.test_sample_num - self.default_past_seq_len + 1,
+                               self.future_seq_len_1 + 1)
+        assert y_pred_uncertainty.shape == (self.test_sample_num - self.default_past_seq_len + 1,
+                                            self.future_seq_len_1)
+        assert np.any(y_pred_uncertainty)
+
+        # test future_seq_len = 3
+        self.pipeline_3 = self.tsp_3.fit(self.train_df, mc=True, validation_df=self.validation_df)
+        y_out, y_pred_uncertainty = self.pipeline_3.predict_with_uncertainty(self.test_df,
+                                                                             n_iter=2)
+        assert y_out.shape == (self.test_sample_num - self.default_past_seq_len + 1,
+                               self.future_seq_len_3 + 1)
+        assert y_pred_uncertainty.shape == (self.test_sample_num - self.default_past_seq_len + 1,
+                                            self.future_seq_len_3)
+        assert np.any(y_pred_uncertainty)
+
+    def test_fit_predict_with_uncertainty(self):
+        # test future_seq_len = 1
+        self.pipeline_1 = self.tsp_1.fit(self.train_df, mc=True, validation_df=self.validation_df)
+        self.pipeline_1.fit(self.validation_df, mc=True, epoch_num=1)
+        y_out, y_pred_uncertainty = self.pipeline_1.predict_with_uncertainty(self.test_df,
+                                                                             n_iter=2)
+        assert y_out.shape == (self.test_sample_num - self.default_past_seq_len + 1,
+                               self.future_seq_len_1 + 1)
+        assert y_pred_uncertainty.shape == (self.test_sample_num - self.default_past_seq_len + 1,
+                                            self.future_seq_len_1)
+        assert np.any(y_pred_uncertainty)
+
+        # test future_seq_len = 3
+        self.pipeline_3 = self.tsp_3.fit(self.train_df, mc=True, validation_df=self.validation_df)
+        self.pipeline_3.fit(self.validation_df, mc=True, epoch_num=1)
+        y_out, y_pred_uncertainty = self.pipeline_3.predict_with_uncertainty(self.test_df,
+                                                                             n_iter=2)
+        assert y_out.shape == (self.test_sample_num - self.default_past_seq_len + 1,
+                               self.future_seq_len_3 + 1)
+        assert y_pred_uncertainty.shape == (self.test_sample_num - self.default_past_seq_len + 1,
+                                            self.future_seq_len_3)
+        assert np.any(y_pred_uncertainty)
+
+    def test_fit_fixed_configs_predict_with_uncertainty(self):
+        # test future_seq_len = 1
         self.pipeline_1 = self.tsp_1.fit(self.train_df, validation_df=self.validation_df)
         config_file = self.pipeline_1.config_save()
         assert os.path.isfile(config_file)
@@ -500,11 +546,28 @@ class TestTimeSequencePipeline(ZooTestCase):
         os.rmdir(os.path.dirname(os.path.abspath(config_file)))
         ppl = TimeSequencePipeline(name='test', config=configs)
         ppl.fit_with_fixed_configs(self.train_df, self.validation_df, mc=True)
-        y_out, y_pred_uncertainty = ppl.predict_with_uncertainty(self.test_df, n_iter=10)
+        y_out, y_pred_uncertainty = ppl.predict_with_uncertainty(self.test_df, n_iter=2)
         assert y_out.shape == (self.test_sample_num - self.default_past_seq_len + 1,
                                self.future_seq_len_1 + 1)
         assert y_pred_uncertainty.shape == (self.test_sample_num - self.default_past_seq_len + 1,
                                             self.future_seq_len_1)
+        assert np.any(y_pred_uncertainty)
+
+        # test future_seq_len = 3
+        self.pipeline_3 = self.tsp_3.fit(self.train_df, validation_df=self.validation_df)
+        config_file = self.pipeline_3.config_save()
+        assert os.path.isfile(config_file)
+        configs = load_config(config_file)
+        os.remove(config_file)
+        os.rmdir(os.path.dirname(os.path.abspath(config_file)))
+        ppl = TimeSequencePipeline(name='test', config=configs)
+        ppl.fit_with_fixed_configs(self.train_df, self.validation_df, mc=True)
+        y_out, y_pred_uncertainty = ppl.predict_with_uncertainty(self.test_df, n_iter=2)
+        assert y_out.shape == (self.test_sample_num - self.default_past_seq_len + 1,
+                               self.future_seq_len_3 + 1)
+        assert y_pred_uncertainty.shape == (self.test_sample_num - self.default_past_seq_len + 1,
+                                            self.future_seq_len_3)
+        assert np.any(y_pred_uncertainty)
 
 
 if __name__ == '__main__':

--- a/pyzoo/zoo/automl/feature/time_sequence.py
+++ b/pyzoo/zoo/automl/feature/time_sequence.py
@@ -201,6 +201,12 @@ class TimeSequenceFeatureTransformer(BaseFeatureTransformer):
         y_unscale = y * value_scale + value_mean
         return y_unscale
 
+    def unscale_uncertainty(self, y_uncertainty):
+        value_scale = self.scaler.scale_[0]
+        # print(value_scale)
+        y_uncertainty_unscle = y_uncertainty * value_scale
+        return y_uncertainty_unscle
+
     def _get_y_pred_df(self, y_pred_dt_df, y_pred_unscale):
         """
         get prediction data frame with datetime column and target column.

--- a/pyzoo/zoo/automl/model/Seq2Seq.py
+++ b/pyzoo/zoo/automl/model/Seq2Seq.py
@@ -45,7 +45,7 @@ class LSTMSeq2Seq(BaseModel):
         self.batch_size = None
         self.check_optional_config = check_optional_config
 
-    def _build_train(self, **config):
+    def _build_train(self, mc=False, **config):
         """
         build LSTM Seq2Seq model
         :param config:
@@ -58,6 +58,7 @@ class LSTMSeq2Seq(BaseModel):
         self.lr = config.get('lr', 0.001)
         # for restore in continuous training
         self.batch_size = config.get('batch_size', 64)
+        training = True if mc else None
 
         # Define an input sequence and process it.
         self.encoder_inputs = Input(shape=(None, self.feature_num), name="encoder_inputs")
@@ -65,7 +66,7 @@ class LSTMSeq2Seq(BaseModel):
                        dropout=self.dropout,
                        return_state=True,
                        name="encoder_lstm")
-        encoder_outputs, state_h, state_c = encoder(self.encoder_inputs)
+        encoder_outputs, state_h, state_c = encoder(self.encoder_inputs, training=training)
         # We discard `encoder_outputs` and only keep the states.
         self.encoder_states = [state_h, state_c]
 
@@ -80,6 +81,7 @@ class LSTMSeq2Seq(BaseModel):
                                  return_state=True,
                                  name="decoder_lstm")
         decoder_outputs, _, _ = self.decoder_lstm(self.decoder_inputs,
+                                                  training=training,
                                                   initial_state=self.encoder_states)
 
         self.decoder_dense = Dense(self.target_col_num, name="decoder_dense")
@@ -103,7 +105,8 @@ class LSTMSeq2Seq(BaseModel):
 
         self.decoder_dense = self.model.layers[4]
 
-    def _build_inference(self):
+    def _build_inference(self, mc=False):
+        training = True if mc else None
         # from our previous model - mapping encoder sequence to state vectors
         encoder_model = Model(self.encoder_inputs, self.encoder_states)
 
@@ -115,6 +118,7 @@ class LSTMSeq2Seq(BaseModel):
         decoder_states_inputs = [decoder_state_input_h, decoder_state_input_c]
 
         decoder_outputs, state_h, state_c = self.decoder_lstm(self.decoder_inputs,
+                                                              training=training,
                                                               initial_state=decoder_states_inputs)
         decoder_states = [state_h, state_c]
 
@@ -123,8 +127,8 @@ class LSTMSeq2Seq(BaseModel):
                               [decoder_outputs] + decoder_states)
         return encoder_model, decoder_model
 
-    def _decode_sequence(self, input_seq):
-        encoder_model, decoder_model = self._build_inference()
+    def _decode_sequence(self, input_seq, mc=False):
+        encoder_model, decoder_model = self._build_inference(mc=mc)
         # Encode the input as state vectors.
         states_value = encoder_model.predict(input_seq)
 
@@ -226,7 +230,7 @@ class LSTMSeq2Seq(BaseModel):
 
         # if model is not initialized, __build the model
         if self.model is None:
-            self._build_train(**config)
+            self._build_train(mc=mc, **config)
 
         # batch_size = config.get('batch_size', 64)
         epochs = config.get('epochs', 10)
@@ -264,13 +268,13 @@ class LSTMSeq2Seq(BaseModel):
         # y = np.squeeze(y, axis=2)
         return [Evaluator.evaluate(m, y, y_pred) for m in metric]
 
-    def predict(self, x):
+    def predict(self, x, mc=False):
         """
         Prediction on x.
         :param x: input
         :return: predicted y (expected dimension = 2)
         """
-        y_pred = self._decode_sequence(x)
+        y_pred = self._decode_sequence(x, mc=mc)
         y_pred = np.squeeze(y_pred, axis=2)
         return y_pred
 
@@ -278,7 +282,7 @@ class LSTMSeq2Seq(BaseModel):
         result = np.zeros((n_iter,) + (x.shape[0], self.future_seq_len))
 
         for i in range(n_iter):
-            result[i, :, :] = self.predict(x)
+            result[i, :, :] = self.predict(x, mc=True)
 
         prediction = result.mean(axis=0)
         uncertainty = result.std(axis=0)
@@ -343,9 +347,14 @@ class LSTMSeq2Seq(BaseModel):
 
 
 if __name__ == "__main__":
-    model = LSTMSeq2Seq(check_optional_config=False)
-    train_df, val_df, test_df = load_nytaxi_data_df()
-    feature_transformer = TimeSequenceFeatureTransformer()
+    dataset_path = os.getenv("ANALYTICS_ZOO_HOME") + "/bin/data/NAB/nyc_taxi/nyc_taxi.csv"
+    df = pd.read_csv(dataset_path)
+    from zoo.automl.common.util import split_input_df
+    train_df, val_df, test_df = split_input_df(df, val_split_ratio=0.1, test_split_ratio=0.1)
+    future_seq_len = 2
+    feature_transformer = TimeSequenceFeatureTransformer(future_seq_len=future_seq_len)
+    model = LSTMSeq2Seq(check_optional_config=False, future_seq_len=future_seq_len)
+
     config = {
         # 'input_shape_x': x_train.shape[1],
         # 'input_shape_y': x_train.shape[-1],
@@ -357,30 +366,43 @@ if __name__ == "__main__":
     x_train, y_train = feature_transformer.fit_transform(train_df, **config)
     x_test, y_test = feature_transformer.transform(test_df, is_train=True)
 
-    print("fit_eval:", model.fit_eval(x_train, y_train, validation_data=(x_test, y_test), **config))
+    print("fit_eval:", model.fit_eval(x_train, y_train, validation_data=(x_test, y_test),
+                                      mc=True, **config))
     print("evaluate:", model.evaluate(x_test, y_test))
     y_pred = model.predict(x_test)
     print(y_pred.shape)
+    y_pred, y_uncertainty = model.predict_with_uncertainty(x_test, n_iter=3)
+    print("shape of output of uncertain predict:", y_pred.shape, y_uncertainty.shape)
+    print(y_uncertainty[:5])
 
-    from matplotlib import pyplot as plt
+    dirname = 'tmp'
+    save(dirname, model=model)
+    restore(dirname, model=model, config=config)
+    y_pred, y_uncertainty = model.predict_with_uncertainty(x_test, n_iter=3)
+    print("shape of output of uncertain predict:", y_pred.shape, y_uncertainty.shape)
+    print(y_uncertainty[:5])
 
-    y_test = np.squeeze(y_test)
-    y_pred = np.squeeze(y_pred)
-
-    def plot_result(y_test, y_pred):
-        # target column of dataframe is "value"
-        # past sequence length is 50
-        # pred_value = pred_df["value"].values
-        # true_value = test_df["value"].values[50:]
-        fig, axs = plt.subplots()
-
-        axs.plot(y_pred, color='red', label='predicted values')
-        axs.plot(y_test, color='blue', label='actual values')
-        axs.set_title('the predicted values and actual values (for the test data)')
-
-        plt.xlabel('test data index')
-        plt.ylabel('number of taxi passengers')
-        plt.legend(loc='upper left')
-        plt.savefig("seq2seq_result.png")
-
-    plot_result(y_test, y_pred)
+    import shutil
+    shutil.rmtree(dirname)
+    # from matplotlib import pyplot as plt
+    #
+    # y_test = np.squeeze(y_test)
+    # y_pred = np.squeeze(y_pred)
+    #
+    # def plot_result(y_test, y_pred):
+    #     # target column of dataframe is "value"
+    #     # past sequence length is 50
+    #     # pred_value = pred_df["value"].values
+    #     # true_value = test_df["value"].values[50:]
+    #     fig, axs = plt.subplots()
+    #
+    #     axs.plot(y_pred, color='red', label='predicted values')
+    #     axs.plot(y_test, color='blue', label='actual values')
+    #     axs.set_title('the predicted values and actual values (for the test data)')
+    #
+    #     plt.xlabel('test data index')
+    #     plt.ylabel('number of taxi passengers')
+    #     plt.legend(loc='upper left')
+    #     plt.savefig("seq2seq_result.png")
+    #
+    # plot_result(y_test, y_pred)

--- a/pyzoo/zoo/automl/model/abstract.py
+++ b/pyzoo/zoo/automl/model/abstract.py
@@ -26,7 +26,7 @@ class BaseModel(ABC):
     future_seq_len = None
 
     @abstractmethod
-    def fit_eval(self, x, y, validation_data=None, verbose=0, **config):
+    def fit_eval(self, x, y, validation_data=None, mc=False, verbose=0, **config):
         """
         optimize and evaluate for one iteration for tuning
         :param config: tunable parameters for optimization
@@ -46,7 +46,7 @@ class BaseModel(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def predict(self, x):
+    def predict(self, x, mc=False):
         """
         Prediction.
         :param x: input

--- a/pyzoo/zoo/automl/model/time_sequence.py
+++ b/pyzoo/zoo/automl/model/time_sequence.py
@@ -75,7 +75,7 @@ class TimeSequenceModel(BaseModel):
         """
         return self.model.evaluate(x, y, metric)
 
-    def predict(self, x):
+    def predict(self, x, mc=False):
         """
         Prediction on x.
         :param x: input

--- a/pyzoo/zoo/automl/pipeline/time_sequence.py
+++ b/pyzoo/zoo/automl/pipeline/time_sequence.py
@@ -159,7 +159,8 @@ class TimeSequencePipeline(Pipeline):
         x, _ = self.feature_transformers.transform(input_df, is_train=False)
         y_pred, y_pred_uncertainty = self.model.predict_with_uncertainty(x=x, n_iter=n_iter)
         y_output = self.feature_transformers.post_processing(input_df, y_pred, is_train=False)
-        return y_output, y_pred_uncertainty
+        y_uncertainty = self.feature_transformers.unscale_uncertainty(y_pred_uncertainty)
+        return y_output, y_uncertainty
 
     def save(self, ppl_file=None):
         """

--- a/pyzoo/zoo/automl/pipeline/time_sequence.py
+++ b/pyzoo/zoo/automl/pipeline/time_sequence.py
@@ -46,14 +46,14 @@ class TimeSequencePipeline(Pipeline):
             print(info + ":", self.config[info])
         print("")
 
-    def fit(self, input_df, validation_df=None, epoch_num=20):
+    def fit(self, input_df, validation_df=None, mc=False, epoch_num=20):
         x, y = self.feature_transformers.transform(input_df, is_train=True)
         if validation_df is not None and not validation_df.empty:
             validation_data = self.feature_transformers.transform(validation_df)
         else:
             validation_data = None
         new_config = {'epochs': epoch_num}
-        self.model.fit_eval(x, y, validation_data, verbose=1, **new_config)
+        self.model.fit_eval(x, y, validation_data, mc=mc, verbose=1, **new_config)
         print('Fit done!')
 
     def _is_val_df_valid(self, validation_df):


### PR DESCRIPTION
- fix bug of predict_with_uncertainty: uncertainty value is not reverse transformed.

- add MCDropout for seq2seq model and UTs

- change interface for model.predict and pipeline.fit: add mc option

- fix bug of test pipeline predict function while input a list of data frames: sometimes UT fails on pd.Dataframe.equals(). And it works well with assert_frame_equal() 



