### PR TITLE
add callZooFunc and change all callBigDlFunc to callZooFunc

### DIFF
--- a/pyzoo/zoo/common/utils.py
+++ b/pyzoo/zoo/common/utils.py
@@ -18,7 +18,6 @@ import numpy as np
 
 
 def to_list_of_numpy(elements):
-
     if isinstance(elements, np.ndarray):
         return [elements]
     elif np.isscalar(elements):

--- a/pyzoo/zoo/common/utils.py
+++ b/pyzoo/zoo/common/utils.py
@@ -13,7 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from bigdl.util.common import Sample as BSample, JTensor as BJTensor, JavaCreator, _get_gateway, _java2py, _py2java
+from bigdl.util.common import Sample as BSample, JTensor as BJTensor,\
+    JavaCreator, _get_gateway, _java2py, _py2java
 import numpy as np
 
 

--- a/pyzoo/zoo/common/utils.py
+++ b/pyzoo/zoo/common/utils.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from bigdl.util.common import Sample as BSample, JTensor as BJTensor, callBigDlFunc, JavaCreator, _get_gateway, _java2py, _py2java
+from bigdl.util.common import Sample as BSample, JTensor as BJTensor, JavaCreator, _get_gateway, _java2py, _py2java
 import numpy as np
 
 
@@ -39,7 +39,7 @@ def to_list_of_numpy(elements):
 
 
 def set_core_number(num):
-    callBigDlFunc("float", "setCoreNumber", num)
+    callZooFunc("float", "setCoreNumber", num)
 
 
 def callZooFunc(bigdl_type, name, *args):

--- a/pyzoo/zoo/common/utils.py
+++ b/pyzoo/zoo/common/utils.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from bigdl.util.common import Sample as BSample, JTensor as BJTensor, callBigDlFunc
+from bigdl.util.common import Sample as BSample, JTensor as BJTensor, callBigDlFunc, JavaCreator, _get_gateway, _java2py, _py2java
 import numpy as np
 
 
@@ -40,6 +40,27 @@ def to_list_of_numpy(elements):
 
 def set_core_number(num):
     callBigDlFunc("float", "setCoreNumber", num)
+
+
+def callZooFunc(bigdl_type, name, *args):
+    """ Call API in PythonBigDL """
+    gateway = _get_gateway()
+    args = [_py2java(gateway, a) for a in args]
+    error = Exception("Cannot find function: %s" % name)
+    for jinvoker in JavaCreator.instance(bigdl_type, gateway).value:
+        # hasattr(jinvoker, name) always return true here,
+        # so you need to invoke the method to check if it exist or not
+        try:
+            api = getattr(jinvoker, name)
+            java_result = api(*args)
+            result = _java2py(gateway, java_result)
+        except Exception as e:
+            error = e
+            if "does not exist" not in str(e):
+                raise e
+        else:
+            return result
+    raise error
 
 
 class JTensor(BJTensor):

--- a/pyzoo/zoo/feature/common.py
+++ b/pyzoo/zoo/feature/common.py
@@ -28,6 +28,7 @@ class Relation(object):
     """
     It represents the relationship between two items.
     """
+
     def __init__(self, id1, id2, label, bigdl_type="float"):
         self.id1 = id1
         self.id2 = id2
@@ -92,6 +93,7 @@ class Preprocessing(JavaValue):
     Preprocessing defines data transform action during feature preprocessing. Python wrapper for
     the scala Preprocessing
     """
+
     def __init__(self, bigdl_type="float", *args):
         self.bigdl_type = bigdl_type
         self.value = callZooFunc(bigdl_type, JavaValue.jvm_class_constructor(self), *args)
@@ -119,6 +121,7 @@ class ChainedPreprocessing(Preprocessing):
     chains two Preprocessing together. The output type of the first
     Preprocessing should be the same with the input type of the second Preprocessing.
     """
+
     def __init__(self, transformers, bigdl_type="float"):
         for transfomer in transformers:
             assert isinstance(transfomer, Preprocessing), \
@@ -131,6 +134,7 @@ class ScalarToTensor(Preprocessing):
     """
     a Preprocessing that converts a number to a Tensor.
     """
+
     def __init__(self, bigdl_type="float"):
         super(ScalarToTensor, self).__init__(bigdl_type)
 
@@ -140,6 +144,7 @@ class SeqToTensor(Preprocessing):
     a Transformer that converts an Array[_] or Seq[_] to a Tensor.
     :param size dimensions of target Tensor.
     """
+
     def __init__(self, size=[], bigdl_type="float"):
         super(SeqToTensor, self).__init__(bigdl_type, size)
 
@@ -149,6 +154,7 @@ class SeqToMultipleTensors(Preprocessing):
     a Transformer that converts an Array[_] or Seq[_] or ML Vector to several tensors.
     :param size, list of int list, dimensions of target Tensors, e.g. [[2],[4]]
     """
+
     def __init__(self, size=[], bigdl_type="float"):
         super(SeqToMultipleTensors, self).__init__(bigdl_type, size)
 
@@ -158,6 +164,7 @@ class ArrayToTensor(Preprocessing):
     a Transformer that converts an Array[_] to a Tensor.
     :param size dimensions of target Tensor.
     """
+
     def __init__(self, size, bigdl_type="float"):
         super(ArrayToTensor, self).__init__(bigdl_type, size)
 
@@ -168,6 +175,7 @@ class MLlibVectorToTensor(Preprocessing):
     .. note:: Deprecated in 0.4.0. NNEstimator will automatically extract Vectors now.
     :param size dimensions of target Tensor.
     """
+
     def __init__(self, size, bigdl_type="float"):
         super(MLlibVectorToTensor, self).__init__(bigdl_type, size)
 
@@ -180,6 +188,7 @@ class FeatureLabelPreprocessing(Preprocessing):
     :param feature_transformer transformer for feature, transform F to Tensor[T]
     :param label_transformer transformer for label, transform L to Tensor[T]
     """
+
     def __init__(self, feature_transformer, label_transformer, bigdl_type="float"):
         super(FeatureLabelPreprocessing, self).__init__(bigdl_type,
                                                         feature_transformer, label_transformer)
@@ -189,6 +198,7 @@ class TensorToSample(Preprocessing):
     """
      a Transformer that converts Tensor to Sample.
     """
+
     def __init__(self, bigdl_type="float"):
         super(TensorToSample, self).__init__(bigdl_type)
 
@@ -207,6 +217,7 @@ class ToTuple(Preprocessing):
     """
      a Transformer that converts Feature to (Feature, None).
     """
+
     def __init__(self, bigdl_type="float"):
         super(ToTuple, self).__init__(bigdl_type)
 
@@ -219,6 +230,7 @@ class FeatureSet(DataSet):
     Different from BigDL's DataSet, this FeatureSet could be cached to Intel Optane DC Persistent
     Memory, if you set memory_type to PMEM when creating FeatureSet.
     """
+
     def __init__(self, jvalue=None, bigdl_type="float"):
         self.bigdl_type = bigdl_type
         if jvalue:
@@ -246,7 +258,7 @@ class FeatureSet(DataSet):
         :return: A feature set
         """
         jvalue = callZooFunc(bigdl_type, "createFeatureSetFromImageFrame",
-                               image_frame, memory_type, sequential_order, shuffle)
+                             image_frame, memory_type, sequential_order, shuffle)
         return cls(jvalue=jvalue)
 
     @classmethod
@@ -271,8 +283,8 @@ class FeatureSet(DataSet):
         :return: A feature set
         """
         jvalue = callZooFunc(bigdl_type, "createFeatureSetFromImageFrame",
-                               imageset.to_image_frame(), memory_type,
-                               sequential_order, shuffle)
+                             imageset.to_image_frame(), memory_type,
+                             sequential_order, shuffle)
         return cls(jvalue=jvalue)
 
     @classmethod
@@ -297,7 +309,7 @@ class FeatureSet(DataSet):
         :return: A feature set
         """
         jvalue = callZooFunc(bigdl_type, "createSampleFeatureSetFromRDD", rdd,
-                               memory_type, sequential_order, shuffle)
+                             memory_type, sequential_order, shuffle)
         return cls(jvalue=jvalue)
 
     @classmethod
@@ -321,7 +333,7 @@ class FeatureSet(DataSet):
         :return: A feature set
         """
         jvalue = callZooFunc(bigdl_type, "createFeatureSetFromRDD", rdd,
-                               memory_type, sequential_order, shuffle)
+                             memory_type, sequential_order, shuffle)
         return cls(jvalue=jvalue)
 
     def transform(self, transformer):

--- a/pyzoo/zoo/feature/common.py
+++ b/pyzoo/zoo/feature/common.py
@@ -15,6 +15,7 @@
 #
 
 from bigdl.util.common import *
+from zoo.common.utils import callZooFunc
 from bigdl.dataset.dataset import DataSet
 import sys
 
@@ -64,10 +65,10 @@ class Relations(object):
                                texts. Only need to specify this when sc is not None. Default is 1.
         """
         if sc:
-            jvalue = callBigDlFunc(bigdl_type, "readRelations", path, sc, min_partitions)
+            jvalue = callZooFunc(bigdl_type, "readRelations", path, sc, min_partitions)
             res = jvalue.map(lambda x: Relation(str(x[0]), str(x[1]), int(x[2])))
         else:
-            jvalue = callBigDlFunc(bigdl_type, "readRelations", path)
+            jvalue = callZooFunc(bigdl_type, "readRelations", path)
             res = [Relation(str(x[0]), str(x[1]), int(x[2])) for x in jvalue]
         return res
 
@@ -82,7 +83,7 @@ class Relations(object):
         :param sc: An instance of SparkContext.
         :return: RDD of Relation.
         """
-        jvalue = callBigDlFunc(bigdl_type, "readRelationsParquet", path, sc)
+        jvalue = callZooFunc(bigdl_type, "readRelationsParquet", path, sc)
         return jvalue.map(lambda x: Relation(str(x[0]), str(x[1]), int(x[2])))
 
 
@@ -93,7 +94,7 @@ class Preprocessing(JavaValue):
     """
     def __init__(self, bigdl_type="float", *args):
         self.bigdl_type = bigdl_type
-        self.value = callBigDlFunc(bigdl_type, JavaValue.jvm_class_constructor(self), *args)
+        self.value = callZooFunc(bigdl_type, JavaValue.jvm_class_constructor(self), *args)
 
     def __call__(self, input):
         """
@@ -106,10 +107,10 @@ class Preprocessing(JavaValue):
             from zoo.feature.text import TextSet
         # if type(input) is ImageSet:
         if isinstance(input, ImageSet):
-            jset = callBigDlFunc(self.bigdl_type, "transformImageSet", self.value, input)
+            jset = callZooFunc(self.bigdl_type, "transformImageSet", self.value, input)
             return ImageSet(jvalue=jset)
         elif isinstance(input, TextSet):
-            jset = callBigDlFunc(self.bigdl_type, "transformTextSet", self.value, input)
+            jset = callZooFunc(self.bigdl_type, "transformTextSet", self.value, input)
             return TextSet(jvalue=jset)
 
 
@@ -244,7 +245,7 @@ class FeatureSet(DataSet):
         :param bigdl_type: numeric type
         :return: A feature set
         """
-        jvalue = callBigDlFunc(bigdl_type, "createFeatureSetFromImageFrame",
+        jvalue = callZooFunc(bigdl_type, "createFeatureSetFromImageFrame",
                                image_frame, memory_type, sequential_order, shuffle)
         return cls(jvalue=jvalue)
 
@@ -269,7 +270,7 @@ class FeatureSet(DataSet):
         :param bigdl_type: numeric type
         :return: A feature set
         """
-        jvalue = callBigDlFunc(bigdl_type, "createFeatureSetFromImageFrame",
+        jvalue = callZooFunc(bigdl_type, "createFeatureSetFromImageFrame",
                                imageset.to_image_frame(), memory_type,
                                sequential_order, shuffle)
         return cls(jvalue=jvalue)
@@ -295,7 +296,7 @@ class FeatureSet(DataSet):
         :param bigdl_type:numeric type
         :return: A feature set
         """
-        jvalue = callBigDlFunc(bigdl_type, "createSampleFeatureSetFromRDD", rdd,
+        jvalue = callZooFunc(bigdl_type, "createSampleFeatureSetFromRDD", rdd,
                                memory_type, sequential_order, shuffle)
         return cls(jvalue=jvalue)
 
@@ -319,7 +320,7 @@ class FeatureSet(DataSet):
         :param bigdl_type:numeric type
         :return: A feature set
         """
-        jvalue = callBigDlFunc(bigdl_type, "createFeatureSetFromRDD", rdd,
+        jvalue = callZooFunc(bigdl_type, "createFeatureSetFromRDD", rdd,
                                memory_type, sequential_order, shuffle)
         return cls(jvalue=jvalue)
 
@@ -329,7 +330,7 @@ class FeatureSet(DataSet):
         :param transformer: the transformers to transform this feature set.
         :return: A feature set
         """
-        jvalue = callBigDlFunc(self.bigdl_type, "transformFeatureSet", self.value, transformer)
+        jvalue = callZooFunc(self.bigdl_type, "transformFeatureSet", self.value, transformer)
         return FeatureSet(jvalue=jvalue)
 
     def to_dataset(self):
@@ -337,5 +338,5 @@ class FeatureSet(DataSet):
         To BigDL compatible DataSet
         :return:
         """
-        jvalue = callBigDlFunc(self.bigdl_type, "featureSetToDataSet", self.value)
+        jvalue = callZooFunc(self.bigdl_type, "featureSetToDataSet", self.value)
         return FeatureSet(jvalue=jvalue)

--- a/pyzoo/zoo/feature/image/imageset.py
+++ b/pyzoo/zoo/feature/image/imageset.py
@@ -15,6 +15,7 @@
 #
 from bigdl.transform.vision.image import ImageFrame
 from bigdl.util.common import *
+from zoo.common.utils import callZooFunc
 
 
 class ImageSet(JavaValue):
@@ -34,20 +35,20 @@ class ImageSet(JavaValue):
         """
         whether this is a LocalImageSet
         """
-        return callBigDlFunc(self.bigdl_type, "isLocalImageSet", self.value)
+        return callZooFunc(self.bigdl_type, "isLocalImageSet", self.value)
 
     def is_distributed(self):
         """
         whether this is a DistributedImageSet
         """
-        return callBigDlFunc(self.bigdl_type, "isDistributedImageSet", self.value)
+        return callZooFunc(self.bigdl_type, "isDistributedImageSet", self.value)
 
     @property
     def label_map(self):
         """
         :return: the labelMap of this ImageSet, None if the ImageSet does not have a labelMap
         """
-        return callBigDlFunc(self.bigdl_type, "imageSetGetLabelMap", self.value)
+        return callZooFunc(self.bigdl_type, "imageSetGetLabelMap", self.value)
 
     @classmethod
     def read(cls, path, sc=None, min_partitions=1, resize_height=-1,
@@ -77,14 +78,14 @@ class ImageSet(JavaValue):
         :param one_based_label whether to use one based label
         :return ImageSet
         """
-        return ImageSet(jvalue=callBigDlFunc(bigdl_type, "readImageSet", path,
+        return ImageSet(jvalue=callZooFunc(bigdl_type, "readImageSet", path,
                                              sc, min_partitions, resize_height,
                                              resize_width, image_codec, with_label,
                                              one_based_label))
 
     @classmethod
     def from_image_frame(cls, image_frame, bigdl_type="float"):
-        return ImageSet(jvalue=callBigDlFunc(bigdl_type, "imageFrameToImageSet", image_frame))
+        return ImageSet(jvalue=callZooFunc(bigdl_type, "imageFrameToImageSet", image_frame))
 
     @classmethod
     def from_rdds(cls, image_rdd, label_rdd=None, bigdl_type="float"):
@@ -98,14 +99,14 @@ class ImageSet(JavaValue):
         image_rdd = image_rdd.map(lambda x: JTensor.from_ndarray(x))
         if label_rdd is not None:
             label_rdd = label_rdd.map(lambda x: JTensor.from_ndarray(x))
-        return ImageSet(jvalue=callBigDlFunc(bigdl_type, "createDistributedImageSet",
+        return ImageSet(jvalue=callZooFunc(bigdl_type, "createDistributedImageSet",
                                              image_rdd, label_rdd), bigdl_type=bigdl_type)
 
     def transform(self, transformer):
         """
         transformImageSet
         """
-        return ImageSet(callBigDlFunc(self.bigdl_type, "transformImageSet",
+        return ImageSet(callZooFunc(self.bigdl_type, "transformImageSet",
                                       transformer, self.value), self.bigdl_type)
 
     def get_image(self, key="floats", to_chw=True):
@@ -127,7 +128,7 @@ class ImageSet(JavaValue):
         return self.image_set.get_predict(key)
 
     def to_image_frame(self, bigdl_type="float"):
-        return ImageFrame(callBigDlFunc(bigdl_type, "imageSetToImageFrame", self.value), bigdl_type)
+        return ImageFrame(callZooFunc(bigdl_type, "imageSetToImageFrame", self.value), bigdl_type)
 
 
 class LocalImageSet(ImageSet):
@@ -143,7 +144,7 @@ class LocalImageSet(ImageSet):
             image_tensor_list = list(map(lambda image: JTensor.from_ndarray(image), image_list))
             label_tensor_list = list(map(lambda label: JTensor.from_ndarray(label), label_list))\
                 if label_list else None
-            self.value = callBigDlFunc(bigdl_type, JavaValue.jvm_class_constructor(self),
+            self.value = callZooFunc(bigdl_type, JavaValue.jvm_class_constructor(self),
                                        image_tensor_list, label_tensor_list)
         self.bigdl_type = bigdl_type
 
@@ -151,7 +152,7 @@ class LocalImageSet(ImageSet):
         """
         get image list from ImageSet
         """
-        tensors = callBigDlFunc(self.bigdl_type, "localImageSetToImageTensor",
+        tensors = callZooFunc(self.bigdl_type, "localImageSetToImageTensor",
                                 self.value, key, to_chw)
         return list(map(lambda tensor: tensor.to_ndarray(), tensors))
 
@@ -159,14 +160,14 @@ class LocalImageSet(ImageSet):
         """
         get label list from ImageSet
         """
-        labels = callBigDlFunc(self.bigdl_type, "localImageSetToLabelTensor", self.value)
+        labels = callZooFunc(self.bigdl_type, "localImageSetToLabelTensor", self.value)
         return map(lambda tensor: tensor.to_ndarray(), labels)
 
     def get_predict(self, key="predict"):
         """
         get prediction list from ImageSet
         """
-        predicts = callBigDlFunc(self.bigdl_type, "localImageSetToPredict", self.value, key)
+        predicts = callZooFunc(self.bigdl_type, "localImageSetToPredict", self.value, key)
         return list(map(lambda predict:
                         (predict[0], list(map(lambda x: x.to_ndarray(), predict[1]))) if predict[1]
                         else (predict[0], None), predicts))
@@ -186,7 +187,7 @@ class DistributedImageSet(ImageSet):
             image_tensor_rdd = image_rdd.map(lambda image: JTensor.from_ndarray(image))
             label_tensor_rdd = label_rdd.map(lambda label: JTensor.from_ndarray(label))\
                 if label_rdd else None
-            self.value = callBigDlFunc(bigdl_type, JavaValue.jvm_class_constructor(self),
+            self.value = callZooFunc(bigdl_type, JavaValue.jvm_class_constructor(self),
                                        image_tensor_rdd, label_tensor_rdd)
         self.bigdl_type = bigdl_type
 
@@ -194,7 +195,7 @@ class DistributedImageSet(ImageSet):
         """
         get image rdd from ImageSet
         """
-        tensor_rdd = callBigDlFunc(self.bigdl_type, "distributedImageSetToImageTensorRdd",
+        tensor_rdd = callZooFunc(self.bigdl_type, "distributedImageSetToImageTensorRdd",
                                    self.value, key, to_chw)
         return tensor_rdd.map(lambda tensor: tensor.to_ndarray())
 
@@ -202,7 +203,7 @@ class DistributedImageSet(ImageSet):
         """
         get label rdd from ImageSet
         """
-        tensor_rdd = callBigDlFunc(self.bigdl_type, "distributedImageSetToLabelTensorRdd",
+        tensor_rdd = callZooFunc(self.bigdl_type, "distributedImageSetToLabelTensorRdd",
                                    self.value)
         return tensor_rdd.map(lambda tensor: tensor.to_ndarray())
 
@@ -210,7 +211,7 @@ class DistributedImageSet(ImageSet):
         """
         get prediction rdd from ImageSet
         """
-        predicts = callBigDlFunc(self.bigdl_type, "distributedImageSetToPredict", self.value, key)
+        predicts = callZooFunc(self.bigdl_type, "distributedImageSetToPredict", self.value, key)
         return predicts.map(lambda predict:
                             (predict[0],
                              list(map(lambda x: x.to_ndarray(), predict[1]))) if predict[1]

--- a/pyzoo/zoo/feature/image/imageset.py
+++ b/pyzoo/zoo/feature/image/imageset.py
@@ -79,9 +79,9 @@ class ImageSet(JavaValue):
         :return ImageSet
         """
         return ImageSet(jvalue=callZooFunc(bigdl_type, "readImageSet", path,
-                                             sc, min_partitions, resize_height,
-                                             resize_width, image_codec, with_label,
-                                             one_based_label))
+                                           sc, min_partitions, resize_height,
+                                           resize_width, image_codec, with_label,
+                                           one_based_label))
 
     @classmethod
     def from_image_frame(cls, image_frame, bigdl_type="float"):
@@ -100,14 +100,14 @@ class ImageSet(JavaValue):
         if label_rdd is not None:
             label_rdd = label_rdd.map(lambda x: JTensor.from_ndarray(x))
         return ImageSet(jvalue=callZooFunc(bigdl_type, "createDistributedImageSet",
-                                             image_rdd, label_rdd), bigdl_type=bigdl_type)
+                                           image_rdd, label_rdd), bigdl_type=bigdl_type)
 
     def transform(self, transformer):
         """
         transformImageSet
         """
         return ImageSet(callZooFunc(self.bigdl_type, "transformImageSet",
-                                      transformer, self.value), self.bigdl_type)
+                                    transformer, self.value), self.bigdl_type)
 
     def get_image(self, key="floats", to_chw=True):
         """
@@ -135,6 +135,7 @@ class LocalImageSet(ImageSet):
     """
     LocalImageSet wraps a list of ImageFeature
     """
+
     def __init__(self, image_list=None, label_list=None, jvalue=None, bigdl_type="float"):
         assert jvalue or image_list, "jvalue and image_list cannot be None in the same time"
         if jvalue:
@@ -142,10 +143,10 @@ class LocalImageSet(ImageSet):
         else:
             # init from image ndarray list and label rdd(optional)
             image_tensor_list = list(map(lambda image: JTensor.from_ndarray(image), image_list))
-            label_tensor_list = list(map(lambda label: JTensor.from_ndarray(label), label_list))\
+            label_tensor_list = list(map(lambda label: JTensor.from_ndarray(label), label_list)) \
                 if label_list else None
             self.value = callZooFunc(bigdl_type, JavaValue.jvm_class_constructor(self),
-                                       image_tensor_list, label_tensor_list)
+                                     image_tensor_list, label_tensor_list)
         self.bigdl_type = bigdl_type
 
     def get_image(self, key="floats", to_chw=True):
@@ -153,7 +154,7 @@ class LocalImageSet(ImageSet):
         get image list from ImageSet
         """
         tensors = callZooFunc(self.bigdl_type, "localImageSetToImageTensor",
-                                self.value, key, to_chw)
+                              self.value, key, to_chw)
         return list(map(lambda tensor: tensor.to_ndarray(), tensors))
 
     def get_label(self):
@@ -185,10 +186,10 @@ class DistributedImageSet(ImageSet):
         else:
             # init from image ndarray rdd and label rdd(optional)
             image_tensor_rdd = image_rdd.map(lambda image: JTensor.from_ndarray(image))
-            label_tensor_rdd = label_rdd.map(lambda label: JTensor.from_ndarray(label))\
+            label_tensor_rdd = label_rdd.map(lambda label: JTensor.from_ndarray(label)) \
                 if label_rdd else None
             self.value = callZooFunc(bigdl_type, JavaValue.jvm_class_constructor(self),
-                                       image_tensor_rdd, label_tensor_rdd)
+                                     image_tensor_rdd, label_tensor_rdd)
         self.bigdl_type = bigdl_type
 
     def get_image(self, key="floats", to_chw=True):
@@ -196,7 +197,7 @@ class DistributedImageSet(ImageSet):
         get image rdd from ImageSet
         """
         tensor_rdd = callZooFunc(self.bigdl_type, "distributedImageSetToImageTensorRdd",
-                                   self.value, key, to_chw)
+                                 self.value, key, to_chw)
         return tensor_rdd.map(lambda tensor: tensor.to_ndarray())
 
     def get_label(self):
@@ -204,7 +205,7 @@ class DistributedImageSet(ImageSet):
         get label rdd from ImageSet
         """
         tensor_rdd = callZooFunc(self.bigdl_type, "distributedImageSetToLabelTensorRdd",
-                                   self.value)
+                                 self.value)
         return tensor_rdd.map(lambda tensor: tensor.to_ndarray())
 
     def get_predict(self, key="predict"):

--- a/pyzoo/zoo/feature/text/text_feature.py
+++ b/pyzoo/zoo/feature/text/text_feature.py
@@ -16,7 +16,8 @@
 
 import sys
 import six
-from bigdl.util.common import JavaValue, callBigDlFunc
+from bigdl.util.common import JavaValue
+from zoo.common.utils import callZooFunc
 
 if sys.version >= '3':
     long = int
@@ -46,7 +47,7 @@ class TextFeature(JavaValue):
 
         :return: String
         """
-        return callBigDlFunc(self.bigdl_type, "textFeatureGetText", self.value)
+        return callZooFunc(self.bigdl_type, "textFeatureGetText", self.value)
 
     def get_label(self):
         """
@@ -55,7 +56,7 @@ class TextFeature(JavaValue):
 
         :return: Int
         """
-        return callBigDlFunc(self.bigdl_type, "textFeatureGetLabel", self.value)
+        return callZooFunc(self.bigdl_type, "textFeatureGetLabel", self.value)
 
     def get_uri(self):
         """
@@ -64,7 +65,7 @@ class TextFeature(JavaValue):
 
         :return: String
         """
-        return callBigDlFunc(self.bigdl_type, "textFeatureGetURI", self.value)
+        return callZooFunc(self.bigdl_type, "textFeatureGetURI", self.value)
 
     def has_label(self):
         """
@@ -72,7 +73,7 @@ class TextFeature(JavaValue):
 
         :return: Boolean
         """
-        return callBigDlFunc(self.bigdl_type, "textFeatureHasLabel", self.value)
+        return callZooFunc(self.bigdl_type, "textFeatureHasLabel", self.value)
 
     def set_label(self, label):
         """
@@ -81,7 +82,7 @@ class TextFeature(JavaValue):
         :param label: Int
         :return: The TextFeature with label.
         """
-        self.value = callBigDlFunc(self.bigdl_type, "textFeatureSetLabel", self.value, int(label))
+        self.value = callZooFunc(self.bigdl_type, "textFeatureSetLabel", self.value, int(label))
         return self
 
     def get_tokens(self):
@@ -91,7 +92,7 @@ class TextFeature(JavaValue):
 
         :return: List of String
         """
-        return callBigDlFunc(self.bigdl_type, "textFeatureGetTokens", self.value)
+        return callZooFunc(self.bigdl_type, "textFeatureGetTokens", self.value)
 
     def get_sample(self):
         """
@@ -100,7 +101,7 @@ class TextFeature(JavaValue):
 
         :return: BigDL Sample
         """
-        return callBigDlFunc(self.bigdl_type, "textFeatureGetSample", self.value)
+        return callZooFunc(self.bigdl_type, "textFeatureGetSample", self.value)
 
     def keys(self):
         """
@@ -108,4 +109,4 @@ class TextFeature(JavaValue):
 
         :return: List of String
         """
-        return callBigDlFunc(self.bigdl_type, "textFeatureGetKeys", self.value)
+        return callZooFunc(self.bigdl_type, "textFeatureGetKeys", self.value)

--- a/pyzoo/zoo/feature/text/text_feature.py
+++ b/pyzoo/zoo/feature/text/text_feature.py
@@ -31,6 +31,7 @@ class TextFeature(JavaValue):
     e.g. original text content, uri, category label, tokens, index representation
     of tokens, BigDL Sample representation, prediction result and so on.
     """
+
     def __init__(self, text=None, label=None, uri=None, jvalue=None, bigdl_type="float"):
         if text is not None:
             assert isinstance(text, six.string_types), "text of a TextFeature should be a string"

--- a/pyzoo/zoo/feature/text/text_set.py
+++ b/pyzoo/zoo/feature/text/text_set.py
@@ -15,7 +15,8 @@
 #
 
 import six
-from bigdl.util.common import JavaValue, callBigDlFunc
+from bigdl.util.common import JavaValue
+from zoo.common.utils import callZooFunc
 from pyspark import RDD
 
 
@@ -32,7 +33,7 @@ class TextSet(JavaValue):
 
         :return: Boolean
         """
-        return callBigDlFunc(self.bigdl_type, "textSetIsLocal", self.value)
+        return callZooFunc(self.bigdl_type, "textSetIsLocal", self.value)
 
     def is_distributed(self):
         """
@@ -40,7 +41,7 @@ class TextSet(JavaValue):
 
         :return: Boolean
         """
-        return callBigDlFunc(self.bigdl_type, "textSetIsDistributed", self.value)
+        return callZooFunc(self.bigdl_type, "textSetIsDistributed", self.value)
 
     def to_distributed(self, sc=None, partition_num=4):
         """
@@ -55,7 +56,7 @@ class TextSet(JavaValue):
             jvalue = self.value
         else:
             assert sc, "sc cannot be null to transform a LocalTextSet to a DistributedTextSet"
-            jvalue = callBigDlFunc(self.bigdl_type, "textSetToDistributed", self.value,
+            jvalue = callZooFunc(self.bigdl_type, "textSetToDistributed", self.value,
                                    sc, partition_num)
         return DistributedTextSet(jvalue=jvalue)
 
@@ -68,7 +69,7 @@ class TextSet(JavaValue):
         if self.is_local():
             jvalue = self.value
         else:
-            jvalue = callBigDlFunc(self.bigdl_type, "textSetToLocal", self.value)
+            jvalue = callZooFunc(self.bigdl_type, "textSetToLocal", self.value)
         return LocalTextSet(jvalue=jvalue)
 
     def get_word_index(self):
@@ -78,7 +79,7 @@ class TextSet(JavaValue):
 
         :return: Dictionary {word: id}
         """
-        return callBigDlFunc(self.bigdl_type, "textSetGetWordIndex", self.value)
+        return callZooFunc(self.bigdl_type, "textSetGetWordIndex", self.value)
 
     def save_word_index(self, path):
         """
@@ -90,7 +91,7 @@ class TextSet(JavaValue):
 
         :param path: The path to the text file.
         """
-        callBigDlFunc(self.bigdl_type, "textSetSaveWordIndex", self.value, path)
+        callZooFunc(self.bigdl_type, "textSetSaveWordIndex", self.value, path)
 
     def load_word_index(self, path):
         """
@@ -107,7 +108,7 @@ class TextSet(JavaValue):
 
         :return: TextSet with the loaded word_index.
         """
-        jvalue = callBigDlFunc(self.bigdl_type, "textSetLoadWordIndex", self.value, path)
+        jvalue = callZooFunc(self.bigdl_type, "textSetLoadWordIndex", self.value, path)
         return TextSet(jvalue=jvalue)
 
     def set_word_index(self, vocab):
@@ -118,7 +119,7 @@ class TextSet(JavaValue):
 
         :return: TextSet with the word_index set.
         """
-        jvalue = callBigDlFunc(self.bigdl_type, "textSetSetWordIndex", self.value, vocab)
+        jvalue = callZooFunc(self.bigdl_type, "textSetSetWordIndex", self.value, vocab)
         return TextSet(jvalue=jvalue)
 
     def generate_word_index_map(self, remove_topN=0, max_words_num=-1,
@@ -131,7 +132,7 @@ class TextSet(JavaValue):
 
         :return: Dictionary {word: id}
         """
-        return callBigDlFunc(self.bigdl_type, "textSetGenerateWordIndexMap", self.value,
+        return callZooFunc(self.bigdl_type, "textSetGenerateWordIndexMap", self.value,
                              remove_topN, max_words_num, min_freq, existing_map)
 
     def get_texts(self):
@@ -141,7 +142,7 @@ class TextSet(JavaValue):
         :return: List of String for LocalTextSet.
                  RDD of String for DistributedTextSet.
         """
-        return callBigDlFunc(self.bigdl_type, "textSetGetTexts", self.value)
+        return callZooFunc(self.bigdl_type, "textSetGetTexts", self.value)
 
     def get_uris(self):
         """
@@ -151,7 +152,7 @@ class TextSet(JavaValue):
         :return: List of String for LocalTextSet.
                  RDD of String for DistributedTextSet.
         """
-        return callBigDlFunc(self.bigdl_type, "textSetGetURIs", self.value)
+        return callZooFunc(self.bigdl_type, "textSetGetURIs", self.value)
 
     def get_labels(self):
         """
@@ -161,7 +162,7 @@ class TextSet(JavaValue):
         :return: List of int for LocalTextSet.
                  RDD of int for DistributedTextSet.
         """
-        return callBigDlFunc(self.bigdl_type, "textSetGetLabels", self.value)
+        return callZooFunc(self.bigdl_type, "textSetGetLabels", self.value)
 
     def get_predicts(self):
         """
@@ -171,7 +172,7 @@ class TextSet(JavaValue):
         :return: List of list of numpy array for LocalTextSet.
                  RDD of list of numpy array for DistributedTextSet.
         """
-        predicts = callBigDlFunc(self.bigdl_type, "textSetGetPredicts", self.value)
+        predicts = callZooFunc(self.bigdl_type, "textSetGetPredicts", self.value)
         if isinstance(predicts, RDD):
             return predicts.map(lambda predict: _process_predict_result(predict))
         else:
@@ -185,7 +186,7 @@ class TextSet(JavaValue):
         :return: List of Sample for LocalTextSet.
                  RDD of Sample for DistributedTextSet.
         """
-        return callBigDlFunc(self.bigdl_type, "textSetGetSamples", self.value)
+        return callZooFunc(self.bigdl_type, "textSetGetSamples", self.value)
 
     def random_split(self, weights):
         """
@@ -194,7 +195,7 @@ class TextSet(JavaValue):
 
         :param weights: List of float indicating the split portions.
         """
-        jvalues = callBigDlFunc(self.bigdl_type, "textSetRandomSplit", self.value, weights)
+        jvalues = callZooFunc(self.bigdl_type, "textSetRandomSplit", self.value, weights)
         return [TextSet(jvalue=jvalue) for jvalue in list(jvalues)]
 
     def tokenize(self):
@@ -204,7 +205,7 @@ class TextSet(JavaValue):
 
         :return: TextSet after tokenization.
         """
-        jvalue = callBigDlFunc(self.bigdl_type, "textSetTokenize", self.value)
+        jvalue = callZooFunc(self.bigdl_type, "textSetTokenize", self.value)
         return TextSet(jvalue=jvalue)
 
     def normalize(self):
@@ -215,7 +216,7 @@ class TextSet(JavaValue):
 
         :return: TextSet after normalization.
         """
-        jvalue = callBigDlFunc(self.bigdl_type, "textSetNormalize", self.value)
+        jvalue = callZooFunc(self.bigdl_type, "textSetNormalize", self.value)
         return TextSet(jvalue=jvalue)
 
     def word2idx(self, remove_topN=0, max_words_num=-1, min_freq=1, existing_map=None):
@@ -263,7 +264,7 @@ class TextSet(JavaValue):
 
         :return: TextSet after word2idx.
         """
-        jvalue = callBigDlFunc(self.bigdl_type, "textSetWord2idx", self.value,
+        jvalue = callZooFunc(self.bigdl_type, "textSetWord2idx", self.value,
                                remove_topN, max_words_num, min_freq, existing_map)
         return TextSet(jvalue=jvalue)
 
@@ -276,7 +277,7 @@ class TextSet(JavaValue):
         :return: TextSet after sequence shaping.
         """
         assert isinstance(pad_element, int), "pad_element should be an int"
-        jvalue = callBigDlFunc(self.bigdl_type, "textSetShapeSequence", self.value,
+        jvalue = callZooFunc(self.bigdl_type, "textSetShapeSequence", self.value,
                                len, trunc_mode, pad_element)
         return TextSet(jvalue=jvalue)
 
@@ -288,11 +289,11 @@ class TextSet(JavaValue):
 
         :return: TextSet with Samples.
         """
-        jvalue = callBigDlFunc(self.bigdl_type, "textSetGenerateSample", self.value)
+        jvalue = callZooFunc(self.bigdl_type, "textSetGenerateSample", self.value)
         return TextSet(jvalue=jvalue)
 
     def transform(self, transformer):
-        return TextSet(callBigDlFunc(self.bigdl_type, "transformTextSet",
+        return TextSet(callZooFunc(self.bigdl_type, "transformTextSet",
                                      transformer, self.value), self.bigdl_type)
 
     @classmethod
@@ -322,7 +323,7 @@ class TextSet(JavaValue):
 
         :return: TextSet.
         """
-        jvalue = callBigDlFunc(bigdl_type, "readTextSet", path, sc, min_partitions)
+        jvalue = callZooFunc(bigdl_type, "readTextSet", path, sc, min_partitions)
         return TextSet(jvalue=jvalue)
 
     @classmethod
@@ -344,7 +345,7 @@ class TextSet(JavaValue):
 
         :return: TextSet.
         """
-        jvalue = callBigDlFunc(bigdl_type, "textSetReadCSV", path, sc, min_partitions)
+        jvalue = callZooFunc(bigdl_type, "textSetReadCSV", path, sc, min_partitions)
         return TextSet(jvalue=jvalue)
 
     @classmethod
@@ -359,7 +360,7 @@ class TextSet(JavaValue):
 
         :return: DistributedTextSet.
         """
-        jvalue = callBigDlFunc(bigdl_type, "textSetReadParquet", path, sc)
+        jvalue = callZooFunc(bigdl_type, "textSetReadParquet", path, sc)
         return DistributedTextSet(jvalue=jvalue)
 
     @classmethod
@@ -391,7 +392,7 @@ class TextSet(JavaValue):
             relations = [relation.to_tuple() for relation in relations]
         else:
             raise TypeError("relations should be RDD or list of Relation")
-        jvalue = callBigDlFunc(bigdl_type, "textSetFromRelationPairs", relations, corpus1, corpus2)
+        jvalue = callZooFunc(bigdl_type, "textSetFromRelationPairs", relations, corpus1, corpus2)
         return TextSet(jvalue=jvalue)
 
     @classmethod
@@ -425,7 +426,7 @@ class TextSet(JavaValue):
             relations = [relation.to_tuple() for relation in relations]
         else:
             raise TypeError("relations should be RDD or list of Relation")
-        jvalue = callBigDlFunc(bigdl_type, "textSetFromRelationLists", relations, corpus1, corpus2)
+        jvalue = callZooFunc(bigdl_type, "textSetFromRelationLists", relations, corpus1, corpus2)
         return TextSet(jvalue=jvalue)
 
 

--- a/pyzoo/zoo/feature/text/text_set.py
+++ b/pyzoo/zoo/feature/text/text_set.py
@@ -24,6 +24,7 @@ class TextSet(JavaValue):
     """
     TextSet wraps a set of texts with status.
     """
+
     def __init__(self, jvalue, bigdl_type="float", *args):
         super(TextSet, self).__init__(jvalue, bigdl_type, *args)
 
@@ -57,7 +58,7 @@ class TextSet(JavaValue):
         else:
             assert sc, "sc cannot be null to transform a LocalTextSet to a DistributedTextSet"
             jvalue = callZooFunc(self.bigdl_type, "textSetToDistributed", self.value,
-                                   sc, partition_num)
+                                 sc, partition_num)
         return DistributedTextSet(jvalue=jvalue)
 
     def to_local(self):
@@ -133,7 +134,7 @@ class TextSet(JavaValue):
         :return: Dictionary {word: id}
         """
         return callZooFunc(self.bigdl_type, "textSetGenerateWordIndexMap", self.value,
-                             remove_topN, max_words_num, min_freq, existing_map)
+                           remove_topN, max_words_num, min_freq, existing_map)
 
     def get_texts(self):
         """
@@ -265,7 +266,7 @@ class TextSet(JavaValue):
         :return: TextSet after word2idx.
         """
         jvalue = callZooFunc(self.bigdl_type, "textSetWord2idx", self.value,
-                               remove_topN, max_words_num, min_freq, existing_map)
+                             remove_topN, max_words_num, min_freq, existing_map)
         return TextSet(jvalue=jvalue)
 
     def shape_sequence(self, len, trunc_mode="pre", pad_element=0):
@@ -278,7 +279,7 @@ class TextSet(JavaValue):
         """
         assert isinstance(pad_element, int), "pad_element should be an int"
         jvalue = callZooFunc(self.bigdl_type, "textSetShapeSequence", self.value,
-                               len, trunc_mode, pad_element)
+                             len, trunc_mode, pad_element)
         return TextSet(jvalue=jvalue)
 
     def generate_sample(self):
@@ -294,7 +295,7 @@ class TextSet(JavaValue):
 
     def transform(self, transformer):
         return TextSet(callZooFunc(self.bigdl_type, "transformTextSet",
-                                     transformer, self.value), self.bigdl_type)
+                                   transformer, self.value), self.bigdl_type)
 
     @classmethod
     def read(cls, path, sc=None, min_partitions=1, bigdl_type="float"):
@@ -434,6 +435,7 @@ class LocalTextSet(TextSet):
     """
     LocalTextSet is comprised of lists.
     """
+
     def __init__(self, texts=None, labels=None, jvalue=None, bigdl_type="float"):
         """
         Create a LocalTextSet using texts and labels.
@@ -443,7 +445,7 @@ class LocalTextSet(TextSet):
         labels: List of int or None if texts don't have labels.
         """
         if texts is not None:
-            assert all(isinstance(text, six.string_types) for text in texts),\
+            assert all(isinstance(text, six.string_types) for text in texts), \
                 "texts for LocalTextSet should be list of string"
         if labels is not None:
             labels = [int(label) for label in labels]
@@ -454,6 +456,7 @@ class DistributedTextSet(TextSet):
     """
     DistributedTextSet is comprised of RDDs.
     """
+
     def __init__(self, texts=None, labels=None, jvalue=None, bigdl_type="float"):
         """
         Create a DistributedTextSet using texts and labels.

--- a/pyzoo/zoo/feature/text/transformer.py
+++ b/pyzoo/zoo/feature/text/transformer.py
@@ -29,6 +29,7 @@ class TextTransformer(Preprocessing):
     """
     Base class of Transformers that transform TextFeature.
     """
+
     def __init__(self, bigdl_type="float", *args):
         super(TextTransformer, self).__init__(bigdl_type, *args)
 
@@ -47,6 +48,7 @@ class Tokenizer(TextTransformer):
     >>> tokenizer = Tokenizer()
     creating: createTokenizer
     """
+
     def __init__(self, bigdl_type="float"):
         super(Tokenizer, self).__init__(bigdl_type)
 
@@ -60,6 +62,7 @@ class Normalizer(TextTransformer):
     >>> normalizer = Normalizer()
     creating: createNormalizer
     """
+
     def __init__(self, bigdl_type="float"):
         super(Normalizer, self).__init__(bigdl_type)
 
@@ -76,6 +79,7 @@ class WordIndexer(TextTransformer):
     >>> word_indexer = WordIndexer(map={"it": 1, "me": 2})
     creating: createWordIndexer
     """
+
     def __init__(self, map, bigdl_type="float"):
         super(WordIndexer, self).__init__(bigdl_type, map)
 
@@ -100,6 +104,7 @@ class SequenceShaper(TextTransformer):
     >>> sequence_shaper = SequenceShaper(len=6, trunc_mode="post", pad_element=10000)
     creating: createSequenceShaper
     """
+
     def __init__(self, len, trunc_mode="pre", pad_element=0, bigdl_type="float"):
         assert isinstance(pad_element, int), "pad_element should be an int"
         super(SequenceShaper, self).__init__(bigdl_type, len, trunc_mode, pad_element)
@@ -113,5 +118,6 @@ class TextFeatureToSample(TextTransformer):
     >>> to_sample = TextFeatureToSample()
     creating: createTextFeatureToSample
     """
+
     def __init__(self, bigdl_type="float"):
         super(TextFeatureToSample, self).__init__(bigdl_type)

--- a/pyzoo/zoo/feature/text/transformer.py
+++ b/pyzoo/zoo/feature/text/transformer.py
@@ -18,7 +18,7 @@ import sys
 import six
 from zoo.feature.common import Preprocessing
 from zoo.feature.text import TextFeature
-from bigdl.util.common import callBigDlFunc
+from zoo.common.utils import callZooFunc
 
 if sys.version >= '3':
     long = int
@@ -36,7 +36,7 @@ class TextTransformer(Preprocessing):
         """
         Transform a TextFeature.
         """
-        res = callBigDlFunc(self.bigdl_type, "transformTextFeature", self.value, text_feature.value)
+        res = callZooFunc(self.bigdl_type, "transformTextFeature", self.value, text_feature.value)
         return TextFeature(jvalue=res)
 
 

--- a/pyzoo/zoo/models/anomalydetection/anomaly_detector.py
+++ b/pyzoo/zoo/models/anomalydetection/anomaly_detector.py
@@ -19,7 +19,7 @@ import warnings
 from zoo.pipeline.api.keras.models import Sequential
 from zoo.pipeline.api.keras.layers import *
 from zoo.models.common import *
-from bigdl.util.common import callBigDlFunc
+from zoo.common.utils import callZooFunc
 from bigdl.util.common import Sample
 
 if sys.version >= '3':
@@ -85,7 +85,7 @@ class AnomalyDetector(KerasZooModel):
               Amazon S3 path should be like 's3a://bucket/xxx'.
         weight_path: The path for pre-trained weights if any. Default is None.
         """
-        jmodel = callBigDlFunc(bigdl_type, "loadAnomalyDetector", path, weight_path)
+        jmodel = callZooFunc(bigdl_type, "loadAnomalyDetector", path, weight_path)
         model = KerasZooModel._do_load(jmodel, bigdl_type)
         model.__class__ = AnomalyDetector
         return model
@@ -94,7 +94,7 @@ class AnomalyDetector(KerasZooModel):
         """
         Precict on RDD[Sample].
         """
-        results = callBigDlFunc(self.bigdl_type, "modelPredictRDD",
+        results = callZooFunc(self.bigdl_type, "modelPredictRDD",
                                 self.value,
                                 x,
                                 batch_per_thread)
@@ -118,7 +118,7 @@ class AnomalyDetector(KerasZooModel):
                      (3,4), 5, 2
                      (4,5), 6, 3
         """
-        result = callBigDlFunc("float", "unroll", data_rdd, unroll_length, predict_step)
+        result = callZooFunc("float", "unroll", data_rdd, unroll_length, predict_step)
         return cls._to_indexed_rdd(result)
 
     @classmethod
@@ -130,11 +130,11 @@ class AnomalyDetector(KerasZooModel):
         :param anomaly_size: Int. The size to be considered as anomalies.
         :return: RDD of [ytruth, ypredict, anomaly], anomaly is None or ytruth
         """
-        return callBigDlFunc("float", "detectAnomalies", ytruth, ypredict, anomaly_size)
+        return callZooFunc("float", "detectAnomalies", ytruth, ypredict, anomaly_size)
 
     @staticmethod
     def standardScale(df):
-        return callBigDlFunc("float", "standardScaleDF", df)
+        return callZooFunc("float", "standardScaleDF", df)
 
     @staticmethod
     def train_test_split(unrolled, test_size):

--- a/pyzoo/zoo/models/anomalydetection/anomaly_detector.py
+++ b/pyzoo/zoo/models/anomalydetection/anomaly_detector.py
@@ -36,6 +36,7 @@ class AnomalyDetector(KerasZooModel):
     hidden_layers: Units of hidden layers of LSTM.
     dropouts:     Fraction of the input units to drop out. Float between 0 and 1.
     """
+
     def __init__(self, feature_shape, hidden_layers=[8, 32, 15],
                  dropouts=[0.2, 0.2, 0.2], **kwargs):
         assert len(hidden_layers) == len(dropouts), \
@@ -95,9 +96,9 @@ class AnomalyDetector(KerasZooModel):
         Precict on RDD[Sample].
         """
         results = callZooFunc(self.bigdl_type, "modelPredictRDD",
-                                self.value,
-                                x,
-                                batch_per_thread)
+                              self.value,
+                              x,
+                              batch_per_thread)
         return results.map(lambda data: data.to_ndarray())
 
     @classmethod
@@ -157,7 +158,7 @@ class AnomalyDetector(KerasZooModel):
             matrix.append(line)
             return matrix
 
-        return unrolled_rdd\
+        return unrolled_rdd \
             .map(lambda y: FeatureLableIndex(row_to_feature(y[0]), float(y[1]), long(y[2])))
 
 

--- a/pyzoo/zoo/models/common/ranker.py
+++ b/pyzoo/zoo/models/common/ranker.py
@@ -29,6 +29,7 @@ class Ranker(JavaValue):
     Base class for Ranking models (e.g., TextMatcher and Ranker) that
     provides validation methods with different metrics.
     """
+
     def evaluate_ndcg(self, x, k, threshold=0.0):
         """
         Evaluate using normalized discounted cumulative gain on TextSet.
@@ -43,7 +44,7 @@ class Ranker(JavaValue):
         :return: Float. NDCG result.
         """
         return callZooFunc(self.bigdl_type, "evaluateNDCG",
-                             self.value, x, k, threshold)
+                           self.value, x, k, threshold)
 
     def evaluate_map(self, x, threshold=0.0):
         """
@@ -58,4 +59,4 @@ class Ranker(JavaValue):
         :return: Float. MAP result.
         """
         return callZooFunc(self.bigdl_type, "evaluateMAP",
-                             self.value, x, threshold)
+                           self.value, x, threshold)

--- a/pyzoo/zoo/models/common/ranker.py
+++ b/pyzoo/zoo/models/common/ranker.py
@@ -16,7 +16,8 @@
 
 import sys
 
-from bigdl.util.common import JavaValue, callBigDlFunc
+from bigdl.util.common import JavaValue
+from zoo.common.utils import callZooFunc
 
 if sys.version >= '3':
     long = int
@@ -41,7 +42,7 @@ class Ranker(JavaValue):
 
         :return: Float. NDCG result.
         """
-        return callBigDlFunc(self.bigdl_type, "evaluateNDCG",
+        return callZooFunc(self.bigdl_type, "evaluateNDCG",
                              self.value, x, k, threshold)
 
     def evaluate_map(self, x, threshold=0.0):
@@ -56,5 +57,5 @@ class Ranker(JavaValue):
 
         :return: Float. MAP result.
         """
-        return callBigDlFunc(self.bigdl_type, "evaluateMAP",
+        return callZooFunc(self.bigdl_type, "evaluateMAP",
                              self.value, x, threshold)

--- a/pyzoo/zoo/models/common/zoo_model.py
+++ b/pyzoo/zoo/models/common/zoo_model.py
@@ -35,6 +35,7 @@ class ZooModel(ZooModelCreator, Container):
     """
     The base class for models in Analytics Zoo.
     """
+
     def predict_classes(self, x, batch_size=32, zero_based_label=True):
         """
         Predict for classes. By default, label predictions start from 0.
@@ -52,10 +53,10 @@ class ZooModel(ZooModelCreator, Container):
         else:
             raise TypeError("Unsupported prediction data type: %s" % type(x))
         return callZooFunc(self.bigdl_type, "zooModelPredictClasses",
-                             self.value,
-                             data_rdd,
-                             batch_size,
-                             zero_based_label)
+                           self.value,
+                           data_rdd,
+                           batch_size,
+                           zero_based_label)
 
     def save_model(self, path, weight_path=None, over_write=False):
         """
@@ -69,21 +70,21 @@ class ZooModel(ZooModelCreator, Container):
         over_write: Whether to overwrite the file if it already exists. Default is False.
         """
         callZooFunc(self.bigdl_type, "saveZooModel",
-                      self.value, path, weight_path, over_write)
+                    self.value, path, weight_path, over_write)
 
     def summary(self):
         """
         Print out the summary of the model.
         """
         callZooFunc(self.bigdl_type, "zooModelSummary",
-                      self.value)
+                    self.value)
 
     def set_evaluate_status(self):
         """
         Set the model to be in evaluate status, i.e. remove the effect of Dropout, etc.
         """
         callZooFunc(self.bigdl_type, "zooModelSetEvaluateStatus",
-                      self.value)
+                    self.value)
         return self
 
     @staticmethod
@@ -97,6 +98,7 @@ class KerasZooModel(ZooModel):
     """
     The base class for Keras style models in Analytics Zoo.
     """
+
     # For the following method, please see documentation of KerasNet for details
     def compile(self, optimizer, loss, metrics=None):
         self.model.compile(optimizer, loss, metrics)

--- a/pyzoo/zoo/models/common/zoo_model.py
+++ b/pyzoo/zoo/models/common/zoo_model.py
@@ -17,6 +17,7 @@
 from bigdl.nn.layer import Container, Layer
 from bigdl.util.common import *
 from zoo.pipeline.api.keras.engine.topology import KerasNet
+from zoo.common.utils import callZooFunc
 
 if sys.version >= '3':
     long = int
@@ -50,7 +51,7 @@ class ZooModel(ZooModelCreator, Container):
             data_rdd = x
         else:
             raise TypeError("Unsupported prediction data type: %s" % type(x))
-        return callBigDlFunc(self.bigdl_type, "zooModelPredictClasses",
+        return callZooFunc(self.bigdl_type, "zooModelPredictClasses",
                              self.value,
                              data_rdd,
                              batch_size,
@@ -67,21 +68,21 @@ class ZooModel(ZooModelCreator, Container):
         weight_path: The path to save weights. Default is None.
         over_write: Whether to overwrite the file if it already exists. Default is False.
         """
-        callBigDlFunc(self.bigdl_type, "saveZooModel",
+        callZooFunc(self.bigdl_type, "saveZooModel",
                       self.value, path, weight_path, over_write)
 
     def summary(self):
         """
         Print out the summary of the model.
         """
-        callBigDlFunc(self.bigdl_type, "zooModelSummary",
+        callZooFunc(self.bigdl_type, "zooModelSummary",
                       self.value)
 
     def set_evaluate_status(self):
         """
         Set the model to be in evaluate status, i.e. remove the effect of Dropout, etc.
         """
-        callBigDlFunc(self.bigdl_type, "zooModelSetEvaluateStatus",
+        callZooFunc(self.bigdl_type, "zooModelSetEvaluateStatus",
                       self.value)
         return self
 
@@ -140,6 +141,6 @@ class KerasZooModel(ZooModel):
     @staticmethod
     def _do_load(jmodel, bigdl_type="float"):
         model = ZooModel._do_load(jmodel, bigdl_type)
-        labor_model = callBigDlFunc(bigdl_type, "getModule", jmodel)
+        labor_model = callZooFunc(bigdl_type, "getModule", jmodel)
         model.model = KerasNet(labor_model)
         return model

--- a/pyzoo/zoo/models/image/common/image_config.py
+++ b/pyzoo/zoo/models/image/common/image_config.py
@@ -16,7 +16,7 @@
 
 import sys
 from bigdl.util.common import JavaValue
-from bigdl.util.common import callBigDlFunc
+from zoo.common.utils import callZooFunc
 
 from zoo.feature.common import Preprocessing
 
@@ -48,7 +48,7 @@ class ImageConfigure(JavaValue):
             if post_processor:
                 assert issubclass(post_processor.__class__, Preprocessing), \
                     "the post_processor should be subclass of Preprocessing"
-            self.value = callBigDlFunc(
+            self.value = callZooFunc(
                 bigdl_type, JavaValue.jvm_class_constructor(self),
                 pre_processor,
                 post_processor,
@@ -57,11 +57,11 @@ class ImageConfigure(JavaValue):
                 feature_padding_param)
 
     def label_map(self):
-        return callBigDlFunc(self.bigdl_type, "getLabelMap", self.value)
+        return callZooFunc(self.bigdl_type, "getLabelMap", self.value)
 
 
 class PaddingParam(JavaValue):
 
     def __init__(self, bigdl_type="float"):
-        self.value = callBigDlFunc(
+        self.value = callZooFunc(
             bigdl_type, JavaValue.jvm_class_constructor(self))

--- a/pyzoo/zoo/models/image/common/image_config.py
+++ b/pyzoo/zoo/models/image/common/image_config.py
@@ -34,6 +34,7 @@ class ImageConfigure(JavaValue):
     :param label_map mapping from prediction result indexes to real dataset labels
     :param feature_padding_param featurePaddingParam if the inputs have variant size
     """
+
     def __init__(self, pre_processor=None,
                  post_processor=None,
                  batch_per_partition=4,

--- a/pyzoo/zoo/models/image/common/image_model.py
+++ b/pyzoo/zoo/models/image/common/image_model.py
@@ -28,12 +28,13 @@ class ImageModel(ZooModel):
     """
     The basic class for image model.
     """
+
     def __init__(self, bigdl_type="float"):
         super(ImageModel, self).__init__(None, bigdl_type)
 
     def predict_image_set(self, image, configure=None):
         res = callZooFunc(self.bigdl_type, "imageModelPredict", self.value,
-                            image, configure)
+                          image, configure)
         return ImageSet(res)
 
     def get_config(self):

--- a/pyzoo/zoo/models/image/common/image_model.py
+++ b/pyzoo/zoo/models/image/common/image_model.py
@@ -17,6 +17,7 @@
 from zoo.models.common import ZooModel
 from zoo.models.image.common.image_config import ImageConfigure
 from zoo.feature.image.imageset import *
+from zoo.common.utils import callZooFunc
 
 if sys.version >= '3':
     long = int
@@ -31,10 +32,10 @@ class ImageModel(ZooModel):
         super(ImageModel, self).__init__(None, bigdl_type)
 
     def predict_image_set(self, image, configure=None):
-        res = callBigDlFunc(self.bigdl_type, "imageModelPredict", self.value,
+        res = callZooFunc(self.bigdl_type, "imageModelPredict", self.value,
                             image, configure)
         return ImageSet(res)
 
     def get_config(self):
-        config = callBigDlFunc(self.bigdl_type, "getImageConfig", self.value)
+        config = callZooFunc(self.bigdl_type, "getImageConfig", self.value)
         return ImageConfigure(jvalue=config)

--- a/pyzoo/zoo/models/image/imageclassification/image_classification.py
+++ b/pyzoo/zoo/models/image/imageclassification/image_classification.py
@@ -17,6 +17,7 @@
 from bigdl.transform.vision.image import FeatureTransformer
 from zoo.models.image.common.image_model import ImageModel
 from zoo.feature.image.imageset import *
+from zoo.common.utils import callZooFunc
 
 
 if sys.version >= '3':
@@ -28,7 +29,7 @@ def read_imagenet_label_map():
     """
     load imagenet label map
     """
-    return callBigDlFunc("float", "readImagenetLabelMap")
+    return callZooFunc("float", "readImagenetLabelMap")
 
 
 class ImageClassifier(ImageModel):
@@ -51,7 +52,7 @@ class ImageClassifier(ImageModel):
               HDFS path should be like 'hdfs://[host]:[port]/xxx'.
               Amazon S3 path should be like 's3a://bucket/xxx'.
         """
-        jmodel = callBigDlFunc(bigdl_type, "loadImageClassifier", path, weight_path)
+        jmodel = callZooFunc(bigdl_type, "loadImageClassifier", path, weight_path)
         model = ImageModel._do_load(jmodel, bigdl_type)
         model.__class__ = ImageClassifier
         return model
@@ -64,5 +65,5 @@ class LabelOutput(FeatureTransformer):
     probs is the key in ImgFeature where you want to store all the sorted probilities for each class
     """
     def __init__(self, label_map, clses, probs, bigdl_type="float"):
-        self.value = callBigDlFunc(
+        self.value = callZooFunc(
             bigdl_type, JavaValue.jvm_class_constructor(self), label_map, clses, probs)

--- a/pyzoo/zoo/models/image/imageclassification/image_classification.py
+++ b/pyzoo/zoo/models/image/imageclassification/image_classification.py
@@ -19,7 +19,6 @@ from zoo.models.image.common.image_model import ImageModel
 from zoo.feature.image.imageset import *
 from zoo.common.utils import callZooFunc
 
-
 if sys.version >= '3':
     long = int
     unicode = str
@@ -38,6 +37,7 @@ class ImageClassifier(ImageModel):
 
     :param model_path The path containing the pre-trained model
     """
+
     def __init__(self, bigdl_type="float"):
         self.bigdl_type = bigdl_type
         super(ImageClassifier, self).__init__(None, bigdl_type)
@@ -64,6 +64,7 @@ class LabelOutput(FeatureTransformer):
     clses is the key in ImgFeature where you want to store all sorted mapped labels
     probs is the key in ImgFeature where you want to store all the sorted probilities for each class
     """
+
     def __init__(self, label_map, clses, probs, bigdl_type="float"):
         self.value = callZooFunc(
             bigdl_type, JavaValue.jvm_class_constructor(self), label_map, clses, probs)

--- a/pyzoo/zoo/models/image/objectdetection/object_detector.py
+++ b/pyzoo/zoo/models/image/objectdetection/object_detector.py
@@ -16,9 +16,9 @@
 
 import sys
 from bigdl.util.common import JavaValue
-from bigdl.util.common import callBigDlFunc
 
 from zoo.models.image.common.image_model import ImageModel
+from zoo.common.utils import callZooFunc
 from zoo.feature.image.imageset import *
 from zoo.feature.image.imagePreprocessing import *
 
@@ -32,14 +32,14 @@ def read_pascal_label_map():
     """
     load pascal label map
     """
-    return callBigDlFunc("float", "readPascalLabelMap")
+    return callZooFunc("float", "readPascalLabelMap")
 
 
 def read_coco_label_map():
     """
     load coco label map
     """
-    return callBigDlFunc("float", "readCocoLabelMap")
+    return callZooFunc("float", "readCocoLabelMap")
 
 
 class ObjectDetector(ImageModel):
@@ -62,7 +62,7 @@ class ObjectDetector(ImageModel):
               HDFS path should be like 'hdfs://[host]:[port]/xxx'.
               Amazon S3 path should be like 's3a://bucket/xxx'.
         """
-        jmodel = callBigDlFunc(bigdl_type, "loadObjectDetector", path, weight_path)
+        jmodel = callZooFunc(bigdl_type, "loadObjectDetector", path, weight_path)
         model = ImageModel._do_load(jmodel, bigdl_type)
         model.__class__ = ObjectDetector
         return model
@@ -115,13 +115,13 @@ class Visualizer(ImagePreprocessing):
     """
     def __init__(self, label_map, thresh=0.3, encoding="png",
                  bigdl_type="float"):
-        self.value = callBigDlFunc(
+        self.value = callZooFunc(
             bigdl_type, JavaValue.jvm_class_constructor(self), label_map, thresh, encoding)
 
     def __call__(self, image_set, bigdl_type="float"):
         """
         transform ImageSet
         """
-        jset = callBigDlFunc(bigdl_type,
+        jset = callZooFunc(bigdl_type,
                              "transformImageSet", self.value, image_set)
         return ImageSet(jvalue=jset)

--- a/pyzoo/zoo/models/image/objectdetection/object_detector.py
+++ b/pyzoo/zoo/models/image/objectdetection/object_detector.py
@@ -22,7 +22,6 @@ from zoo.common.utils import callZooFunc
 from zoo.feature.image.imageset import *
 from zoo.feature.image.imagePreprocessing import *
 
-
 if sys.version >= '3':
     long = int
     unicode = str
@@ -48,6 +47,7 @@ class ObjectDetector(ImageModel):
 
     :param model_path The path containing the pre-trained model
     """
+
     def __init__(self, bigdl_type="float"):
         self.bigdl_type = bigdl_type
         super(ObjectDetector, self).__init__(None, bigdl_type)
@@ -73,6 +73,7 @@ class ImInfo(ImagePreprocessing):
     Generate imInfo
     imInfo is a tensor that contains height, width, scaleInHeight, scaleInWidth
     """
+
     def __init__(self, bigdl_type="float"):
         super(ImInfo, self).__init__(bigdl_type)
 
@@ -92,6 +93,7 @@ class DecodeOutput(ImagePreprocessing):
     3, 0.3, 20, 10, 40, 70
     ```
     """
+
     def __init__(self, bigdl_type="float"):
         super(DecodeOutput, self).__init__(bigdl_type)
 
@@ -103,6 +105,7 @@ class ScaleDetection(ImagePreprocessing):
     Note that in this transformer, the tensor from model output will be decoded,
     just like `DecodeOutput`
     """
+
     def __init__(self, bigdl_type="float"):
         super(ScaleDetection, self).__init__(bigdl_type)
 
@@ -113,6 +116,7 @@ class Visualizer(ImagePreprocessing):
     (tensors that encodes label, score, boundingbox)
     You can call image_frame.get_image() to get the visualized results
     """
+
     def __init__(self, label_map, thresh=0.3, encoding="png",
                  bigdl_type="float"):
         self.value = callZooFunc(
@@ -123,5 +127,5 @@ class Visualizer(ImagePreprocessing):
         transform ImageSet
         """
         jset = callZooFunc(bigdl_type,
-                             "transformImageSet", self.value, image_set)
+                           "transformImageSet", self.value, image_set)
         return ImageSet(jvalue=jset)

--- a/pyzoo/zoo/models/recommendation/neuralcf.py
+++ b/pyzoo/zoo/models/recommendation/neuralcf.py
@@ -20,6 +20,7 @@ from zoo.models.common import KerasZooModel
 from zoo.models.recommendation import Recommender
 from zoo.pipeline.api.keras.layers import *
 from zoo.pipeline.api.keras.models import *
+from zoo.common.utils import callZooFunc
 
 if sys.version >= '3':
     long = int
@@ -105,7 +106,7 @@ class NeuralCF(Recommender):
               Amazon S3 path should be like 's3a://bucket/xxx'.
         weight_path: The path for pre-trained weights if any. Default is None.
         """
-        jmodel = callBigDlFunc(bigdl_type, "loadNeuralCF", path, weight_path)
+        jmodel = callZooFunc(bigdl_type, "loadNeuralCF", path, weight_path)
         model = KerasZooModel._do_load(jmodel, bigdl_type)
         model.__class__ = NeuralCF
         return model

--- a/pyzoo/zoo/models/recommendation/neuralcf.py
+++ b/pyzoo/zoo/models/recommendation/neuralcf.py
@@ -41,6 +41,7 @@ class NeuralCF(Recommender):
     include_mf: Whether to include Matrix Factorization. Boolean. Default is True.
     mf_embed: Units of matrix factorization embedding. Positive int. Default is 20.
     """
+
     def __init__(self, user_count, item_count, class_num, user_embed=20,
                  item_embed=20, hidden_layers=[40, 20, 10], include_mf=True,
                  mf_embed=20, bigdl_type="float"):
@@ -66,7 +67,7 @@ class NeuralCF(Recommender):
                                        self.model)
 
     def build_model(self):
-        input = Input(shape=(2, ))
+        input = Input(shape=(2,))
         user_flat = Flatten()(Select(1, 0)(input))
         item_flat = Flatten()(Select(1, 1)(input))
         mlp_user_embed = Embedding(self.user_count + 1, self.user_embed, init="uniform")(user_flat)
@@ -81,7 +82,7 @@ class NeuralCF(Recommender):
             mlp_linear = linear_mid
 
         if (self.include_mf):
-            assert(self.mf_embed > 0)
+            assert (self.mf_embed > 0)
             mf_user_embed = Embedding(self.user_count + 1, self.mf_embed, init="uniform")(user_flat)
             mf_item_embed = Embedding(self.item_count + 1, self.mf_embed, init="uniform")(item_flat)
             mf_user_flatten = Flatten()(mf_user_embed)

--- a/pyzoo/zoo/models/recommendation/recommender.py
+++ b/pyzoo/zoo/models/recommendation/recommender.py
@@ -21,7 +21,6 @@ from pyspark import RDD
 from zoo.models.common import *
 from zoo.common.utils import callZooFunc
 
-
 if sys.version >= '3':
     long = int
     unicode = str
@@ -36,6 +35,7 @@ class UserItemFeature(object):
     item_id: Positive int.
     sample: Sample which consists of feature(s) and label(s).
     """
+
     def __init__(self, user_id, item_id, sample, bigdl_type="float"):
         self.user_id = int(user_id)
         self.item_id = int(item_id)
@@ -60,6 +60,7 @@ class UserItemPrediction(object):
     prediction: The prediction (rating) for the user on the item.
     probability: The probability for the prediction.
     """
+
     def __init__(self, user_id, item_id, prediction, probability, bigdl_type="float"):
         self.user_id = user_id
         self.item_id = item_id
@@ -79,6 +80,7 @@ class Recommender(KerasZooModel):
     """
     The base class for recommendation models in Analytics Zoo.
     """
+
     def predict_user_item_pair(self, feature_rdd):
         """
         Predict for user-item pairs.
@@ -88,8 +90,8 @@ class Recommender(KerasZooModel):
         :return RDD of UserItemPrediction.
         """
         result_rdd = callZooFunc(self.bigdl_type, "predictUserItemPair",
-                                   self.value,
-                                   self._to_tuple_rdd(feature_rdd))
+                                 self.value,
+                                 self._to_tuple_rdd(feature_rdd))
         return self._to_prediction_rdd(result_rdd)
 
     def recommend_for_user(self, feature_rdd, max_items):
@@ -102,9 +104,9 @@ class Recommender(KerasZooModel):
         :return RDD of UserItemPrediction.
         """
         result_rdd = callZooFunc(self.bigdl_type, "recommendForUser",
-                                   self.value,
-                                   self._to_tuple_rdd(feature_rdd),
-                                   int(max_items))
+                                 self.value,
+                                 self._to_tuple_rdd(feature_rdd),
+                                 int(max_items))
         return self._to_prediction_rdd(result_rdd)
 
     def recommend_for_item(self, feature_rdd, max_users):
@@ -117,9 +119,9 @@ class Recommender(KerasZooModel):
         :return RDD of UserItemPrediction.
         """
         result_rdd = callZooFunc(self.bigdl_type, "recommendForItem",
-                                   self.value,
-                                   self._to_tuple_rdd(feature_rdd),
-                                   int(max_users))
+                                 self.value,
+                                 self._to_tuple_rdd(feature_rdd),
+                                 int(max_users))
         return self._to_prediction_rdd(result_rdd)
 
     @staticmethod

--- a/pyzoo/zoo/models/recommendation/recommender.py
+++ b/pyzoo/zoo/models/recommendation/recommender.py
@@ -19,7 +19,7 @@ import sys
 from pyspark import RDD
 
 from zoo.models.common import *
-from bigdl.util.common import callBigDlFunc
+from zoo.common.utils import callZooFunc
 
 
 if sys.version >= '3':
@@ -87,7 +87,7 @@ class Recommender(KerasZooModel):
         feature_rdd: RDD of UserItemFeature.
         :return RDD of UserItemPrediction.
         """
-        result_rdd = callBigDlFunc(self.bigdl_type, "predictUserItemPair",
+        result_rdd = callZooFunc(self.bigdl_type, "predictUserItemPair",
                                    self.value,
                                    self._to_tuple_rdd(feature_rdd))
         return self._to_prediction_rdd(result_rdd)
@@ -101,7 +101,7 @@ class Recommender(KerasZooModel):
         max_items: The number of items to be recommended to each user. Positive int.
         :return RDD of UserItemPrediction.
         """
-        result_rdd = callBigDlFunc(self.bigdl_type, "recommendForUser",
+        result_rdd = callZooFunc(self.bigdl_type, "recommendForUser",
                                    self.value,
                                    self._to_tuple_rdd(feature_rdd),
                                    int(max_items))
@@ -116,7 +116,7 @@ class Recommender(KerasZooModel):
         max_users: The number of users to be recommended to each item. Positive int.
         :return RDD of UserItemPrediction.
         """
-        result_rdd = callBigDlFunc(self.bigdl_type, "recommendForItem",
+        result_rdd = callZooFunc(self.bigdl_type, "recommendForItem",
                                    self.value,
                                    self._to_tuple_rdd(feature_rdd),
                                    int(max_users))

--- a/pyzoo/zoo/models/recommendation/session_recommender.py
+++ b/pyzoo/zoo/models/recommendation/session_recommender.py
@@ -40,6 +40,7 @@ class SessionRecommender(Recommender):
      mlp_hidden_layers: Units of hidden layers for the mlp model. Array of positive integers.
      history_length: The max number of items in the sequence of historical purchase
      """
+
     def __init__(self, item_count, item_embed, rnn_hidden_layers=[40, 20], session_length=0,
                  include_history=False, mlp_hidden_layers=[40, 20], history_length=0,
                  bigdl_type="float"):
@@ -115,14 +116,14 @@ class SessionRecommender(Recommender):
             sc = get_spark_context()
             sessions_rdd = sc.parallelize(sessions)
         elif (isinstance(sessions, RDD)):
-                sessions_rdd = sessions
+            sessions_rdd = sessions
         else:
             raise TypeError("Unsupported training data type: %s" % type(sessions))
         results = callZooFunc(self.bigdl_type, "recommendForSession",
-                                self.value,
-                                sessions_rdd,
-                                max_items,
-                                zero_based_label)
+                              self.value,
+                              sessions_rdd,
+                              max_items,
+                              zero_based_label)
 
         if isinstance(sessions, list):
             return results.collect()

--- a/pyzoo/zoo/models/recommendation/session_recommender.py
+++ b/pyzoo/zoo/models/recommendation/session_recommender.py
@@ -20,6 +20,7 @@ from zoo.models.common import KerasZooModel
 from zoo.models.recommendation import Recommender
 from zoo.pipeline.api.keras.layers import *
 from zoo.pipeline.api.keras.models import *
+from zoo.common.utils import callZooFunc
 
 if sys.version >= '3':
     long = int
@@ -117,7 +118,7 @@ class SessionRecommender(Recommender):
                 sessions_rdd = sessions
         else:
             raise TypeError("Unsupported training data type: %s" % type(sessions))
-        results = callBigDlFunc(self.bigdl_type, "recommendForSession",
+        results = callZooFunc(self.bigdl_type, "recommendForSession",
                                 self.value,
                                 sessions_rdd,
                                 max_items,
@@ -140,7 +141,7 @@ class SessionRecommender(Recommender):
               Amazon S3 path should be like 's3a://bucket/xxx'.
         weight_path: The path for pre-trained weights if any. Default is None.
         """
-        jmodel = callBigDlFunc(bigdl_type, "loadSessionRecommender", path, weight_path)
+        jmodel = callZooFunc(bigdl_type, "loadSessionRecommender", path, weight_path)
         model = KerasZooModel._do_load(jmodel, bigdl_type)
         model.__class__ = SessionRecommender
         return model

--- a/pyzoo/zoo/models/recommendation/utils.py
+++ b/pyzoo/zoo/models/recommendation/utils.py
@@ -16,8 +16,9 @@
 
 import numpy as np
 
-from bigdl.util.common import JTensor, callBigDlFunc, Sample
+from bigdl.util.common import JTensor, Sample
 
+from zoo.common.utils import callZooFunc
 from zoo.models.recommendation import UserItemFeature
 
 
@@ -43,7 +44,7 @@ def get_boundaries(target, boundaries, default=-1, start=0):
 
 
 def get_negative_samples(indexed):
-    return callBigDlFunc("float", "getNegativeSamples",
+    return callZooFunc("float", "getNegativeSamples",
                          indexed)
 
 

--- a/pyzoo/zoo/models/recommendation/utils.py
+++ b/pyzoo/zoo/models/recommendation/utils.py
@@ -45,7 +45,7 @@ def get_boundaries(target, boundaries, default=-1, start=0):
 
 def get_negative_samples(indexed):
     return callZooFunc("float", "getNegativeSamples",
-                         indexed)
+                       indexed)
 
 
 def get_wide_tensor(row, column_info):
@@ -67,7 +67,7 @@ def get_wide_tensor(row, column_info):
         if i == 0:
             res = index
         else:
-            acc += wide_dims[i-1]
+            acc += wide_dims[i - 1]
             res = acc + index
         indices.append(res)
     values = np.array([i + 1 for i in indices])
@@ -88,7 +88,7 @@ def get_deep_tensors(row, column_info):
     emb_col = column_info.embed_cols
     cont_col = column_info.continuous_cols
 
-    ind_tensor = np.zeros(sum(column_info.indicator_dims),)
+    ind_tensor = np.zeros(sum(column_info.indicator_dims), )
     # setup indicators
     acc = 0
     for i in range(0, len(ind_col)):
@@ -96,15 +96,15 @@ def get_deep_tensors(row, column_info):
         if i == 0:
             res = index
         else:
-            acc += column_info.indicator_dims[i-1]
+            acc += column_info.indicator_dims[i - 1]
             res = acc + index
         ind_tensor[res] = 1
 
-    emb_tensor = np.zeros(len(emb_col),)
+    emb_tensor = np.zeros(len(emb_col), )
     for i in range(0, len(emb_col)):
         emb_tensor[i] = float(row[emb_col[i]])
 
-    cont_tensor = np.zeros(len(cont_col),)
+    cont_tensor = np.zeros(len(cont_col), )
     for i in range(0, len(cont_col)):
         cont_tensor[i] = float(row[cont_col[i]])
 

--- a/pyzoo/zoo/models/recommendation/wide_and_deep.py
+++ b/pyzoo/zoo/models/recommendation/wide_and_deep.py
@@ -112,7 +112,7 @@ class WideAndDeep(Recommender):
         assert len(column_info.indicator_cols) == len(column_info.indicator_dims), \
             "size of wide_indicator_columns should match"
         assert len(column_info.embed_cols) == len(column_info.embed_in_dims) \
-               == len(column_info.embed_out_dims), "size of wide_indicator_columns should match"
+            == len(column_info.embed_out_dims), "size of wide_indicator_columns should match"
 
         self.class_num = int(class_num)
         self.wide_base_dims = column_info.wide_base_dims

--- a/pyzoo/zoo/models/recommendation/wide_and_deep.py
+++ b/pyzoo/zoo/models/recommendation/wide_and_deep.py
@@ -18,7 +18,7 @@ import sys
 
 from zoo.models.common import *
 from zoo.models.recommendation import Recommender
-from bigdl.util.common import callBigDlFunc
+from zoo.common.utils import callZooFunc
 from zoo.pipeline.api.keras.layers import *
 
 if sys.version >= '3':
@@ -229,7 +229,7 @@ class WideAndDeep(Recommender):
               Amazon S3 path should be like 's3a://bucket/xxx'.
         weight_path: The path for pre-trained weights if any. Default is None.
         """
-        jmodel = callBigDlFunc(bigdl_type, "loadWideAndDeep", path, weight_path)
+        jmodel = callZooFunc(bigdl_type, "loadWideAndDeep", path, weight_path)
         model = ZooModel._do_load(jmodel, bigdl_type)
         labor_model = KerasZooModel._do_load(jmodel, bigdl_type)
         model.model = labor_model

--- a/pyzoo/zoo/models/recommendation/wide_and_deep.py
+++ b/pyzoo/zoo/models/recommendation/wide_and_deep.py
@@ -56,6 +56,7 @@ class ColumnFeatureInfo(object):
                      the deep model. List of String. Default is an empty list.
     label: The name of the 'label' column. String. Default is 'label'.
     """
+
     def __init__(self, wide_base_cols=None, wide_base_dims=None, wide_cross_cols=None,
                  wide_cross_dims=None, indicator_cols=None, indicator_dims=None,
                  embed_cols=None, embed_in_dims=None, embed_out_dims=None,
@@ -101,16 +102,17 @@ class WideAndDeep(Recommender):
     hidden_layers: Units of hidden layers for the deep model.
                    Tuple of positive int. Default is (40, 20, 10).
     """
+
     def __init__(self, class_num, column_info, model_type="wide_n_deep",
                  hidden_layers=[40, 20, 10], bigdl_type="float"):
-        assert len(column_info.wide_base_cols) == len(column_info.wide_base_dims),\
+        assert len(column_info.wide_base_cols) == len(column_info.wide_base_dims), \
             "size of wide_base_columns should match"
-        assert len(column_info.wide_cross_cols) == len(column_info.wide_cross_dims),\
+        assert len(column_info.wide_cross_cols) == len(column_info.wide_cross_dims), \
             "size of wide_cross_columns should match"
-        assert len(column_info.indicator_cols) == len(column_info.indicator_dims),\
+        assert len(column_info.indicator_cols) == len(column_info.indicator_dims), \
             "size of wide_indicator_columns should match"
         assert len(column_info.embed_cols) == len(column_info.embed_in_dims) \
-            == len(column_info.embed_out_dims), "size of wide_indicator_columns should match"
+               == len(column_info.embed_out_dims), "size of wide_indicator_columns should match"
 
         self.class_num = int(class_num)
         self.wide_base_dims = column_info.wide_base_dims
@@ -147,12 +149,12 @@ class WideAndDeep(Recommender):
         if (self.model_type == "wide"):
             out = Activation("softmax")(wide_linear)
             model = Model(input_wide, out)
-        elif(self.model_type == "deep"):
+        elif (self.model_type == "deep"):
             (input_deep, merge_list) = self._deep_merge(input_ind, input_emb, input_con)
             deep_linear = self._deep_hidden(merge_list)
             out = Activation("softmax")(deep_linear)
             model = Model(input_deep, out)
-        elif(self.model_type == "wide_n_deep"):
+        elif (self.model_type == "wide_n_deep"):
             (input_deep, merge_list) = self._deep_merge(input_ind, input_emb, input_con)
             deep_linear = self._deep_hidden(merge_list)
             merged = merge([wide_linear, deep_linear], "sum")

--- a/pyzoo/zoo/models/seq2seq/seq2seq.py
+++ b/pyzoo/zoo/models/seq2seq/seq2seq.py
@@ -22,7 +22,6 @@ from zoo.common.utils import callZooFunc
 from zoo.pipeline.api.keras.engine import ZooKerasLayer
 from zoo.pipeline.api.keras.models import Model
 
-
 if sys.version >= '3':
     long = int
     unicode = str
@@ -61,6 +60,7 @@ class RNNEncoder(ZooKerasLayer):
     >>> encoder = RNNEncoder([lstm], embedding)
     creating: createZooKerasRNNEncoder
     """
+
     def __init__(self, rnns, embedding=None, input_shape=None):
         super(RNNEncoder, self).__init__(None,
                                          rnns,
@@ -100,6 +100,7 @@ class RNNDecoder(ZooKerasLayer):
     >>> encoder = RNNDecoder([lstm], embedding)
     creating: createZooKerasRNNDecoder
     """
+
     def __init__(self, rnns, embedding=None, input_shape=None):
         super(RNNDecoder, self).__init__(None,
                                          rnns,
@@ -134,6 +135,7 @@ class Bridge(ZooKerasLayer):
     >>> bridge = Bridge.initialize_from_keras_layer(dense)
     creating: createZooKerasBridge
     """
+
     def __init__(self, bridge_type, decoder_hidden_size, bridge):
         super(Bridge, self).__init__(None, bridge_type, decoder_hidden_size, bridge)
 
@@ -208,7 +210,7 @@ class Seq2seq(ZooModel):
         encoder_output = self.encoder(encoder_input)
 
         encoder_final_states = SelectTable(1)(encoder_output)
-        decoder_init_states =\
+        decoder_init_states = \
             self.bridge(encoder_final_states) if self.bridge else encoder_final_states
 
         decoder_output = self.decoder([decoder_input, decoder_init_states])
@@ -219,9 +221,9 @@ class Seq2seq(ZooModel):
 
     def set_checkpoint(self, path, over_write=True):
         callZooFunc(self.bigdl_type, "seq2seqSetCheckpoint",
-                      self.value,
-                      path,
-                      over_write)
+                    self.value,
+                    path,
+                    over_write)
 
     @staticmethod
     def load_model(path, weight_path=None, bigdl_type="float"):
@@ -249,18 +251,18 @@ class Seq2seq(ZooModel):
         if metrics and all(isinstance(metric, six.string_types) for metric in metrics):
             metrics = to_bigdl_metrics(metrics, loss)
         callZooFunc(self.bigdl_type, "seq2seqCompile",
-                      self.value,
-                      optimizer,
-                      loss,
-                      metrics)
+                    self.value,
+                    optimizer,
+                    loss,
+                    metrics)
 
     def fit(self, x, batch_size=32, nb_epoch=10, validation_data=None):
         callZooFunc(self.bigdl_type, "seq2seqFit",
-                      self.value,
-                      x,
-                      batch_size,
-                      nb_epoch,
-                      validation_data)
+                    self.value,
+                    x,
+                    batch_size,
+                    nb_epoch,
+                    validation_data)
 
     def infer(self, input, start_sign, max_seq_len=30, stop_sign=None, build_output=None):
         """
@@ -284,10 +286,10 @@ class Seq2seq(ZooModel):
         else:
             jstop_sign = None
         results = callZooFunc(self.bigdl_type, "seq2seqInfer",
-                                self.value,
-                                jinput[0],
-                                jstart_sign[0],
-                                max_seq_len,
-                                jstop_sign[0] if jstop_sign else None,
-                                build_output)
+                              self.value,
+                              jinput[0],
+                              jstart_sign[0],
+                              max_seq_len,
+                              jstop_sign[0] if jstop_sign else None,
+                              build_output)
         return results

--- a/pyzoo/zoo/models/seq2seq/seq2seq.py
+++ b/pyzoo/zoo/models/seq2seq/seq2seq.py
@@ -17,6 +17,7 @@
 from bigdl.nn.layer import Layer
 from zoo.pipeline.api.keras.layers import *
 from zoo.models.common import ZooModel
+from zoo.common.utils import callZooFunc
 
 from zoo.pipeline.api.keras.engine import ZooKerasLayer
 from zoo.pipeline.api.keras.models import Model
@@ -217,7 +218,7 @@ class Seq2seq(ZooModel):
         return Model([encoder_input, decoder_input], output)
 
     def set_checkpoint(self, path, over_write=True):
-        callBigDlFunc(self.bigdl_type, "seq2seqSetCheckpoint",
+        callZooFunc(self.bigdl_type, "seq2seqSetCheckpoint",
                       self.value,
                       path,
                       over_write)
@@ -234,7 +235,7 @@ class Seq2seq(ZooModel):
               Amazon S3 path should be like 's3a://bucket/xxx'.
         weight_path: The path for pre-trained weights if any. Default is None.
         """
-        jmodel = callBigDlFunc(bigdl_type, "loadSeq2seq", path, weight_path)
+        jmodel = callZooFunc(bigdl_type, "loadSeq2seq", path, weight_path)
         model = ZooModel._do_load(jmodel, bigdl_type)
         model.__class__ = Seq2seq
         return model
@@ -247,14 +248,14 @@ class Seq2seq(ZooModel):
             loss = to_bigdl_criterion(loss)
         if metrics and all(isinstance(metric, six.string_types) for metric in metrics):
             metrics = to_bigdl_metrics(metrics, loss)
-        callBigDlFunc(self.bigdl_type, "seq2seqCompile",
+        callZooFunc(self.bigdl_type, "seq2seqCompile",
                       self.value,
                       optimizer,
                       loss,
                       metrics)
 
     def fit(self, x, batch_size=32, nb_epoch=10, validation_data=None):
-        callBigDlFunc(self.bigdl_type, "seq2seqFit",
+        callZooFunc(self.bigdl_type, "seq2seqFit",
                       self.value,
                       x,
                       batch_size,
@@ -282,7 +283,7 @@ class Seq2seq(ZooModel):
             assert not start_sign_is_table
         else:
             jstop_sign = None
-        results = callBigDlFunc(self.bigdl_type, "seq2seqInfer",
+        results = callZooFunc(self.bigdl_type, "seq2seqInfer",
                                 self.value,
                                 jinput[0],
                                 jstart_sign[0],

--- a/pyzoo/zoo/models/textclassification/text_classifier.py
+++ b/pyzoo/zoo/models/textclassification/text_classifier.py
@@ -21,7 +21,6 @@ from zoo.pipeline.api.keras.layers import *
 from zoo.models.common import ZooModel
 from zoo.common.utils import callZooFunc
 
-
 if sys.version >= '3':
     long = int
     unicode = str
@@ -50,6 +49,7 @@ class TextClassifier(ZooModel):
              Default is 'cnn'.
     encoder_output_dim: The output dimension for the encoder. Positive int. Default is 256.
     """
+
     def __init__(self, class_num, embedding_file, word_index=None, sequence_length=500,
                  encoder="cnn", encoder_output_dim=256, **kwargs):
         if 'token_length' in kwargs:
@@ -123,22 +123,22 @@ class TextClassifier(ZooModel):
         if metrics and all(isinstance(metric, six.string_types) for metric in metrics):
             metrics = to_bigdl_metrics(metrics, loss)
         callZooFunc(self.bigdl_type, "textClassifierCompile",
-                      self.value,
-                      optimizer,
-                      loss,
-                      metrics)
+                    self.value,
+                    optimizer,
+                    loss,
+                    metrics)
 
     def set_tensorboard(self, log_dir, app_name):
         callZooFunc(self.bigdl_type, "textClassifierSetTensorBoard",
-                      self.value,
-                      log_dir,
-                      app_name)
+                    self.value,
+                    log_dir,
+                    app_name)
 
     def set_checkpoint(self, path, over_write=True):
         callZooFunc(self.bigdl_type, "textClassifierSetCheckpoint",
-                      self.value,
-                      path,
-                      over_write)
+                    self.value,
+                    path,
+                    over_write)
 
     def fit(self, x, batch_size=32, nb_epoch=10, validation_data=None):
         """
@@ -148,11 +148,11 @@ class TextClassifier(ZooModel):
         if validation_data:
             assert isinstance(validation_data, TextSet), "validation_data should be a TextSet"
         callZooFunc(self.bigdl_type, "textClassifierFit",
-                      self.value,
-                      x,
-                      batch_size,
-                      nb_epoch,
-                      validation_data)
+                    self.value,
+                    x,
+                    batch_size,
+                    nb_epoch,
+                    validation_data)
 
     def evaluate(self, x, batch_size=32):
         """
@@ -160,9 +160,9 @@ class TextClassifier(ZooModel):
         """
         assert isinstance(x, TextSet), "x should be a TextSet"
         return callZooFunc(self.bigdl_type, "textClassifierEvaluate",
-                             self.value,
-                             x,
-                             batch_size)
+                           self.value,
+                           x,
+                           batch_size)
 
     def predict(self, x, batch_per_thread=4):
         """
@@ -170,7 +170,7 @@ class TextClassifier(ZooModel):
         """
         assert isinstance(x, TextSet), "x should be a TextSet"
         results = callZooFunc(self.bigdl_type, "textClassifierPredict",
-                                self.value,
-                                x,
-                                batch_per_thread)
+                              self.value,
+                              x,
+                              batch_per_thread)
         return TextSet(results)

--- a/pyzoo/zoo/models/textclassification/text_classifier.py
+++ b/pyzoo/zoo/models/textclassification/text_classifier.py
@@ -19,7 +19,7 @@ import warnings
 from zoo.pipeline.api.keras.models import Sequential
 from zoo.pipeline.api.keras.layers import *
 from zoo.models.common import ZooModel
-from bigdl.util.common import callBigDlFunc
+from zoo.common.utils import callZooFunc
 
 
 if sys.version >= '3':
@@ -109,7 +109,7 @@ class TextClassifier(ZooModel):
               Amazon S3 path should be like 's3a://bucket/xxx'.
         weight_path: The path for pre-trained weights if any. Default is None.
         """
-        jmodel = callBigDlFunc(bigdl_type, "loadTextClassifier", path, weight_path)
+        jmodel = callZooFunc(bigdl_type, "loadTextClassifier", path, weight_path)
         model = ZooModel._do_load(jmodel, bigdl_type)
         model.__class__ = TextClassifier
         return model
@@ -122,20 +122,20 @@ class TextClassifier(ZooModel):
             loss = to_bigdl_criterion(loss)
         if metrics and all(isinstance(metric, six.string_types) for metric in metrics):
             metrics = to_bigdl_metrics(metrics, loss)
-        callBigDlFunc(self.bigdl_type, "textClassifierCompile",
+        callZooFunc(self.bigdl_type, "textClassifierCompile",
                       self.value,
                       optimizer,
                       loss,
                       metrics)
 
     def set_tensorboard(self, log_dir, app_name):
-        callBigDlFunc(self.bigdl_type, "textClassifierSetTensorBoard",
+        callZooFunc(self.bigdl_type, "textClassifierSetTensorBoard",
                       self.value,
                       log_dir,
                       app_name)
 
     def set_checkpoint(self, path, over_write=True):
-        callBigDlFunc(self.bigdl_type, "textClassifierSetCheckpoint",
+        callZooFunc(self.bigdl_type, "textClassifierSetCheckpoint",
                       self.value,
                       path,
                       over_write)
@@ -147,7 +147,7 @@ class TextClassifier(ZooModel):
         assert isinstance(x, TextSet), "x should be a TextSet"
         if validation_data:
             assert isinstance(validation_data, TextSet), "validation_data should be a TextSet"
-        callBigDlFunc(self.bigdl_type, "textClassifierFit",
+        callZooFunc(self.bigdl_type, "textClassifierFit",
                       self.value,
                       x,
                       batch_size,
@@ -159,7 +159,7 @@ class TextClassifier(ZooModel):
         Evaluate on TextSet.
         """
         assert isinstance(x, TextSet), "x should be a TextSet"
-        return callBigDlFunc(self.bigdl_type, "textClassifierEvaluate",
+        return callZooFunc(self.bigdl_type, "textClassifierEvaluate",
                              self.value,
                              x,
                              batch_size)
@@ -169,7 +169,7 @@ class TextClassifier(ZooModel):
         Predict on TextSet.
         """
         assert isinstance(x, TextSet), "x should be a TextSet"
-        results = callBigDlFunc(self.bigdl_type, "textClassifierPredict",
+        results = callZooFunc(self.bigdl_type, "textClassifierPredict",
                                 self.value,
                                 x,
                                 batch_per_thread)

--- a/pyzoo/zoo/models/textmatching/knrm.py
+++ b/pyzoo/zoo/models/textmatching/knrm.py
@@ -62,6 +62,7 @@ class KNRM(TextMatcher):
                  you are recommended to use 'binary_crossentropy' as loss for binary classification.
                  Default mode is 'ranking'.
     """
+
     def __init__(self, text1_length, text2_length, embedding_file, word_index=None,
                  train_embed=True, kernel_num=21, sigma=0.1, exact_sigma=0.001,
                  target_mode="ranking", bigdl_type="float"):
@@ -92,7 +93,7 @@ class KNRM(TextMatcher):
     def build_model(self):
         # Remark: Share weights for embedding is not supported.
         # Thus here the model takes concatenated input and slice to split the input.
-        input = Input(name='input', shape=(self.text1_length + self.text2_length, ))
+        input = Input(name='input', shape=(self.text1_length + self.text2_length,))
         embedding = Embedding(self.vocab_size, self.embed_size,
                               weights=self.embed_weights, trainable=self.train_embed)(input)
         query_embed = embedding.slice(1, 0, self.text1_length)

--- a/pyzoo/zoo/models/textmatching/knrm.py
+++ b/pyzoo/zoo/models/textmatching/knrm.py
@@ -21,7 +21,8 @@ from zoo.models.common import ZooModel
 from zoo.models.textmatching import TextMatcher
 from zoo.pipeline.api.keras.layers import Input, Embedding, Dense, Squeeze, prepare_embedding
 from zoo.pipeline.api.keras.models import Model
-from bigdl.util.common import callBigDlFunc, JTensor
+from bigdl.util.common import JTensor
+from zoo.common.utils import callZooFunc
 
 if sys.version >= '3':
     long = int
@@ -131,7 +132,7 @@ class KNRM(TextMatcher):
               Amazon S3 path should be like 's3a://bucket/xxx'.
         weight_path: The path for pre-trained weights if any. Default is None.
         """
-        jmodel = callBigDlFunc(bigdl_type, "loadKNRM", path, weight_path)
+        jmodel = callZooFunc(bigdl_type, "loadKNRM", path, weight_path)
         model = ZooModel._do_load(jmodel, bigdl_type)
         model.__class__ = KNRM
         return model

--- a/pyzoo/zoo/pipeline/api/autograd.py
+++ b/pyzoo/zoo/pipeline/api/autograd.py
@@ -426,9 +426,9 @@ class Lambda(kbase.ZooKerasCreator):
             input_shapes = [var.get_output_shape() for var in x]
             layer = self.create(remove_batch(input_shapes))
         return Variable.from_jvalue(callZooFunc(self.bigdl_type,
-                                                  "connectInputs",
-                                                  layer,
-                                                  to_list(x)))
+                                                "connectInputs",
+                                                layer,
+                                                to_list(x)))
 
     # input_shapes should not contain batch dim
     def create(self, input_shapes):
@@ -458,6 +458,7 @@ class Parameter(kbase.ZooKerasLayer, VariableOperator):
     :param init_weight: A ndarray as the init value.
     :param trainable It's true by default, meaning the value would be updated by gradient.
     """
+
     def __init__(self, shape, init_method=None,
                  init_weight=None, trainable=True, **kwargs):
         if not init_method:
@@ -468,7 +469,7 @@ class Parameter(kbase.ZooKerasLayer, VariableOperator):
                                         init_method,
                                         kbase.JTensor.from_ndarray(init_weight),
                                         trainable,
-                                        ** kwargs)
+                                        **kwargs)
 
     @property
     def shape(self):
@@ -479,8 +480,8 @@ class Parameter(kbase.ZooKerasLayer, VariableOperator):
         :return: the ndarray for the current weight
         """
         jtensor = callZooFunc(self.bigdl_type,
-                                "getParameterWeight",
-                                self)
+                              "getParameterWeight",
+                              self)
         return jtensor.to_ndarray()
 
     def set_weight(self, value):
@@ -489,9 +490,9 @@ class Parameter(kbase.ZooKerasLayer, VariableOperator):
         :return:
         """
         callZooFunc(self.bigdl_type,
-                      "setParameterWeight",
-                      self,
-                      kbase.JTensor.from_ndarray(value))
+                    "setParameterWeight",
+                    self,
+                    kbase.JTensor.from_ndarray(value))
 
 
 class Constant(kbase.ZooKerasCreator, VariableOperator):
@@ -500,6 +501,7 @@ class Constant(kbase.ZooKerasCreator, VariableOperator):
     :param data: value of the Variable.
     :param name: Optional. Name of the Variable
     """
+
     def __init__(self, data, name=None, bigdl_type="float"):
         self.data = data
         super(Constant, self).__init__(None, bigdl_type, JTensor.from_ndarray(data), name)
@@ -535,12 +537,12 @@ class CustomLoss(LossFunction):
         jinput, input_is_table = Layer.check_input(input)
         jtarget, target_is_table = Layer.check_input(target)
         output = callZooFunc(self.bigdl_type,
-                               "criterionForward",
-                               self.value,
-                               jinput,
-                               input_is_table,
-                               jtarget,
-                               target_is_table)
+                             "criterionForward",
+                             self.value,
+                             jinput,
+                             input_is_table,
+                             jtarget,
+                             target_is_table)
         return output
 
     def backward(self, y_true, y_pred):
@@ -557,10 +559,10 @@ class CustomLoss(LossFunction):
         jinput, input_is_table = Layer.check_input(input)
         jtarget, target_is_table = Layer.check_input(target)
         output = callZooFunc(self.bigdl_type,
-                               "criterionBackward",
-                               self.value,
-                               jinput,
-                               input_is_table,
-                               jtarget,
-                               target_is_table)
+                             "criterionBackward",
+                             self.value,
+                             jinput,
+                             input_is_table,
+                             jtarget,
+                             target_is_table)
         return Layer.convert_output(output)

--- a/pyzoo/zoo/pipeline/api/autograd.py
+++ b/pyzoo/zoo/pipeline/api/autograd.py
@@ -17,8 +17,9 @@
 import sys
 
 from bigdl.nn.layer import Layer, Node
-from bigdl.util.common import callBigDlFunc, to_list, JTensor
+from bigdl.util.common import to_list, JTensor
 
+from zoo.common.utils import callZooFunc
 import zoo.pipeline.api.keras.base as kbase
 from zoo.pipeline.api.keras.objectives import LossFunction
 from zoo.pipeline.api.utils import remove_batch, toMultiShape
@@ -39,7 +40,7 @@ def mean(x, axis=0, keepDims=False):
             the reduced dimensions are retained with length 1.
     :return: A variable with the mean of elements of `x`.
     """
-    return Variable.from_jvalue(callBigDlFunc("float", "mean", x, axis, keepDims))
+    return Variable.from_jvalue(callZooFunc("float", "mean", x, axis, keepDims))
 
 
 def abs(x):
@@ -48,7 +49,7 @@ def abs(x):
     :param x: A variable.
     :return: A variable.
     """
-    return Variable.from_jvalue(callBigDlFunc("float", "abs", x))
+    return Variable.from_jvalue(callZooFunc("float", "abs", x))
 
 
 def batch_dot(x, y, axes=1, normalize=False):
@@ -73,7 +74,7 @@ def batch_dot(x, y, axes=1, normalize=False):
     if not normalize:
         if isinstance(axes, int):
             axes = [axes] * 2
-    return Variable.from_jvalue(callBigDlFunc("float", "batchDot", x, y, axes, normalize))
+    return Variable.from_jvalue(callZooFunc("float", "batchDot", x, y, axes, normalize))
 
 
 def l2_normalize(x, axis):
@@ -83,7 +84,7 @@ def l2_normalize(x, axis):
     :param axis: axis along which to perform normalization.
     :return: A variable.
     """
-    return Variable.from_jvalue(callBigDlFunc("float", "l2Normalize", x, int(axis)))
+    return Variable.from_jvalue(callZooFunc("float", "l2Normalize", x, int(axis)))
 
 
 def sum(x, axis=0, keepDims=False):
@@ -97,7 +98,7 @@ def sum(x, axis=0, keepDims=False):
             the reduced dimensions are retained with length 1.
     :return: A variable with sum of `x`.
     """
-    return Variable.from_jvalue(callBigDlFunc("float", "sum", x, axis, keepDims))
+    return Variable.from_jvalue(callZooFunc("float", "sum", x, axis, keepDims))
 
 
 def stack(inputs, axis=1):
@@ -108,7 +109,7 @@ def stack(inputs, axis=1):
     :param axis: axis along which to perform stacking.
     :return:
     """
-    return Variable.from_jvalue(callBigDlFunc("float", "stack", inputs, axis))
+    return Variable.from_jvalue(callZooFunc("float", "stack", inputs, axis))
 
 
 def expand_dims(x, axis):
@@ -118,7 +119,7 @@ def expand_dims(x, axis):
     :param axis: axis Position where to add a new axis.
     The axis is 0 based and if you set the axis to 0, you would change the batch dim.
     """
-    return Variable.from_jvalue(callBigDlFunc("float", "expandDims", x, axis))
+    return Variable.from_jvalue(callZooFunc("float", "expandDims", x, axis))
 
 
 def clip(x, min, max):
@@ -129,7 +130,7 @@ def clip(x, min, max):
     :param max: Python float or integer.
     :return: A variable.
     """
-    return Variable.from_jvalue(callBigDlFunc("float", "clip", x, float(min), float(max)))
+    return Variable.from_jvalue(callZooFunc("float", "clip", x, float(min), float(max)))
 
 
 def contiguous(x):
@@ -137,7 +138,7 @@ def contiguous(x):
     Turn the output and grad to be contiguous for the input Variable
     :param x: A variable.
     """
-    return Variable.from_jvalue(callBigDlFunc("float", "contiguous", x))
+    return Variable.from_jvalue(callZooFunc("float", "contiguous", x))
 
 
 def square(x):
@@ -146,7 +147,7 @@ def square(x):
     :param x: A variable.
     :return: A variable.
     """
-    return Variable.from_jvalue(callBigDlFunc("float", "square", x))
+    return Variable.from_jvalue(callZooFunc("float", "square", x))
 
 
 def sqrt(x):
@@ -155,7 +156,7 @@ def sqrt(x):
     :param x: A variable.
     :return: A variable.
     """
-    return Variable.from_jvalue(callBigDlFunc("float", "sqrt", x))
+    return Variable.from_jvalue(callZooFunc("float", "sqrt", x))
 
 
 def exp(x):
@@ -164,7 +165,7 @@ def exp(x):
     :param x: A variable.
     :return: A variable.
     """
-    return Variable.from_jvalue(callBigDlFunc("float", "exp", x))
+    return Variable.from_jvalue(callZooFunc("float", "exp", x))
 
 
 def maximum(x, y):
@@ -174,7 +175,7 @@ def maximum(x, y):
     :param y: A variable.
     :return: A variable.
     """
-    return Variable.from_jvalue(callBigDlFunc("float", "maximum", x, y))
+    return Variable.from_jvalue(callZooFunc("float", "maximum", x, y))
 
 
 def log(x):
@@ -183,7 +184,7 @@ def log(x):
     :param x: A variable.
     :return: A variable.
     """
-    return Variable.from_jvalue(callBigDlFunc("float", "log", x))
+    return Variable.from_jvalue(callZooFunc("float", "log", x))
 
 
 def pow(x, a):
@@ -193,7 +194,7 @@ def pow(x, a):
     :param a: Python integer.
     :return: A variable.
     """
-    return Variable.from_jvalue(callBigDlFunc("float", "pow", x, float(a)))
+    return Variable.from_jvalue(callZooFunc("float", "pow", x, float(a)))
 
 
 def epsilon():
@@ -201,7 +202,7 @@ def epsilon():
     Define the value of epsilon.
     :return: A value of type Double.
     """
-    return Variable.from_jvalue(callBigDlFunc("float", "epsilon"))
+    return Variable.from_jvalue(callZooFunc("float", "epsilon"))
 
 
 def neg(x):
@@ -210,7 +211,7 @@ def neg(x):
     :param x: A variable.
     :return: A variable.
     """
-    return Variable.from_jvalue(callBigDlFunc("float", "neg", x))
+    return Variable.from_jvalue(callZooFunc("float", "neg", x))
 
 
 def softsign(x):
@@ -219,7 +220,7 @@ def softsign(x):
     :param x: A variable.
     :return: A variable.
     """
-    return Variable.from_jvalue(callBigDlFunc("float", "softsign", x))
+    return Variable.from_jvalue(callZooFunc("float", "softsign", x))
 
 
 def softplus(x):
@@ -228,7 +229,7 @@ def softplus(x):
     :param x: A variable.
     :return: A variable.
     """
-    return Variable.from_jvalue(callBigDlFunc("float", "softplus", x))
+    return Variable.from_jvalue(callZooFunc("float", "softplus", x))
 
 
 def mm(x, y, axes=None):
@@ -240,7 +241,7 @@ def mm(x, y, axes=None):
     :param axes: Axes along which to perform multiplication.
     :return: A variable.
     """
-    return Variable.from_jvalue(callBigDlFunc("float", "mm", x, y, axes))
+    return Variable.from_jvalue(callZooFunc("float", "mm", x, y, axes))
 
 
 def erf(x):
@@ -249,7 +250,7 @@ def erf(x):
     :param x: A variable.
     :return: A variable.
     """
-    return Variable.from_jvalue(callBigDlFunc("float", "erf", x))
+    return Variable.from_jvalue(callZooFunc("float", "erf", x))
 
 
 class VariableOperator(object):
@@ -264,10 +265,10 @@ class VariableOperator(object):
             return [self.__to_batch_shape(s) for s in shape]
 
     def get_input_shape(self):
-        return self.__process_shape(callBigDlFunc("float", "varGetInputShape", self))
+        return self.__process_shape(callZooFunc("float", "varGetInputShape", self))
 
     def get_output_shape(self):
-        return self.__process_shape(callBigDlFunc("float", "varGetOutputShape", self))
+        return self.__process_shape(callZooFunc("float", "varGetOutputShape", self))
 
     @property
     def shape(self):
@@ -278,17 +279,17 @@ class VariableOperator(object):
         return Variable(input_shape=None, node=None, jvalue=jvalue)
 
     def add(self, var):
-        return Variable.from_jvalue(callBigDlFunc("float", "add", self, var))
+        return Variable.from_jvalue(callZooFunc("float", "add", self, var))
         # self.value.getClass().getSimpleName()
 
     def sub(self, var):
-        return Variable.from_jvalue(callBigDlFunc("float", "sub", self, var))
+        return Variable.from_jvalue(callZooFunc("float", "sub", self, var))
 
     def __sub__(self, other):
         return self.sub(other)
 
     def __rsub__(self, other):
-        return Variable.from_jvalue(callBigDlFunc("float", "sub", other, self))
+        return Variable.from_jvalue(callZooFunc("float", "sub", other, self))
 
     def __add__(self, other):
         return self.add(other)
@@ -296,17 +297,17 @@ class VariableOperator(object):
     __radd__ = __add__
 
     def __mul__(self, other):
-        return Variable.from_jvalue(callBigDlFunc("float", "mul", self, other))
+        return Variable.from_jvalue(callZooFunc("float", "mul", self, other))
 
     __rmul__ = __mul__
 
     def __div__(self, other):
-        return Variable.from_jvalue(callBigDlFunc("float", "div", self, other))
+        return Variable.from_jvalue(callZooFunc("float", "div", self, other))
 
     __truediv__ = __div__
 
     def __rdiv__(self, other):
-        return Variable.from_jvalue(callBigDlFunc("float", "div", other, self))
+        return Variable.from_jvalue(callZooFunc("float", "div", other, self))
 
     __rtruediv__ = __rdiv__
 
@@ -334,7 +335,7 @@ class VariableOperator(object):
         :param length The length to be sliced. Default is 1.
         """
         return Variable.from_jvalue(
-            callBigDlFunc("float", "slice", self, dim, start_index, length))
+            callZooFunc("float", "slice", self, dim, start_index, length))
 
     def index_select(self, dim, index):
         """
@@ -352,7 +353,7 @@ class VariableOperator(object):
                -1 means the last dimension of the input.
         :return:
         """
-        return Variable.from_jvalue(callBigDlFunc("float", "indexSelect", self, dim, index))
+        return Variable.from_jvalue(callZooFunc("float", "indexSelect", self, dim, index))
 
     def squeeze(self, dim=None):
         """
@@ -362,7 +363,7 @@ class VariableOperator(object):
         Squeeze(dim = 1) will give output size (2, 3, 4, 1)
         Squeeze(dims = null) will give output size (2, 3, 4)
         """
-        return Variable.from_jvalue(callBigDlFunc("float", "squeeze", self, dim))
+        return Variable.from_jvalue(callZooFunc("float", "squeeze", self, dim))
 
 
 class Variable(kbase.ZooKerasCreator, VariableOperator):
@@ -424,7 +425,7 @@ class Lambda(kbase.ZooKerasCreator):
         if isinstance(self, Lambda):
             input_shapes = [var.get_output_shape() for var in x]
             layer = self.create(remove_batch(input_shapes))
-        return Variable.from_jvalue(callBigDlFunc(self.bigdl_type,
+        return Variable.from_jvalue(callZooFunc(self.bigdl_type,
                                                   "connectInputs",
                                                   layer,
                                                   to_list(x)))
@@ -477,7 +478,7 @@ class Parameter(kbase.ZooKerasLayer, VariableOperator):
         """
         :return: the ndarray for the current weight
         """
-        jtensor = callBigDlFunc(self.bigdl_type,
+        jtensor = callZooFunc(self.bigdl_type,
                                 "getParameterWeight",
                                 self)
         return jtensor.to_ndarray()
@@ -487,7 +488,7 @@ class Parameter(kbase.ZooKerasLayer, VariableOperator):
         :param value: value is a ndarray
         :return:
         """
-        callBigDlFunc(self.bigdl_type,
+        callZooFunc(self.bigdl_type,
                       "setParameterWeight",
                       self,
                       kbase.JTensor.from_ndarray(value))
@@ -533,7 +534,7 @@ class CustomLoss(LossFunction):
         target = y_true
         jinput, input_is_table = Layer.check_input(input)
         jtarget, target_is_table = Layer.check_input(target)
-        output = callBigDlFunc(self.bigdl_type,
+        output = callZooFunc(self.bigdl_type,
                                "criterionForward",
                                self.value,
                                jinput,
@@ -555,7 +556,7 @@ class CustomLoss(LossFunction):
         target = y_true
         jinput, input_is_table = Layer.check_input(input)
         jtarget, target_is_table = Layer.check_input(target)
-        output = callBigDlFunc(self.bigdl_type,
+        output = callZooFunc(self.bigdl_type,
                                "criterionBackward",
                                self.value,
                                jinput,

--- a/pyzoo/zoo/pipeline/api/keras/base.py
+++ b/pyzoo/zoo/pipeline/api/keras/base.py
@@ -39,9 +39,9 @@ class ZooCallable(object):
         """
         from zoo.pipeline.api.autograd import Variable
         return Variable.from_jvalue(callZooFunc(self.bigdl_type,
-                                                  "connectInputs",
-                                                  self,
-                                                  to_list(x)))
+                                                "connectInputs",
+                                                self,
+                                                to_list(x)))
 
 
 class InferShape(JavaValue):
@@ -67,7 +67,7 @@ class InferShape(JavaValue):
         Return one shape tuple otherwise.
         """
         input = callZooFunc(self.bigdl_type, "getInputShape",
-                              self.value)
+                            self.value)
         return self.__process_shape(input)
 
     def get_output_shape(self):
@@ -76,7 +76,7 @@ class InferShape(JavaValue):
         Return one shape tuple otherwise.
         """
         output = callZooFunc(self.bigdl_type, "getOutputShape",
-                               self.value)
+                             self.value)
         return self.__process_shape(output)
 
 
@@ -99,7 +99,7 @@ class ZooKerasLayer(ZooKerasCreator, ZooCallable, Layer, InferShape):
         :return: None if without weights
         """
         jshapes = callZooFunc(self.bigdl_type, "zooGetWeightsShape",
-                                self.value)
+                              self.value)
         return [tuple(jshape) for jshape in jshapes]
 
     def set_weights(self, weights):

--- a/pyzoo/zoo/pipeline/api/keras/base.py
+++ b/pyzoo/zoo/pipeline/api/keras/base.py
@@ -16,6 +16,7 @@
 
 from bigdl.nn.layer import Layer
 from bigdl.util.common import *
+from zoo.common.utils import callZooFunc
 
 if sys.version >= '3':
     long = int
@@ -37,7 +38,7 @@ class ZooCallable(object):
         :return: Variable containing current module
         """
         from zoo.pipeline.api.autograd import Variable
-        return Variable.from_jvalue(callBigDlFunc(self.bigdl_type,
+        return Variable.from_jvalue(callZooFunc(self.bigdl_type,
                                                   "connectInputs",
                                                   self,
                                                   to_list(x)))
@@ -65,7 +66,7 @@ class InferShape(JavaValue):
         Return a list of shape tuples if there are multiple inputs.
         Return one shape tuple otherwise.
         """
-        input = callBigDlFunc(self.bigdl_type, "getInputShape",
+        input = callZooFunc(self.bigdl_type, "getInputShape",
                               self.value)
         return self.__process_shape(input)
 
@@ -74,7 +75,7 @@ class InferShape(JavaValue):
         Return a list of shape tuples if there are multiple outputs.
         Return one shape tuple otherwise.
         """
-        output = callBigDlFunc(self.bigdl_type, "getOutputShape",
+        output = callZooFunc(self.bigdl_type, "getOutputShape",
                                self.value)
         return self.__process_shape(output)
 
@@ -97,7 +98,7 @@ class ZooKerasLayer(ZooKerasCreator, ZooCallable, Layer, InferShape):
         """
         :return: None if without weights
         """
-        jshapes = callBigDlFunc(self.bigdl_type, "zooGetWeightsShape",
+        jshapes = callZooFunc(self.bigdl_type, "zooGetWeightsShape",
                                 self.value)
         return [tuple(jshape) for jshape in jshapes]
 
@@ -114,7 +115,7 @@ class ZooKerasLayer(ZooKerasCreator, ZooCallable, Layer, InferShape):
                 "The shape of parameter should be the same, but got %s, %s" % (w.shape, cws)
 
         tensors = [JTensor.from_ndarray(param, self.bigdl_type) for param in to_list(weights)]
-        callBigDlFunc(self.bigdl_type, "zooSetWeights", self.value, tensors)
+        callZooFunc(self.bigdl_type, "zooSetWeights", self.value, tensors)
 
     @classmethod
     def of(cls, jvalue, bigdl_type="float"):

--- a/pyzoo/zoo/pipeline/api/keras/engine/topology.py
+++ b/pyzoo/zoo/pipeline/api/keras/engine/topology.py
@@ -71,10 +71,10 @@ class KerasNet(ZooKerasLayer):
         if metrics and all(isinstance(metric, six.string_types) for metric in metrics):
             metrics = to_bigdl_metrics(metrics, loss)
         callZooFunc(self.bigdl_type, "zooCompile",
-                      self.value,
-                      optimizer,
-                      criterion,
-                      metrics)
+                    self.value,
+                    optimizer,
+                    criterion,
+                    metrics)
 
     def set_tensorboard(self, log_dir, app_name):
         """
@@ -90,9 +90,9 @@ class KerasNet(ZooKerasLayer):
         app_name: The name of the application.
         """
         callZooFunc(self.bigdl_type, "zooSetTensorBoard",
-                      self.value,
-                      log_dir,
-                      app_name)
+                    self.value,
+                    log_dir,
+                    app_name)
 
     def get_train_summary(self, tag=None):
         """
@@ -108,7 +108,7 @@ class KerasNet(ZooKerasLayer):
                             + 'are supported in train summary')
 
         return callZooFunc(self.bigdl_type, "zooGetScalarFromSummary",
-                             self.value, tag, "Train")
+                           self.value, tag, "Train")
 
     def get_validation_summary(self, tag=None):
         """
@@ -126,7 +126,7 @@ class KerasNet(ZooKerasLayer):
             raise TypeError('Only subclasses of ValidationMethod are supported,'
                             + 'which are ' + str(validation_set))
         return callZooFunc(self.bigdl_type, "zooGetScalarFromSummary",
-                             self.value, tag, "Validation")
+                           self.value, tag, "Validation")
 
     def set_checkpoint(self, path, over_write=True):
         """
@@ -138,9 +138,9 @@ class KerasNet(ZooKerasLayer):
         over_write: Whether to overwrite existing snapshots in the given path. Default is True.
         """
         callZooFunc(self.bigdl_type, "zooSetCheckpoint",
-                      self.value,
-                      path,
-                      over_write)
+                    self.value,
+                    path,
+                    over_write)
 
     def clear_gradient_clipping(self):
         """
@@ -148,7 +148,7 @@ class KerasNet(ZooKerasLayer):
         In order to take effect, it needs to be called before fit.
         """
         callZooFunc(self.bigdl_type, "zooClearGradientClipping",
-                      self.value)
+                    self.value)
 
     def set_constant_gradient_clipping(self, min, max):
         """
@@ -160,9 +160,9 @@ class KerasNet(ZooKerasLayer):
         max: The maximum value to clip by. Float.
         """
         callZooFunc(self.bigdl_type, "zooSetConstantGradientClipping",
-                      self.value,
-                      float(min),
-                      float(max))
+                    self.value,
+                    float(min),
+                    float(max))
 
     def set_gradient_clipping_by_l2_norm(self, clip_norm):
         """
@@ -173,15 +173,15 @@ class KerasNet(ZooKerasLayer):
         clip_norm: Gradient L2-Norm threshold. Float.
         """
         callZooFunc(self.bigdl_type, "zooSetGradientClippingByL2Norm",
-                      self.value,
-                      float(clip_norm))
+                    self.value,
+                    float(clip_norm))
 
     def set_evaluate_status(self):
         """
         Set the model to be in evaluate status, i.e. remove the effect of Dropout, etc.
         """
         callZooFunc(self.bigdl_type, "zooSetEvaluateStatus",
-                      self.value)
+                    self.value)
         return self
 
     def fit(self, x, y=None, batch_size=32, nb_epoch=10,
@@ -213,17 +213,17 @@ class KerasNet(ZooKerasLayer):
                     x, y = x[:split_index], y[:split_index]
                     validation_data = to_sample_rdd(*validation_data)
                 training_data = to_sample_rdd(x, y)
-            elif (isinstance(x, RDD) or isinstance(x, ImageSet) or isinstance(x, TextSet))\
+            elif (isinstance(x, RDD) or isinstance(x, ImageSet) or isinstance(x, TextSet)) \
                     or isinstance(x, FeatureSet) and not y:
                 training_data = x
             else:
                 raise TypeError("Unsupported training data type: %s" % type(x))
             callZooFunc(self.bigdl_type, "zooFit",
-                          self.value,
-                          training_data,
-                          batch_size,
-                          nb_epoch,
-                          validation_data)
+                        self.value,
+                        training_data,
+                        batch_size,
+                        nb_epoch,
+                        validation_data)
         else:
             if validation_data:
                 val_x = [JTensor.from_ndarray(x) for x in to_list(validation_data[0])]
@@ -231,13 +231,13 @@ class KerasNet(ZooKerasLayer):
             else:
                 val_x, val_y = None, None
             callZooFunc(self.bigdl_type, "zooFit",
-                          self.value,
-                          [JTensor.from_ndarray(x) for x in to_list(x)],
-                          JTensor.from_ndarray(y),
-                          batch_size,
-                          nb_epoch,
-                          val_x,
-                          val_y)
+                        self.value,
+                        [JTensor.from_ndarray(x) for x in to_list(x)],
+                        JTensor.from_ndarray(y),
+                        batch_size,
+                        nb_epoch,
+                        val_x,
+                        val_y)
 
     def evaluate(self, x, y=None, batch_size=32):
         """
@@ -256,9 +256,9 @@ class KerasNet(ZooKerasLayer):
         else:
             raise TypeError("Unsupported evaluation data type: %s" % type(x))
         return callZooFunc(self.bigdl_type, "zooEvaluate",
-                             self.value,
-                             data,
-                             batch_size)
+                           self.value,
+                           data,
+                           batch_size)
 
     def forward(self, input):
         """
@@ -270,10 +270,10 @@ class KerasNet(ZooKerasLayer):
         """
         jinput, input_is_table = self.check_input(input)
         output = callZooFunc(self.bigdl_type,
-                               "zooForward",
-                               self.value,
-                               jinput,
-                               input_is_table)
+                             "zooForward",
+                             self.value,
+                             jinput,
+                             input_is_table)
         return self.convert_output(output)
 
     @staticmethod
@@ -300,9 +300,9 @@ class KerasNet(ZooKerasLayer):
         """
         if isinstance(x, ImageSet) or isinstance(x, TextSet):
             results = callZooFunc(self.bigdl_type, "zooPredict",
-                                    self.value,
-                                    x,
-                                    batch_per_thread)
+                                  self.value,
+                                  x,
+                                  batch_per_thread)
             return ImageSet(results) if isinstance(x, ImageSet) else TextSet(results)
         if distributed:
             if isinstance(x, np.ndarray):
@@ -312,16 +312,16 @@ class KerasNet(ZooKerasLayer):
             else:
                 raise TypeError("Unsupported prediction data type: %s" % type(x))
             results = callZooFunc(self.bigdl_type, "zooPredict",
-                                    self.value,
-                                    data_rdd,
-                                    batch_per_thread)
+                                  self.value,
+                                  data_rdd,
+                                  batch_per_thread)
             return results.map(lambda result: Layer.convert_output(result))
         else:
             if isinstance(x, np.ndarray) or isinstance(x, list):
                 results = callZooFunc(self.bigdl_type, "zooPredict",
-                                        self.value,
-                                        self._to_jtensors(x),
-                                        batch_per_thread)
+                                      self.value,
+                                      self._to_jtensors(x),
+                                      batch_per_thread)
                 return [Layer.convert_output(result) for result in results]
             else:
                 raise TypeError("Unsupported prediction data type: %s" % type(x))
@@ -346,10 +346,10 @@ class KerasNet(ZooKerasLayer):
         else:
             raise TypeError("Unsupported prediction data type: %s" % type(x))
         return callZooFunc(self.bigdl_type, "zooPredictClasses",
-                             self.value,
-                             data_rdd,
-                             batch_per_thread,
-                             zero_based_label)
+                           self.value,
+                           data_rdd,
+                           batch_per_thread,
+                           zero_based_label)
 
     def get_layer(self, name):
         layer = [l for l in self.layers if l.name() == name]
@@ -386,9 +386,9 @@ class KerasNet(ZooKerasLayer):
                    If the field has a smaller length, the remaining part will be white spaces.
         """
         callZooFunc(self.bigdl_type, "zooKerasNetSummary",
-                      self.value,
-                      line_length,
-                      [float(p) for p in positions])
+                    self.value,
+                    line_length,
+                    [float(p) for p in positions])
 
     def to_model(self):
         from zoo.pipeline.api.keras.models import Model
@@ -418,6 +418,7 @@ class Input(autograd.Variable):
     >>> input = Input(name="input1", shape=(3, 5))
     creating: createZooKerasInput
     """
+
     def __init__(self, shape=None, name=None, bigdl_type="float"):
         super(Input, self).__init__(input_shape=list(shape) if shape else None,
                                     node=None, jvalue=None, name=name)
@@ -435,6 +436,7 @@ class InputLayer(ZooKerasLayer):
     >>> inputlayer = InputLayer(input_shape=(3, 5), name="input1")
     creating: createZooKerasInputLayer
     """
+
     def __init__(self, input_shape=None, **kwargs):
         super(InputLayer, self).__init__(None,
                                          list(input_shape) if input_shape else None,
@@ -467,6 +469,7 @@ class Merge(ZooKerasLayer):
     >>> merge = Merge(layers=[l1, l2], mode='sum', name="merge1")
     creating: createZooKerasMerge
     """
+
     def __init__(self, layers=None, mode="sum", concat_axis=-1,
                  input_shape=None, **kwargs):
         super(Merge, self).__init__(None,

--- a/pyzoo/zoo/pipeline/api/keras/engine/topology.py
+++ b/pyzoo/zoo/pipeline/api/keras/engine/topology.py
@@ -21,6 +21,7 @@ from zoo.feature.common import FeatureSet
 from zoo.pipeline.api.keras.base import ZooKerasLayer
 from zoo.pipeline.api.keras.utils import *
 from bigdl.nn.layer import Layer
+from zoo.common.utils import callZooFunc
 
 if sys.version >= '3':
     long = int
@@ -69,7 +70,7 @@ class KerasNet(ZooKerasLayer):
             criterion = CustomLoss(loss, self.get_output_shape()[1:])
         if metrics and all(isinstance(metric, six.string_types) for metric in metrics):
             metrics = to_bigdl_metrics(metrics, loss)
-        callBigDlFunc(self.bigdl_type, "zooCompile",
+        callZooFunc(self.bigdl_type, "zooCompile",
                       self.value,
                       optimizer,
                       criterion,
@@ -88,7 +89,7 @@ class KerasNet(ZooKerasLayer):
         log_dir: The base directory path to store training and validation logs.
         app_name: The name of the application.
         """
-        callBigDlFunc(self.bigdl_type, "zooSetTensorBoard",
+        callZooFunc(self.bigdl_type, "zooSetTensorBoard",
                       self.value,
                       log_dir,
                       app_name)
@@ -106,7 +107,7 @@ class KerasNet(ZooKerasLayer):
             raise TypeError('Only "Loss", "LearningRate", "Throughput"'
                             + 'are supported in train summary')
 
-        return callBigDlFunc(self.bigdl_type, "zooGetScalarFromSummary",
+        return callZooFunc(self.bigdl_type, "zooGetScalarFromSummary",
                              self.value, tag, "Train")
 
     def get_validation_summary(self, tag=None):
@@ -124,7 +125,7 @@ class KerasNet(ZooKerasLayer):
         if tag not in validation_set:
             raise TypeError('Only subclasses of ValidationMethod are supported,'
                             + 'which are ' + str(validation_set))
-        return callBigDlFunc(self.bigdl_type, "zooGetScalarFromSummary",
+        return callZooFunc(self.bigdl_type, "zooGetScalarFromSummary",
                              self.value, tag, "Validation")
 
     def set_checkpoint(self, path, over_write=True):
@@ -136,7 +137,7 @@ class KerasNet(ZooKerasLayer):
         path: The path to save snapshots. Make sure this path exists beforehand.
         over_write: Whether to overwrite existing snapshots in the given path. Default is True.
         """
-        callBigDlFunc(self.bigdl_type, "zooSetCheckpoint",
+        callZooFunc(self.bigdl_type, "zooSetCheckpoint",
                       self.value,
                       path,
                       over_write)
@@ -146,7 +147,7 @@ class KerasNet(ZooKerasLayer):
         Clear gradient clipping parameters. In this case, gradient clipping will not be applied.
         In order to take effect, it needs to be called before fit.
         """
-        callBigDlFunc(self.bigdl_type, "zooClearGradientClipping",
+        callZooFunc(self.bigdl_type, "zooClearGradientClipping",
                       self.value)
 
     def set_constant_gradient_clipping(self, min, max):
@@ -158,7 +159,7 @@ class KerasNet(ZooKerasLayer):
         min: The minimum value to clip by. Float.
         max: The maximum value to clip by. Float.
         """
-        callBigDlFunc(self.bigdl_type, "zooSetConstantGradientClipping",
+        callZooFunc(self.bigdl_type, "zooSetConstantGradientClipping",
                       self.value,
                       float(min),
                       float(max))
@@ -171,7 +172,7 @@ class KerasNet(ZooKerasLayer):
         # Arguments
         clip_norm: Gradient L2-Norm threshold. Float.
         """
-        callBigDlFunc(self.bigdl_type, "zooSetGradientClippingByL2Norm",
+        callZooFunc(self.bigdl_type, "zooSetGradientClippingByL2Norm",
                       self.value,
                       float(clip_norm))
 
@@ -179,7 +180,7 @@ class KerasNet(ZooKerasLayer):
         """
         Set the model to be in evaluate status, i.e. remove the effect of Dropout, etc.
         """
-        callBigDlFunc(self.bigdl_type, "zooSetEvaluateStatus",
+        callZooFunc(self.bigdl_type, "zooSetEvaluateStatus",
                       self.value)
         return self
 
@@ -217,7 +218,7 @@ class KerasNet(ZooKerasLayer):
                 training_data = x
             else:
                 raise TypeError("Unsupported training data type: %s" % type(x))
-            callBigDlFunc(self.bigdl_type, "zooFit",
+            callZooFunc(self.bigdl_type, "zooFit",
                           self.value,
                           training_data,
                           batch_size,
@@ -229,7 +230,7 @@ class KerasNet(ZooKerasLayer):
                 val_y = JTensor.from_ndarray(validation_data[1])
             else:
                 val_x, val_y = None, None
-            callBigDlFunc(self.bigdl_type, "zooFit",
+            callZooFunc(self.bigdl_type, "zooFit",
                           self.value,
                           [JTensor.from_ndarray(x) for x in to_list(x)],
                           JTensor.from_ndarray(y),
@@ -254,7 +255,7 @@ class KerasNet(ZooKerasLayer):
             data = x
         else:
             raise TypeError("Unsupported evaluation data type: %s" % type(x))
-        return callBigDlFunc(self.bigdl_type, "zooEvaluate",
+        return callZooFunc(self.bigdl_type, "zooEvaluate",
                              self.value,
                              data,
                              batch_size)
@@ -268,7 +269,7 @@ class KerasNet(ZooKerasLayer):
         :return: ndarray or list of ndarray
         """
         jinput, input_is_table = self.check_input(input)
-        output = callBigDlFunc(self.bigdl_type,
+        output = callZooFunc(self.bigdl_type,
                                "zooForward",
                                self.value,
                                jinput,
@@ -298,7 +299,7 @@ class KerasNet(ZooKerasLayer):
                      Default is True. In local mode, x must be a Numpy array.
         """
         if isinstance(x, ImageSet) or isinstance(x, TextSet):
-            results = callBigDlFunc(self.bigdl_type, "zooPredict",
+            results = callZooFunc(self.bigdl_type, "zooPredict",
                                     self.value,
                                     x,
                                     batch_per_thread)
@@ -310,14 +311,14 @@ class KerasNet(ZooKerasLayer):
                 data_rdd = x
             else:
                 raise TypeError("Unsupported prediction data type: %s" % type(x))
-            results = callBigDlFunc(self.bigdl_type, "zooPredict",
+            results = callZooFunc(self.bigdl_type, "zooPredict",
                                     self.value,
                                     data_rdd,
                                     batch_per_thread)
             return results.map(lambda result: Layer.convert_output(result))
         else:
             if isinstance(x, np.ndarray) or isinstance(x, list):
-                results = callBigDlFunc(self.bigdl_type, "zooPredict",
+                results = callZooFunc(self.bigdl_type, "zooPredict",
                                         self.value,
                                         self._to_jtensors(x),
                                         batch_per_thread)
@@ -344,7 +345,7 @@ class KerasNet(ZooKerasLayer):
             data_rdd = x
         else:
             raise TypeError("Unsupported prediction data type: %s" % type(x))
-        return callBigDlFunc(self.bigdl_type, "zooPredictClasses",
+        return callZooFunc(self.bigdl_type, "zooPredictClasses",
                              self.value,
                              data_rdd,
                              batch_per_thread,
@@ -384,23 +385,23 @@ class KerasNet(ZooKerasLayer):
                    If the field has a larger length, the remaining part will be trimmed.
                    If the field has a smaller length, the remaining part will be white spaces.
         """
-        callBigDlFunc(self.bigdl_type, "zooKerasNetSummary",
+        callZooFunc(self.bigdl_type, "zooKerasNetSummary",
                       self.value,
                       line_length,
                       [float(p) for p in positions])
 
     def to_model(self):
         from zoo.pipeline.api.keras.models import Model
-        return Model.from_jvalue(callBigDlFunc(self.bigdl_type, "kerasNetToModel", self.value))
+        return Model.from_jvalue(callZooFunc(self.bigdl_type, "kerasNetToModel", self.value))
 
     @property
     def layers(self):
-        jlayers = callBigDlFunc(self.bigdl_type, "getSubModules", self)
+        jlayers = callZooFunc(self.bigdl_type, "getSubModules", self)
         layers = [Layer.of(jlayer) for jlayer in jlayers]
         return layers
 
     def flattened_layers(self, include_container=False):
-        jlayers = callBigDlFunc(self.bigdl_type, "getFlattenSubModules", self, include_container)
+        jlayers = callZooFunc(self.bigdl_type, "getFlattenSubModules", self, include_container)
         layers = [Layer.of(jlayer) for jlayer in jlayers]
         return layers
 

--- a/pyzoo/zoo/pipeline/api/keras/layers/embeddings.py
+++ b/pyzoo/zoo/pipeline/api/keras/layers/embeddings.py
@@ -60,11 +60,12 @@ class Embedding(ZooKerasLayer):
     >>> embedding = Embedding(10, 200, weights=np.random.random([10, 200]), input_length=10)
     creating: createZooKerasEmbedding
     """
+
     def __init__(self, input_dim, output_dim, init="uniform", weights=None, trainable=True,
                  input_length=None, W_regularizer=None, input_shape=None, mask_zero=False,
                  padding_value=0, zero_based_id=True, **kwargs):
         if input_length:
-            input_shape = (input_length, )
+            input_shape = (input_length,)
         super(Embedding, self).__init__(None,
                                         input_dim,
                                         output_dim,
@@ -108,10 +109,11 @@ class WordEmbedding(ZooKerasLayer):
     name: String to set the name of the layer.
           If not specified, its name will by default to be a generated string.
     """
+
     def __init__(self, embedding_file, word_index=None, trainable=False, input_length=None,
                  input_shape=None, **kwargs):
         if input_length:
-            input_shape = (input_length, )
+            input_shape = (input_length,)
         super(WordEmbedding, self).__init__(None,
                                             embedding_file,
                                             word_index,
@@ -136,7 +138,7 @@ class WordEmbedding(ZooKerasLayer):
         the given embedding file.
         """
         return callZooFunc(bigdl_type, "wordEmbeddingGetWordIndex",
-                             embedding_file)
+                           embedding_file)
 
 
 def prepare_embedding(embedding_file, word_index=None,
@@ -155,10 +157,10 @@ def prepare_embedding(embedding_file, word_index=None,
     Pretrained embedding weights as a numpy array.
     """
     return callZooFunc("float", "prepareEmbedding",
-                         embedding_file,
-                         word_index,
-                         randomize_unknown,
-                         normalize).to_ndarray()
+                       embedding_file,
+                       word_index,
+                       randomize_unknown,
+                       normalize).to_ndarray()
 
 
 class SparseEmbedding(ZooKerasLayer):
@@ -193,6 +195,7 @@ class SparseEmbedding(ZooKerasLayer):
     >>> sparse_embedding = SparseEmbedding(input_dim=10, output_dim=4, input_shape=(10, ))
     creating: createZooKerasSparseEmbedding
     """
+
     def __init__(self, input_dim, output_dim, combiner="sum", max_norm=-1.0, init="uniform",
                  W_regularizer=None, input_shape=None, **kwargs):
         super(SparseEmbedding, self).__init__(None,

--- a/pyzoo/zoo/pipeline/api/keras/layers/embeddings.py
+++ b/pyzoo/zoo/pipeline/api/keras/layers/embeddings.py
@@ -16,7 +16,8 @@
 
 import sys
 
-from bigdl.util.common import callBigDlFunc, JTensor
+from bigdl.util.common import JTensor
+from zoo.common.utils import callZooFunc
 from ..engine.topology import ZooKerasLayer
 
 if sys.version >= '3':
@@ -134,7 +135,7 @@ class WordEmbedding(ZooKerasLayer):
         Dictionary of word (string) and its corresponding index (int) obtained from
         the given embedding file.
         """
-        return callBigDlFunc(bigdl_type, "wordEmbeddingGetWordIndex",
+        return callZooFunc(bigdl_type, "wordEmbeddingGetWordIndex",
                              embedding_file)
 
 
@@ -153,7 +154,7 @@ def prepare_embedding(embedding_file, word_index=None,
     # Return
     Pretrained embedding weights as a numpy array.
     """
-    return callBigDlFunc("float", "prepareEmbedding",
+    return callZooFunc("float", "prepareEmbedding",
                          embedding_file,
                          word_index,
                          randomize_unknown,

--- a/pyzoo/zoo/pipeline/api/keras/layers/normalization.py
+++ b/pyzoo/zoo/pipeline/api/keras/layers/normalization.py
@@ -17,7 +17,8 @@
 import sys
 
 from ..engine.topology import ZooKerasLayer
-from bigdl.util.common import callBigDlFunc, JTensor
+from bigdl.util.common import JTensor
+from zoo.common.utils import callZooFunc
 
 if sys.version >= '3':
     long = int
@@ -75,7 +76,7 @@ class BatchNormalization(ZooKerasLayer):
         Set the running mean of the BatchNormalization layer.
         :param running_mean: a Numpy array.
         """
-        callBigDlFunc(self.bigdl_type, "setRunningMean",
+        callZooFunc(self.bigdl_type, "setRunningMean",
                       self.value, JTensor.from_ndarray(running_mean))
         return self
 
@@ -84,7 +85,7 @@ class BatchNormalization(ZooKerasLayer):
         Set the running variance of the BatchNormalization layer.
         :param running_std: a Numpy array.
         """
-        callBigDlFunc(self.bigdl_type, "setRunningStd",
+        callZooFunc(self.bigdl_type, "setRunningStd",
                       self.value, JTensor.from_ndarray(running_std))
         return self
 
@@ -92,12 +93,12 @@ class BatchNormalization(ZooKerasLayer):
         """
         Get the running meaning of the BatchNormalization layer.
         """
-        return callBigDlFunc(self.bigdl_type, "getRunningMean",
+        return callZooFunc(self.bigdl_type, "getRunningMean",
                              self.value).to_ndarray()
 
     def get_running_std(self):
         """
         Get the running variance of the BatchNormalization layer.
         """
-        return callBigDlFunc(self.bigdl_type, "getRunningStd",
+        return callZooFunc(self.bigdl_type, "getRunningStd",
                              self.value).to_ndarray()

--- a/pyzoo/zoo/pipeline/api/keras/layers/normalization.py
+++ b/pyzoo/zoo/pipeline/api/keras/layers/normalization.py
@@ -52,6 +52,7 @@ class BatchNormalization(ZooKerasLayer):
     >>> batchnormalization = BatchNormalization(input_shape=(3, 12, 12), name="bn1")
     creating: createZooKerasBatchNormalization
     """
+
     def __init__(self, epsilon=0.001, mode=0, axis=1, momentum=0.99, beta_init="zero",
                  gamma_init="one", dim_ordering="th", input_shape=None, **kwargs):
         if mode != 0:
@@ -77,7 +78,7 @@ class BatchNormalization(ZooKerasLayer):
         :param running_mean: a Numpy array.
         """
         callZooFunc(self.bigdl_type, "setRunningMean",
-                      self.value, JTensor.from_ndarray(running_mean))
+                    self.value, JTensor.from_ndarray(running_mean))
         return self
 
     def set_running_std(self, running_std):
@@ -86,7 +87,7 @@ class BatchNormalization(ZooKerasLayer):
         :param running_std: a Numpy array.
         """
         callZooFunc(self.bigdl_type, "setRunningStd",
-                      self.value, JTensor.from_ndarray(running_std))
+                    self.value, JTensor.from_ndarray(running_std))
         return self
 
     def get_running_mean(self):
@@ -94,11 +95,11 @@ class BatchNormalization(ZooKerasLayer):
         Get the running meaning of the BatchNormalization layer.
         """
         return callZooFunc(self.bigdl_type, "getRunningMean",
-                             self.value).to_ndarray()
+                           self.value).to_ndarray()
 
     def get_running_std(self):
         """
         Get the running variance of the BatchNormalization layer.
         """
         return callZooFunc(self.bigdl_type, "getRunningStd",
-                             self.value).to_ndarray()
+                           self.value).to_ndarray()

--- a/pyzoo/zoo/pipeline/api/keras/layers/self_attention.py
+++ b/pyzoo/zoo/pipeline/api/keras/layers/self_attention.py
@@ -220,7 +220,7 @@ class TransformerLayer(ZooKerasLayer):
         embedding.add(Merge(layers=[word_input, postion_input], mode='concat')) \
             .add(Reshape([seq_len * 2])) \
             .add(Embedding(vocab, hidden_size, input_length=seq_len * 2,
-                           weights=np.random.normal(0.0, initializer_range, (vocab, hidden_size)))) \
+                           weights=np.random.normal(0.0, initializer_range, (vocab, hidden_size))))\
             .add(Dropout(embedding_drop)) \
             .add(Reshape((seq_len, 2, hidden_size))) \
             .add(KerasLayerWrapper(Sum(dimension=3, squeeze=True)))

--- a/pyzoo/zoo/pipeline/api/keras/layers/self_attention.py
+++ b/pyzoo/zoo/pipeline/api/keras/layers/self_attention.py
@@ -20,7 +20,7 @@ import math
 
 from bigdl.nn.layer import Sum
 from bigdl.nn.layer import Layer
-from bigdl.util.common import callBigDlFunc
+from zoo.common.utils import callZooFunc
 
 from zoo.models.common import ZooModel
 from zoo.pipeline.api.keras.engine import ZooKerasLayer
@@ -376,7 +376,7 @@ class BERT(TransformerLayer):
               Amazon S3 path should be like 's3a://bucket/xxx'.
         weight_path: The path for pre-trained weights if any. Default is None.
         """
-        jlayer = callBigDlFunc(bigdl_type, "loadBERT", path, weight_path, input_seq_len,
+        jlayer = callZooFunc(bigdl_type, "loadBERT", path, weight_path, input_seq_len,
                                hidden_drop, attn_drop, output_all_block)
 
         model = Layer(jvalue=jlayer, bigdl_type=bigdl_type)

--- a/pyzoo/zoo/pipeline/api/keras/layers/self_attention.py
+++ b/pyzoo/zoo/pipeline/api/keras/layers/self_attention.py
@@ -66,6 +66,7 @@ class TransformerLayer(ZooKerasLayer):
     embedding_layer: embedding layer
     input_shape: input shape
     """
+
     def __init__(self, n_block, hidden_drop, attn_drop, n_head, initializer_range, bidirectional,
                  output_all_block, embedding_layer, input_shape, intermediate_size=0,
                  bigdl_type="float"):
@@ -89,15 +90,15 @@ class TransformerLayer(ZooKerasLayer):
 
         next_input = embedding
 
-        output = [None]*n_block
+        output = [None] * n_block
         output[0] = self.block(next_input, hidden_size, extended_attention_mask)
 
-        for index in range(n_block-1):
+        for index in range(n_block - 1):
             o = self.block(output[index], hidden_size, extended_attention_mask)
-            output[index+1] = o
+            output[index + 1] = o
 
         pooler_output = self.pooler(output[-1], hidden_size)
-        model = Model(inputs, output.append(pooler_output)) if output_all_block\
+        model = Model(inputs, output.append(pooler_output)) if output_all_block \
             else Model(inputs, [output[-1], pooler_output])
         self.value = model.value
 
@@ -125,10 +126,10 @@ class TransformerLayer(ZooKerasLayer):
         return Convolution1D(output_size, 1, "normal", (0.0, self.initializer_range))
 
     def multi_head_self_attention(self, x, size, attention_mask=None):
-        c = self.projection_layer(size*3)(x)
+        c = self.projection_layer(size * 3)(x)
         query = c.slice(2, 0, size)
         key = c.slice(2, size, size)
-        value = c.slice(2, size*2, size)
+        value = c.slice(2, size * 2, size)
         q = self.split_heads(query, self.n_head)
         k = self.split_heads(key, self.n_head, k=True)
         v = self.split_heads(value, self.n_head)
@@ -216,12 +217,12 @@ class TransformerLayer(ZooKerasLayer):
         postion_input = InputLayer(input_shape=(seq_len,))
 
         embedding = Sequential()
-        embedding.add(Merge(layers=[word_input, postion_input], mode='concat'))\
-            .add(Reshape([seq_len * 2]))\
+        embedding.add(Merge(layers=[word_input, postion_input], mode='concat')) \
+            .add(Reshape([seq_len * 2])) \
             .add(Embedding(vocab, hidden_size, input_length=seq_len * 2,
-                           weights=np.random.normal(0.0, initializer_range, (vocab, hidden_size))))\
-            .add(Dropout(embedding_drop))\
-            .add(Reshape((seq_len, 2, hidden_size)))\
+                           weights=np.random.normal(0.0, initializer_range, (vocab, hidden_size)))) \
+            .add(Dropout(embedding_drop)) \
+            .add(Reshape((seq_len, 2, hidden_size))) \
             .add(KerasLayerWrapper(Sum(dimension=3, squeeze=True)))
         # walk around for bug #1208, need remove this line after the bug fixed
         embedding.add(KerasLayerWrapper(Squeeze(dim=3)))
@@ -258,6 +259,7 @@ class BERT(TransformerLayer):
     embedding_layer: embedding layer
     input_shape: input shape
     """
+
     def __init__(self, n_block, n_head, intermediate_size, hidden_drop, attn_drop,
                  initializer_range, output_all_block, embedding_layer,
                  input_shape, bigdl_type="float"):
@@ -285,9 +287,9 @@ class BERT(TransformerLayer):
         model_output = [None] * n_block
         model_output[0] = self.block(next_input, self.hidden_size, extended_attention_mask)
 
-        for _ in range(n_block-1):
+        for _ in range(n_block - 1):
             output = self.block(model_output[_], self.hidden_size, extended_attention_mask)
-            model_output[_+1] = output
+            model_output[_ + 1] = output
 
         pooler_output = self.pooler(model_output[-1], self.hidden_size)
 
@@ -304,7 +306,7 @@ class BERT(TransformerLayer):
         return Dense(output_size, "normal", (0.0, self.initializer_range))
 
     def build_input(self, input_shape):
-        if any(not isinstance(i, list) and not isinstance(i, tuple) for i in input_shape)\
+        if any(not isinstance(i, list) and not isinstance(i, tuple) for i in input_shape) \
                 and len(input_shape) != 4:
             raise TypeError('BERT input must be a list of 4 ndarray (consisting of input'
                             ' sequence, sequence positions, segment id, attention mask)')
@@ -377,7 +379,7 @@ class BERT(TransformerLayer):
         weight_path: The path for pre-trained weights if any. Default is None.
         """
         jlayer = callZooFunc(bigdl_type, "loadBERT", path, weight_path, input_seq_len,
-                               hidden_drop, attn_drop, output_all_block)
+                             hidden_drop, attn_drop, output_all_block)
 
         model = Layer(jvalue=jlayer, bigdl_type=bigdl_type)
         model.__class__ = BERT

--- a/pyzoo/zoo/pipeline/api/keras/models.py
+++ b/pyzoo/zoo/pipeline/api/keras/models.py
@@ -18,7 +18,8 @@ import sys
 
 from zoo.pipeline.api.utils import remove_batch
 from .engine.topology import KerasNet
-from bigdl.util.common import to_list, callBigDlFunc
+from bigdl.util.common import to_list
+from zoo.common.utils import callZooFunc
 
 if sys.version >= '3':
     long = int
@@ -96,20 +97,20 @@ class Model(KerasNet):
         log_path: The path to save the model graph.
         backward: The name of the application.
         """
-        callBigDlFunc(self.bigdl_type, "zooSaveGraphTopology",
+        callZooFunc(self.bigdl_type, "zooSaveGraphTopology",
                       self.value,
                       log_path,
                       backward)
 
     def new_graph(self, outputs):
-        value = callBigDlFunc(self.bigdl_type, "newGraph", self.value, outputs)
+        value = callZooFunc(self.bigdl_type, "newGraph", self.value, outputs)
         return self.from_jvalue(value)
 
     def freeze_up_to(self, names):
-        callBigDlFunc(self.bigdl_type, "freezeUpTo", self.value, names)
+        callZooFunc(self.bigdl_type, "freezeUpTo", self.value, names)
 
     def unfreeze(self, names):
-        callBigDlFunc(self.bigdl_type, "unFreeze", self.value, names)
+        callZooFunc(self.bigdl_type, "unFreeze", self.value, names)
 
     @staticmethod
     def from_jvalue(jvalue, bigdl_type="float"):

--- a/pyzoo/zoo/pipeline/api/keras/models.py
+++ b/pyzoo/zoo/pipeline/api/keras/models.py
@@ -36,6 +36,7 @@ class Sequential(KerasNet):
     >>> sequential = Sequential(name="seq1")
     creating: createZooKerasSequential
     """
+
     def __init__(self, jvalue=None, **kwargs):
         super(Sequential, self).__init__(jvalue, **kwargs)
 
@@ -81,6 +82,7 @@ class Model(KerasNet):
     output: An output node or a list of output nodes.
     name: String to specify the name of the graph model. Default is None.
     """
+
     def __init__(self, input, output, jvalue=None, **kwargs):
         super(Model, self).__init__(jvalue,
                                     to_list(input),
@@ -98,9 +100,9 @@ class Model(KerasNet):
         backward: The name of the application.
         """
         callZooFunc(self.bigdl_type, "zooSaveGraphTopology",
-                      self.value,
-                      log_path,
-                      backward)
+                    self.value,
+                    log_path,
+                    backward)
 
     def new_graph(self, outputs):
         value = callZooFunc(self.bigdl_type, "newGraph", self.value, outputs)

--- a/pyzoo/zoo/pipeline/api/keras/optimizers.py
+++ b/pyzoo/zoo/pipeline/api/keras/optimizers.py
@@ -31,6 +31,7 @@ class Adam(OptimMethod, ZooKerasCreator):
     creating: createZooKerasAdam
     creating: createDefault
     """
+
     def __init__(self,
                  lr=1e-3,
                  beta_1=0.9,
@@ -69,6 +70,7 @@ class AdamWeightDecay(OptimMethod, ZooKerasCreator):
     >>> adam = AdamWeightDecay()
     creating: createZooKerasAdamWeightDecay
     """
+
     def __init__(self,
                  lr=1e-3,
                  warmup_portion=-1.0,
@@ -121,5 +123,6 @@ class PolyEpochDecay(ZooKerasCreator):
     >>> poly = PolyEpochDecay(0.5, 5)
     creating: createZooKerasPolyEpochDecay
     """
+
     def __init__(self, power, max_epochs, bigdl_type="float"):
-            JavaValue.__init__(self, None, bigdl_type, power, max_epochs)
+        JavaValue.__init__(self, None, bigdl_type, power, max_epochs)

--- a/pyzoo/zoo/pipeline/api/keras/optimizers.py
+++ b/pyzoo/zoo/pipeline/api/keras/optimizers.py
@@ -17,6 +17,7 @@
 from bigdl.util.common import *
 from bigdl.optim.optimizer import OptimMethod, Default
 from zoo.pipeline.api.keras.base import ZooKerasCreator
+from zoo.common.utils import callZooFunc
 
 if sys.version >= '3':
     long = int
@@ -51,7 +52,7 @@ class Adam(OptimMethod, ZooKerasCreator):
         # 1. This class need to be a subclass of OptimMethod
         # 2. The constructor of OptimMethod invokes JavaValue.jvm_class_constructor() directly
         #    and does not take the polymorphism.
-        self.value = callBigDlFunc(
+        self.value = callZooFunc(
             bigdl_type, ZooKerasCreator.jvm_class_constructor(self),
             lr,
             beta_1,
@@ -94,7 +95,7 @@ class AdamWeightDecay(OptimMethod, ZooKerasCreator):
         # 1. This class need to be a subclass of OptimMethod
         # 2. The constructor of OptimMethod invokes JavaValue.jvm_class_constructor() directly
         #    and does not take the polymorphism.
-        self.value = callBigDlFunc(
+        self.value = callZooFunc(
             bigdl_type, ZooKerasCreator.jvm_class_constructor(self),
             lr,
             warmup_portion,

--- a/pyzoo/zoo/pipeline/api/net/graph_net.py
+++ b/pyzoo/zoo/pipeline/api/net/graph_net.py
@@ -52,9 +52,9 @@ class GraphNet(BModel):
         """
         if isinstance(x, ImageSet) or isinstance(x, TextSet):
             results = callZooFunc(self.bigdl_type, "zooPredict",
-                                    self.value,
-                                    x,
-                                    batch_per_thread)
+                                  self.value,
+                                  x,
+                                  batch_per_thread)
             return ImageSet(results) if isinstance(x, ImageSet) else TextSet(results)
         if distributed:
             if isinstance(x, np.ndarray):
@@ -64,16 +64,16 @@ class GraphNet(BModel):
             else:
                 raise TypeError("Unsupported prediction data type: %s" % type(x))
             results = callZooFunc(self.bigdl_type, "zooPredict",
-                                    self.value,
-                                    data_rdd,
-                                    batch_per_thread)
+                                  self.value,
+                                  data_rdd,
+                                  batch_per_thread)
             return results.map(lambda result: Layer.convert_output(result))
         else:
             if isinstance(x, np.ndarray) or isinstance(x, list):
                 results = callZooFunc(self.bigdl_type, "zooPredict",
-                                        self.value,
-                                        self._to_jtensors(x),
-                                        batch_per_thread)
+                                      self.value,
+                                      self._to_jtensors(x),
+                                      batch_per_thread)
                 return [Layer.convert_output(result) for result in results]
             else:
                 raise TypeError("Unsupported prediction data type: %s" % type(x))

--- a/pyzoo/zoo/pipeline/api/net/graph_net.py
+++ b/pyzoo/zoo/pipeline/api/net/graph_net.py
@@ -22,6 +22,7 @@ from zoo.feature.text import TextSet
 from zoo.pipeline.api.keras.base import ZooKerasLayer
 from zoo.pipeline.api.keras.utils import *
 from bigdl.nn.layer import Layer
+from zoo.common.utils import callZooFunc
 
 if sys.version >= '3':
     long = int
@@ -50,7 +51,7 @@ class GraphNet(BModel):
                      Default is True. In local mode, x must be a Numpy array.
         """
         if isinstance(x, ImageSet) or isinstance(x, TextSet):
-            results = callBigDlFunc(self.bigdl_type, "zooPredict",
+            results = callZooFunc(self.bigdl_type, "zooPredict",
                                     self.value,
                                     x,
                                     batch_per_thread)
@@ -62,14 +63,14 @@ class GraphNet(BModel):
                 data_rdd = x
             else:
                 raise TypeError("Unsupported prediction data type: %s" % type(x))
-            results = callBigDlFunc(self.bigdl_type, "zooPredict",
+            results = callZooFunc(self.bigdl_type, "zooPredict",
                                     self.value,
                                     data_rdd,
                                     batch_per_thread)
             return results.map(lambda result: Layer.convert_output(result))
         else:
             if isinstance(x, np.ndarray) or isinstance(x, list):
-                results = callBigDlFunc(self.bigdl_type, "zooPredict",
+                results = callZooFunc(self.bigdl_type, "zooPredict",
                                         self.value,
                                         self._to_jtensors(x),
                                         batch_per_thread)
@@ -78,13 +79,13 @@ class GraphNet(BModel):
                 raise TypeError("Unsupported prediction data type: %s" % type(x))
 
     def flattened_layers(self, include_container=False):
-        jlayers = callBigDlFunc(self.bigdl_type, "getFlattenSubModules", self, include_container)
+        jlayers = callZooFunc(self.bigdl_type, "getFlattenSubModules", self, include_container)
         layers = [Layer.of(jlayer) for jlayer in jlayers]
         return layers
 
     @property
     def layers(self):
-        jlayers = callBigDlFunc(self.bigdl_type, "getSubModules", self)
+        jlayers = callZooFunc(self.bigdl_type, "getSubModules", self)
         layers = [Layer.of(jlayer) for jlayer in jlayers]
         return layers
 
@@ -107,7 +108,7 @@ class GraphNet(BModel):
         :param outputs: A list of nodes specified
         :return: A graph model
         """
-        value = callBigDlFunc(self.bigdl_type, "newGraph", self.value, outputs)
+        value = callZooFunc(self.bigdl_type, "newGraph", self.value, outputs)
         return self.from_jvalue(value, self.bigdl_type)
 
     def freeze_up_to(self, names):
@@ -118,7 +119,7 @@ class GraphNet(BModel):
         :param names: A list of module names to be Freezed
         :return: current graph model
         """
-        callBigDlFunc(self.bigdl_type, "freezeUpTo", self.value, names)
+        callZooFunc(self.bigdl_type, "freezeUpTo", self.value, names)
 
     def unfreeze(self, names=None):
         """
@@ -129,8 +130,8 @@ class GraphNet(BModel):
         :param names: list of module names to be unFreezed. Default is None.
         :return: current graph model
         """
-        callBigDlFunc(self.bigdl_type, "unFreeze", self.value, names)
+        callZooFunc(self.bigdl_type, "unFreeze", self.value, names)
 
     def to_keras(self):
-        value = callBigDlFunc(self.bigdl_type, "netToKeras", self.value)
+        value = callZooFunc(self.bigdl_type, "netToKeras", self.value)
         return ZooKerasLayer.of(value, self.bigdl_type)

--- a/pyzoo/zoo/pipeline/api/net/net_load.py
+++ b/pyzoo/zoo/pipeline/api/net/net_load.py
@@ -18,7 +18,7 @@ import importlib
 import os
 import sys
 
-from bigdl.util.common import callBigDlFunc
+from zoo.common.utils import callZooFunc
 from bigdl.nn.layer import Model as BModel
 from zoo.pipeline.api.net.graph_net import GraphNet
 
@@ -32,7 +32,7 @@ class JavaToPython:
     # TODO: Add more mapping here as it only support Model and Sequential for now.
     def __init__(self, jvalue, bigdl_type="float"):
         self.jvaule = jvalue
-        self.jfullname = callBigDlFunc(bigdl_type,
+        self.jfullname = callZooFunc(bigdl_type,
                                        "getRealClassNameOfJValue",
                                        jvalue)
 
@@ -83,7 +83,7 @@ class Net:
         :param weight_path: The path to the weights of the pre-trained model. Default is None.
         :return: A pre-trained model.
         """
-        jmodel = callBigDlFunc(bigdl_type, "netLoadBigDL", model_path, weight_path)
+        jmodel = callZooFunc(bigdl_type, "netLoadBigDL", model_path, weight_path)
         return GraphNet.from_jvalue(jmodel)
 
     @staticmethod
@@ -98,7 +98,7 @@ class Net:
         :param weight_path: The path for pre-trained weights if any. Default is None.
         :return: An Analytics Zoo model.
         """
-        jmodel = callBigDlFunc(bigdl_type, "netLoad", model_path, weight_path)
+        jmodel = callZooFunc(bigdl_type, "netLoad", model_path, weight_path)
         return Net.from_jvalue(jmodel, bigdl_type)
 
     @staticmethod
@@ -109,7 +109,7 @@ class Net:
         :param path: The path containing the pre-trained model.
         :return: A pre-trained model.
         """
-        jmodel = callBigDlFunc(bigdl_type, "netLoadTorch", path)
+        jmodel = callZooFunc(bigdl_type, "netLoadTorch", path)
         return GraphNet.from_jvalue(jmodel, bigdl_type)
 
     @staticmethod
@@ -131,9 +131,9 @@ class Net:
         if not inputs and not outputs:  # load_tf from exported folder
             if not os.path.isdir(path):
                 raise ValueError("load_tf from exported folder requires path to be a folder")
-            jmodel = callBigDlFunc(bigdl_type, "netLoadTF", path)
+            jmodel = callZooFunc(bigdl_type, "netLoadTF", path)
         else:
-            jmodel = callBigDlFunc(bigdl_type, "netLoadTF", path, inputs, outputs,
+            jmodel = callZooFunc(bigdl_type, "netLoadTF", path, inputs, outputs,
                                    byte_order, bin_file)
         return GraphNet.from_jvalue(jmodel, bigdl_type)
 
@@ -146,7 +146,7 @@ class Net:
         :param model_path: The path containing the pre-trained caffe model.
         :return: A pre-trained model.
         """
-        jmodel = callBigDlFunc(bigdl_type, "netLoadCaffe", def_path, model_path)
+        jmodel = callZooFunc(bigdl_type, "netLoadCaffe", def_path, model_path)
         return GraphNet.from_jvalue(jmodel, bigdl_type)
 
     @staticmethod

--- a/pyzoo/zoo/pipeline/api/net/net_load.py
+++ b/pyzoo/zoo/pipeline/api/net/net_load.py
@@ -22,7 +22,6 @@ from zoo.common.utils import callZooFunc
 from bigdl.nn.layer import Model as BModel
 from zoo.pipeline.api.net.graph_net import GraphNet
 
-
 if sys.version >= '3':
     long = int
     unicode = str
@@ -33,8 +32,8 @@ class JavaToPython:
     def __init__(self, jvalue, bigdl_type="float"):
         self.jvaule = jvalue
         self.jfullname = callZooFunc(bigdl_type,
-                                       "getRealClassNameOfJValue",
-                                       jvalue)
+                                     "getRealClassNameOfJValue",
+                                     jvalue)
 
     def get_python_class(self):
         """
@@ -134,7 +133,7 @@ class Net:
             jmodel = callZooFunc(bigdl_type, "netLoadTF", path)
         else:
             jmodel = callZooFunc(bigdl_type, "netLoadTF", path, inputs, outputs,
-                                   byte_order, bin_file)
+                                 byte_order, bin_file)
         return GraphNet.from_jvalue(jmodel, bigdl_type)
 
     @staticmethod

--- a/pyzoo/zoo/pipeline/api/net/tf_dataset.py
+++ b/pyzoo/zoo/pipeline/api/net/tf_dataset.py
@@ -558,18 +558,18 @@ class TFRecordDataset(TFDataset):
 
         sc = getOrCreateSparkContext()
         train_rdd = callZooFunc("float", "createRDDFromTFRecords",
-                                  file_path, sc, serialized_graph,
-                                  serialized_example.name, output_names)
+                                file_path, sc, serialized_graph,
+                                serialized_example.name, output_names)
         validation_rdd = None
         if validation_file_path is not None:
             validation_rdd = callZooFunc("float", "createRDDFromTFRecords",
-                                           validation_file_path, sc, serialized_graph,
-                                           serialized_example.name, output_names)
+                                         validation_file_path, sc, serialized_graph,
+                                         serialized_example.name, output_names)
 
         tensor_structure = nest.pack_sequence_as(results,
                                                  [TensorMeta(tf.as_dtype(t.dtype),
-                                                  shape=t.shape,
-                                                  name="data_%s" % i)
+                                                             shape=t.shape,
+                                                             name="data_%s" % i)
                                                   for i, t in enumerate(nest.flatten(results))])
 
         super(TFRecordDataset, self).__init__(tensor_structure, batch_size,

--- a/pyzoo/zoo/pipeline/api/net/tf_dataset.py
+++ b/pyzoo/zoo/pipeline/api/net/tf_dataset.py
@@ -19,7 +19,8 @@ import sys
 
 from bigdl.dataset.dataset import DataSet
 from bigdl.transform.vision.image import FeatureTransformer
-from bigdl.util.common import get_node_and_core_number, callBigDlFunc
+from bigdl.util.common import get_node_and_core_number
+from zoo.common.utils import callZooFunc
 from zoo.common import Sample, JTensor
 from zoo.common.nncontext import getOrCreateSparkContext
 from zoo.feature.common import FeatureSet
@@ -556,12 +557,12 @@ class TFRecordDataset(TFDataset):
         serialized_graph = bytearray(g.as_graph_def().SerializeToString())
 
         sc = getOrCreateSparkContext()
-        train_rdd = callBigDlFunc("float", "createRDDFromTFRecords",
+        train_rdd = callZooFunc("float", "createRDDFromTFRecords",
                                   file_path, sc, serialized_graph,
                                   serialized_example.name, output_names)
         validation_rdd = None
         if validation_file_path is not None:
-            validation_rdd = callBigDlFunc("float", "createRDDFromTFRecords",
+            validation_rdd = callZooFunc("float", "createRDDFromTFRecords",
                                            validation_file_path, sc, serialized_graph,
                                            serialized_example.name, output_names)
 

--- a/pyzoo/zoo/pipeline/api/net/tf_optimizer.py
+++ b/pyzoo/zoo/pipeline/api/net/tf_optimizer.py
@@ -244,8 +244,8 @@ class TFModel(object):
         update_op = tf.group(update_ops)
 
         return trainable_variables, trainable_variable_placeholders, trainable_assign, \
-               extra_variables, extra_variable_assign_placeholders, \
-               extra_variable_assign, update_op
+            extra_variables, extra_variable_assign_placeholders, \
+            extra_variable_assign, update_op
 
     @staticmethod
     def _save_to_dir_for_unfreeze(folder, sess, graph,

--- a/pyzoo/zoo/pipeline/api/net/tf_optimizer.py
+++ b/pyzoo/zoo/pipeline/api/net/tf_optimizer.py
@@ -90,7 +90,7 @@ class TFTrainingHelper2(Layer):
 
     def save_checkpoint(self):
         callZooFunc(self.bigdl_type, "saveCheckpoint",
-                      self.value)
+                    self.value)
 
     def get_weights_to_python(self):
         self.save_checkpoint()
@@ -244,8 +244,8 @@ class TFModel(object):
         update_op = tf.group(update_ops)
 
         return trainable_variables, trainable_variable_placeholders, trainable_assign, \
-            extra_variables, extra_variable_assign_placeholders, \
-            extra_variable_assign, update_op
+               extra_variables, extra_variable_assign_placeholders, \
+               extra_variable_assign, update_op
 
     @staticmethod
     def _save_to_dir_for_unfreeze(folder, sess, graph,
@@ -355,8 +355,8 @@ class TFModel(object):
         outputs, val_methods = TFModel._process_metrics(graph, metrics, loss, inputs)
 
         trainable_variables, trainable_variable_placeholders, trainable_assign, \
-            extra_variables, extra_variable_assign_placeholders, \
-            extra_variable_assign, update_op = \
+        extra_variables, extra_variable_assign_placeholders, \
+        extra_variable_assign, update_op = \
             TFModel._process_variables_for_unfreeze(graph, variables, updates)
 
         meta, saver = \

--- a/pyzoo/zoo/pipeline/api/net/tf_optimizer.py
+++ b/pyzoo/zoo/pipeline/api/net/tf_optimizer.py
@@ -22,7 +22,8 @@ import sys
 
 from bigdl.nn.criterion import Criterion
 from bigdl.nn.layer import Layer
-from bigdl.util.common import to_list, JavaValue, callBigDlFunc
+from bigdl.util.common import to_list, JavaValue
+from zoo.common.utils import callZooFunc
 from bigdl.optim.optimizer import MaxEpoch, EveryEpoch
 from zoo.pipeline.api.keras.engine.topology import to_bigdl_metric, Loss
 from zoo.pipeline.api.net.utils import _find_placeholders, to_bigdl_optim_method
@@ -88,7 +89,7 @@ class TFTrainingHelper2(Layer):
         super(TFTrainingHelper2, self).__init__(None, "float", path, byte_arr)
 
     def save_checkpoint(self):
-        callBigDlFunc(self.bigdl_type, "saveCheckpoint",
+        callZooFunc(self.bigdl_type, "saveCheckpoint",
                       self.value)
 
     def get_weights_to_python(self):

--- a/pyzoo/zoo/pipeline/api/net/tf_optimizer.py
+++ b/pyzoo/zoo/pipeline/api/net/tf_optimizer.py
@@ -355,8 +355,8 @@ class TFModel(object):
         outputs, val_methods = TFModel._process_metrics(graph, metrics, loss, inputs)
 
         trainable_variables, trainable_variable_placeholders, trainable_assign, \
-        extra_variables, extra_variable_assign_placeholders, \
-        extra_variable_assign, update_op = \
+            extra_variables, extra_variable_assign_placeholders, \
+            extra_variable_assign, update_op = \
             TFModel._process_variables_for_unfreeze(graph, variables, updates)
 
         meta, saver = \

--- a/pyzoo/zoo/pipeline/api/net/tfnet.py
+++ b/pyzoo/zoo/pipeline/api/net/tfnet.py
@@ -26,7 +26,7 @@ from pyspark import RDD
 from zoo.common.nncontext import getOrCreateSparkContext
 from zoo.common import JTensor, Sample
 from zoo.feature.image import ImageSet
-from bigdl.util.common import callBigDlFunc
+from zoo.common.utils import callZooFunc
 
 if sys.version >= '3':
     long = int
@@ -107,7 +107,7 @@ class TFNet(Layer):
         Use a model to do prediction.
         """
         if isinstance(x, ImageSet):
-            results = callBigDlFunc(self.bigdl_type, "zooPredict",
+            results = callZooFunc(self.bigdl_type, "zooPredict",
                                     self.value,
                                     x,
                                     batch_per_thread)
@@ -119,7 +119,7 @@ class TFNet(Layer):
                 data_rdd = x
             else:
                 raise TypeError("Unsupported prediction data type: %s" % type(x))
-            results = callBigDlFunc(self.bigdl_type, "zooPredict",
+            results = callZooFunc(self.bigdl_type, "zooPredict",
                                     self.value,
                                     data_rdd,
                                     batch_per_thread)

--- a/pyzoo/zoo/pipeline/api/net/tfnet.py
+++ b/pyzoo/zoo/pipeline/api/net/tfnet.py
@@ -108,9 +108,9 @@ class TFNet(Layer):
         """
         if isinstance(x, ImageSet):
             results = callZooFunc(self.bigdl_type, "zooPredict",
-                                    self.value,
-                                    x,
-                                    batch_per_thread)
+                                  self.value,
+                                  x,
+                                  batch_per_thread)
             return ImageSet(results)
         if distributed:
             if isinstance(x, np.ndarray):
@@ -120,9 +120,9 @@ class TFNet(Layer):
             else:
                 raise TypeError("Unsupported prediction data type: %s" % type(x))
             results = callZooFunc(self.bigdl_type, "zooPredict",
-                                    self.value,
-                                    data_rdd,
-                                    batch_per_thread)
+                                  self.value,
+                                  data_rdd,
+                                  batch_per_thread)
             return results.map(lambda result: Layer.convert_output(result))
         else:
             start_idx = 0

--- a/pyzoo/zoo/pipeline/api/net/torch_net.py
+++ b/pyzoo/zoo/pipeline/api/net/torch_net.py
@@ -106,9 +106,9 @@ class TorchNet(Layer):
         """
         if isinstance(x, ImageSet):
             results = callZooFunc(self.bigdl_type, "zooPredict",
-                                    self.value,
-                                    x,
-                                    batch_per_thread)
+                                  self.value,
+                                  x,
+                                  batch_per_thread)
             return ImageSet(results)
         if distributed:
             if isinstance(x, np.ndarray):
@@ -118,16 +118,16 @@ class TorchNet(Layer):
             else:
                 raise TypeError("Unsupported prediction data type: %s" % type(x))
             results = callZooFunc(self.bigdl_type, "zooPredict",
-                                    self.value,
-                                    data_rdd,
-                                    batch_per_thread)
+                                  self.value,
+                                  data_rdd,
+                                  batch_per_thread)
             return results.map(lambda result: Layer.convert_output(result))
         else:
             if isinstance(x, np.ndarray) or isinstance(x, list):
                 results = callZooFunc(self.bigdl_type, "zooPredict",
-                                        self.value,
-                                        self._to_jtensors(x),
-                                        batch_per_thread)
+                                      self.value,
+                                      self._to_jtensors(x),
+                                      batch_per_thread)
                 return [Layer.convert_output(result) for result in results]
             else:
                 raise TypeError("Unsupported prediction data type: %s" % type(x))

--- a/pyzoo/zoo/pipeline/api/net/torch_net.py
+++ b/pyzoo/zoo/pipeline/api/net/torch_net.py
@@ -24,7 +24,7 @@ from pyspark import RDD
 from bigdl.nn.layer import Layer
 from zoo import getOrCreateSparkContext
 from zoo.feature.image import ImageSet
-from bigdl.util.common import callBigDlFunc
+from zoo.common.utils import callZooFunc
 from zoo.pipeline.api.net.tfnet import to_sample_rdd
 
 if sys.version >= '3':
@@ -97,7 +97,7 @@ class TorchNet(Layer):
         save the model as a torch script module
         '''
         pythonBigDL_method_name = "torchNetSavePytorch"
-        callBigDlFunc(self.bigdl_type, pythonBigDL_method_name, self.value, path)
+        callZooFunc(self.bigdl_type, pythonBigDL_method_name, self.value, path)
         return
 
     def predict(self, x, batch_per_thread=1, distributed=True):
@@ -105,7 +105,7 @@ class TorchNet(Layer):
         Use a model to do prediction.
         """
         if isinstance(x, ImageSet):
-            results = callBigDlFunc(self.bigdl_type, "zooPredict",
+            results = callZooFunc(self.bigdl_type, "zooPredict",
                                     self.value,
                                     x,
                                     batch_per_thread)
@@ -117,14 +117,14 @@ class TorchNet(Layer):
                 data_rdd = x
             else:
                 raise TypeError("Unsupported prediction data type: %s" % type(x))
-            results = callBigDlFunc(self.bigdl_type, "zooPredict",
+            results = callZooFunc(self.bigdl_type, "zooPredict",
                                     self.value,
                                     data_rdd,
                                     batch_per_thread)
             return results.map(lambda result: Layer.convert_output(result))
         else:
             if isinstance(x, np.ndarray) or isinstance(x, list):
-                results = callBigDlFunc(self.bigdl_type, "zooPredict",
+                results = callZooFunc(self.bigdl_type, "zooPredict",
                                         self.value,
                                         self._to_jtensors(x),
                                         batch_per_thread)

--- a/pyzoo/zoo/pipeline/estimator/estimator.py
+++ b/pyzoo/zoo/pipeline/estimator/estimator.py
@@ -14,7 +14,8 @@
 # limitations under the License.
 #
 
-from bigdl.util.common import JavaValue, callBigDlFunc
+from bigdl.util.common import JavaValue
+from zoo.common.utils import callZooFunc
 
 
 class Estimator(JavaValue):
@@ -26,7 +27,7 @@ class Estimator(JavaValue):
     """
     def __init__(self, model, optim_methods=None, model_dir=None, jvalue=None, bigdl_type="float"):
         self.bigdl_type = bigdl_type
-        self.value = jvalue if jvalue else callBigDlFunc(
+        self.value = jvalue if jvalue else callZooFunc(
             bigdl_type, self.jvm_class_constructor(), model, optim_methods, model_dir)
 
     def clear_gradient_clipping(self):
@@ -35,7 +36,7 @@ class Estimator(JavaValue):
         In order to take effect, it needs to be called before fit.
         :return:
         """
-        callBigDlFunc(self.bigdl_type, "clearGradientClipping")
+        callZooFunc(self.bigdl_type, "clearGradientClipping")
 
     def set_constant_gradient_clipping(self, min, max):
         """
@@ -45,7 +46,7 @@ class Estimator(JavaValue):
         :param max: The maximum value to clip by.
         :return:
         """
-        callBigDlFunc(self.bigdl_type, "setConstantGradientClipping", self.value, min, max)
+        callZooFunc(self.bigdl_type, "setConstantGradientClipping", self.value, min, max)
 
     def set_l2_norm_gradient_clipping(self, clip_norm):
         """
@@ -54,7 +55,7 @@ class Estimator(JavaValue):
         :param clip_norm: Gradient L2-Norm threshold.
         :return:
         """
-        callBigDlFunc(self.bigdl_type, "setGradientClippingByL2Norm", self.value, clip_norm)
+        callZooFunc(self.bigdl_type, "setGradientClippingByL2Norm", self.value, clip_norm)
 
     def train(self, train_set, criterion, end_trigger=None, checkpoint_trigger=None,
               validation_set=None, validation_method=None, batch_size=32):
@@ -73,7 +74,7 @@ class Estimator(JavaValue):
         :param batch_size:
         :return: Estimator
         """
-        callBigDlFunc(self.bigdl_type, "estimatorTrain", self.value, train_set,
+        callZooFunc(self.bigdl_type, "estimatorTrain", self.value, train_set,
                       criterion, end_trigger, checkpoint_trigger, validation_set,
                       validation_method, batch_size)
 
@@ -94,7 +95,7 @@ class Estimator(JavaValue):
         :param batch_size: Batch size
         :return:
         """
-        callBigDlFunc(self.bigdl_type, "estimatorTrainImageFeature", self.value, train_set,
+        callZooFunc(self.bigdl_type, "estimatorTrainImageFeature", self.value, train_set,
                       criterion, end_trigger, checkpoint_trigger, validation_set,
                       validation_method, batch_size)
 
@@ -106,7 +107,7 @@ class Estimator(JavaValue):
         :param batch_size: batch size
         :return: validation results
         """
-        callBigDlFunc(self.bigdl_type, "estimatorEvaluate", self.value,
+        callZooFunc(self.bigdl_type, "estimatorEvaluate", self.value,
                       validation_set, validation_method, batch_size)
 
     def evaluate_imagefeature(self, validation_set, validation_method, batch_size=32):
@@ -117,5 +118,5 @@ class Estimator(JavaValue):
         :param batch_size: batch size
         :return: validation results
         """
-        callBigDlFunc(self.bigdl_type, "estimatorEvaluateImageFeature", self.value,
+        callZooFunc(self.bigdl_type, "estimatorEvaluateImageFeature", self.value,
                       validation_set, validation_method, batch_size)

--- a/pyzoo/zoo/pipeline/estimator/estimator.py
+++ b/pyzoo/zoo/pipeline/estimator/estimator.py
@@ -25,6 +25,7 @@ class Estimator(JavaValue):
     Estimator wraps a model, and provide an uniform training, evaluation or prediction operation on
     both local host and distributed spark environment.
     """
+
     def __init__(self, model, optim_methods=None, model_dir=None, jvalue=None, bigdl_type="float"):
         self.bigdl_type = bigdl_type
         self.value = jvalue if jvalue else callZooFunc(
@@ -75,8 +76,8 @@ class Estimator(JavaValue):
         :return: Estimator
         """
         callZooFunc(self.bigdl_type, "estimatorTrain", self.value, train_set,
-                      criterion, end_trigger, checkpoint_trigger, validation_set,
-                      validation_method, batch_size)
+                    criterion, end_trigger, checkpoint_trigger, validation_set,
+                    validation_method, batch_size)
 
     def train_imagefeature(self, train_set, criterion, end_trigger=None, checkpoint_trigger=None,
                            validation_set=None, validation_method=None, batch_size=32):
@@ -96,8 +97,8 @@ class Estimator(JavaValue):
         :return:
         """
         callZooFunc(self.bigdl_type, "estimatorTrainImageFeature", self.value, train_set,
-                      criterion, end_trigger, checkpoint_trigger, validation_set,
-                      validation_method, batch_size)
+                    criterion, end_trigger, checkpoint_trigger, validation_set,
+                    validation_method, batch_size)
 
     def evaluate(self, validation_set, validation_method, batch_size=32):
         """
@@ -108,7 +109,7 @@ class Estimator(JavaValue):
         :return: validation results
         """
         callZooFunc(self.bigdl_type, "estimatorEvaluate", self.value,
-                      validation_set, validation_method, batch_size)
+                    validation_set, validation_method, batch_size)
 
     def evaluate_imagefeature(self, validation_set, validation_method, batch_size=32):
         """
@@ -119,4 +120,4 @@ class Estimator(JavaValue):
         :return: validation results
         """
         callZooFunc(self.bigdl_type, "estimatorEvaluateImageFeature", self.value,
-                      validation_set, validation_method, batch_size)
+                    validation_set, validation_method, batch_size)

--- a/pyzoo/zoo/pipeline/inference/inference_model.py
+++ b/pyzoo/zoo/pipeline/inference/inference_model.py
@@ -14,7 +14,8 @@
 # limitations under the License.
 #
 
-from bigdl.util.common import JavaValue, callBigDlFunc
+from bigdl.util.common import JavaValue
+from zoo.common.utils import callZooFunc
 from bigdl.nn.layer import Layer
 from zoo.pipeline.api.keras.engine import KerasNet
 
@@ -38,7 +39,7 @@ class InferenceModel(JavaValue):
         :param model_path: String. The file path to the model.
         :param weight_path: String. The file path to the weights if any. Default is None.
         """
-        callBigDlFunc(self.bigdl_type, "inferenceModelLoad",
+        callZooFunc(self.bigdl_type, "inferenceModelLoad",
                       self.value, model_path, weight_path)
 
     def load_caffe(self, model_path, weight_path):
@@ -48,7 +49,7 @@ class InferenceModel(JavaValue):
         :param model_path: String. The file path to the prototxt file.
         :param weight_path: String. The file path to the Caffe model.
         """
-        callBigDlFunc(self.bigdl_type, "inferenceModelLoadCaffe",
+        callZooFunc(self.bigdl_type, "inferenceModelLoadCaffe",
                       self.value, model_path, weight_path)
 
     def load_openvino(self, model_path, weight_path, batch_size=0):
@@ -59,7 +60,7 @@ class InferenceModel(JavaValue):
         :param weight_path: String. The file path to the OpenVINO IR bin file.
         :param batch_size: Int. Set batch Size, default is 0 (use default batch size).
         """
-        callBigDlFunc(self.bigdl_type, "inferenceModelLoadOpenVINO",
+        callZooFunc(self.bigdl_type, "inferenceModelLoadOpenVINO",
                       self.value, model_path, weight_path, batch_size)
 
     def load_tf(self, model_path, backend="tensorflow",
@@ -94,22 +95,22 @@ class InferenceModel(JavaValue):
         """
         backend = backend.lower()
         if backend == "tensorflow" or backend == "tf":
-            callBigDlFunc(self.bigdl_type, "inferenceModelTensorFlowLoadTF",
+            callZooFunc(self.bigdl_type, "inferenceModelTensorFlowLoadTF",
                           self.value, model_path, intra_op_parallelism_threads,
                           inter_op_parallelism_threads, use_per_session_threads)
         elif backend == "openvino" or backend == "ov":
             if model_type:
                 if ov_pipeline_config_path:
-                    callBigDlFunc(self.bigdl_type, "inferenceModelOpenVINOLoadTF",
+                    callZooFunc(self.bigdl_type, "inferenceModelOpenVINOLoadTF",
                                   self.value, model_path, model_type, ov_pipeline_config_path, None)
                 else:
-                    callBigDlFunc(self.bigdl_type, "inferenceModelOpenVINOLoadTF",
+                    callZooFunc(self.bigdl_type, "inferenceModelOpenVINOLoadTF",
                                   self.value, model_path, model_type)
             else:
                 if ov_pipeline_config_path is None and ov_extensions_config_path is None:
                     raise Exception("For openvino backend, you must provide either model_type or "
                                     "both pipeline_config_path and extensions_config_path")
-                callBigDlFunc(self.bigdl_type, "inferenceModelOpenVINOLoadTF",
+                callZooFunc(self.bigdl_type, "inferenceModelOpenVINOLoadTF",
                               self.value, model_path, ov_pipeline_config_path,
                               ov_extensions_config_path)
         else:
@@ -129,7 +130,7 @@ class InferenceModel(JavaValue):
         :param extensions_config_path: String, the path of the extensions configure file
         :return:
         """
-        callBigDlFunc(self.bigdl_type,
+        callZooFunc(self.bigdl_type,
                       "inferenceModelOpenVINOLoadTF",
                       self.value,
                       model_path,
@@ -159,7 +160,7 @@ class InferenceModel(JavaValue):
         :param scale: Float, the scale value, to be used for the input image per channel.
         :return:
         """
-        callBigDlFunc(self.bigdl_type,
+        callZooFunc(self.bigdl_type,
                       "inferenceModelOpenVINOLoadTF",
                       self.value,
                       model_path,
@@ -207,7 +208,7 @@ class InferenceModel(JavaValue):
                 please also refer to https://github.com/opencv/opencv.
         :return:
         """
-        callBigDlFunc(self.bigdl_type,
+        callZooFunc(self.bigdl_type,
                       "inferenceModelOpenVINOLoadTFAsCalibratedOpenVINO",
                       self.value,
                       model_path,
@@ -229,7 +230,7 @@ class InferenceModel(JavaValue):
         :param inputs: A numpy array or a list of numpy arrays or JTensor or a list of JTensors.
         """
         jinputs, input_is_table = Layer.check_input(inputs)
-        output = callBigDlFunc(self.bigdl_type,
+        output = callZooFunc(self.bigdl_type,
                                "inferenceModelPredict",
                                self.value,
                                jinputs,

--- a/pyzoo/zoo/pipeline/inference/inference_model.py
+++ b/pyzoo/zoo/pipeline/inference/inference_model.py
@@ -29,6 +29,7 @@ class InferenceModel(JavaValue):
     # Arguments
     supported_concurrent_num: Int. How many concurrent threads to invoke. Default is 1.
     """
+
     def __init__(self, supported_concurrent_num=1, bigdl_type="float"):
         super(InferenceModel, self).__init__(None, bigdl_type, supported_concurrent_num)
 
@@ -40,7 +41,7 @@ class InferenceModel(JavaValue):
         :param weight_path: String. The file path to the weights if any. Default is None.
         """
         callZooFunc(self.bigdl_type, "inferenceModelLoad",
-                      self.value, model_path, weight_path)
+                    self.value, model_path, weight_path)
 
     def load_caffe(self, model_path, weight_path):
         """
@@ -50,7 +51,7 @@ class InferenceModel(JavaValue):
         :param weight_path: String. The file path to the Caffe model.
         """
         callZooFunc(self.bigdl_type, "inferenceModelLoadCaffe",
-                      self.value, model_path, weight_path)
+                    self.value, model_path, weight_path)
 
     def load_openvino(self, model_path, weight_path, batch_size=0):
         """
@@ -61,7 +62,7 @@ class InferenceModel(JavaValue):
         :param batch_size: Int. Set batch Size, default is 0 (use default batch size).
         """
         callZooFunc(self.bigdl_type, "inferenceModelLoadOpenVINO",
-                      self.value, model_path, weight_path, batch_size)
+                    self.value, model_path, weight_path, batch_size)
 
     def load_tf(self, model_path, backend="tensorflow",
                 intra_op_parallelism_threads=1, inter_op_parallelism_threads=1,
@@ -96,23 +97,23 @@ class InferenceModel(JavaValue):
         backend = backend.lower()
         if backend == "tensorflow" or backend == "tf":
             callZooFunc(self.bigdl_type, "inferenceModelTensorFlowLoadTF",
-                          self.value, model_path, intra_op_parallelism_threads,
-                          inter_op_parallelism_threads, use_per_session_threads)
+                        self.value, model_path, intra_op_parallelism_threads,
+                        inter_op_parallelism_threads, use_per_session_threads)
         elif backend == "openvino" or backend == "ov":
             if model_type:
                 if ov_pipeline_config_path:
                     callZooFunc(self.bigdl_type, "inferenceModelOpenVINOLoadTF",
-                                  self.value, model_path, model_type, ov_pipeline_config_path, None)
+                                self.value, model_path, model_type, ov_pipeline_config_path, None)
                 else:
                     callZooFunc(self.bigdl_type, "inferenceModelOpenVINOLoadTF",
-                                  self.value, model_path, model_type)
+                                self.value, model_path, model_type)
             else:
                 if ov_pipeline_config_path is None and ov_extensions_config_path is None:
                     raise Exception("For openvino backend, you must provide either model_type or "
                                     "both pipeline_config_path and extensions_config_path")
                 callZooFunc(self.bigdl_type, "inferenceModelOpenVINOLoadTF",
-                              self.value, model_path, ov_pipeline_config_path,
-                              ov_extensions_config_path)
+                            self.value, model_path, ov_pipeline_config_path,
+                            ov_extensions_config_path)
         else:
             raise ValueError("Currently only tensorflow and openvino are supported as backend")
 
@@ -131,12 +132,12 @@ class InferenceModel(JavaValue):
         :return:
         """
         callZooFunc(self.bigdl_type,
-                      "inferenceModelOpenVINOLoadTF",
-                      self.value,
-                      model_path,
-                      object_detection_model_type,
-                      pipeline_config_path,
-                      extensions_config_path)
+                    "inferenceModelOpenVINOLoadTF",
+                    self.value,
+                    model_path,
+                    object_detection_model_type,
+                    pipeline_config_path,
+                    extensions_config_path)
 
     def load_tf_image_classification_as_openvino(self,
                                                  model_path,
@@ -161,15 +162,15 @@ class InferenceModel(JavaValue):
         :return:
         """
         callZooFunc(self.bigdl_type,
-                      "inferenceModelOpenVINOLoadTF",
-                      self.value,
-                      model_path,
-                      image_classification_model_type,
-                      checkpoint_path,
-                      input_shape,
-                      if_reverse_input_channels,
-                      [float(value) for value in mean_values],
-                      float(scale))
+                    "inferenceModelOpenVINOLoadTF",
+                    self.value,
+                    model_path,
+                    image_classification_model_type,
+                    checkpoint_path,
+                    input_shape,
+                    if_reverse_input_channels,
+                    [float(value) for value in mean_values],
+                    float(scale))
 
     def load_tf_as_calibrated_openvino(self,
                                        model_path,
@@ -209,19 +210,19 @@ class InferenceModel(JavaValue):
         :return:
         """
         callZooFunc(self.bigdl_type,
-                      "inferenceModelOpenVINOLoadTFAsCalibratedOpenVINO",
-                      self.value,
-                      model_path,
-                      model_type,
-                      checkpoint_path,
-                      input_shape,
-                      if_reverse_input_channels,
-                      [float(value) for value in mean_values],
-                      float(scale),
-                      network_type,
-                      validation_file_path,
-                      subset,
-                      opencv_lib_path)
+                    "inferenceModelOpenVINOLoadTFAsCalibratedOpenVINO",
+                    self.value,
+                    model_path,
+                    model_type,
+                    checkpoint_path,
+                    input_shape,
+                    if_reverse_input_channels,
+                    [float(value) for value in mean_values],
+                    float(scale),
+                    network_type,
+                    validation_file_path,
+                    subset,
+                    opencv_lib_path)
 
     def predict(self, inputs):
         """
@@ -231,8 +232,8 @@ class InferenceModel(JavaValue):
         """
         jinputs, input_is_table = Layer.check_input(inputs)
         output = callZooFunc(self.bigdl_type,
-                               "inferenceModelPredict",
-                               self.value,
-                               jinputs,
-                               input_is_table)
+                             "inferenceModelPredict",
+                             self.value,
+                             jinputs,
+                             input_is_table)
         return KerasNet.convert_output(output)

--- a/pyzoo/zoo/pipeline/nnframes/nn_classifier.py
+++ b/pyzoo/zoo/pipeline/nnframes/nn_classifier.py
@@ -197,7 +197,7 @@ class NNEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, 
                 feature_preprocessing = SeqToTensor(feature_preprocessing)
 
         if type(label_preprocessing) is list:
-            assert(all(isinstance(x, int) for x in label_preprocessing))
+            assert (all(isinstance(x, int) for x in label_preprocessing))
             label_preprocessing = SeqToTensor(label_preprocessing)
 
         sample_preprocessing = FeatureLabelPreprocessing(feature_preprocessing, label_preprocessing)
@@ -367,7 +367,7 @@ class NNEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, 
         """
         pythonBigDL_method_name = "setValidation"
         callZooFunc(self.bigdl_type, pythonBigDL_method_name, self.value,
-                      trigger, val_df, val_method, batch_size)
+                    trigger, val_df, val_method, batch_size)
         self.validation_config = [trigger, val_df, val_method, batch_size]
         return self
 
@@ -385,7 +385,7 @@ class NNEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, 
         In order to take effect, it needs to be called before fit.
         """
         callZooFunc(self.bigdl_type, "nnEstimatorClearGradientClipping",
-                      self.value)
+                    self.value)
         return self
 
     def setConstantGradientClipping(self, min, max):
@@ -398,9 +398,9 @@ class NNEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, 
         max: The maximum value to clip by. Float.
         """
         callZooFunc(self.bigdl_type, "nnEstimatorSetConstantGradientClipping",
-                      self.value,
-                      float(min),
-                      float(max))
+                    self.value,
+                    float(min),
+                    float(max))
         return self
 
     def setGradientClippingByL2Norm(self, clip_norm):
@@ -412,8 +412,8 @@ class NNEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, 
         clip_norm: Gradient L2-Norm threshold. Float.
         """
         callZooFunc(self.bigdl_type, "nnEstimatorSetGradientClippingByL2Norm",
-                      self.value,
-                      float(clip_norm))
+                    self.value,
+                    float(clip_norm))
         return self
 
     def setCheckpoint(self, path, trigger, isOverWrite=True):
@@ -426,7 +426,7 @@ class NNEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, 
         """
         pythonBigDL_method_name = "setCheckpoint"
         callZooFunc(self.bigdl_type, pythonBigDL_method_name, self.value,
-                      path, trigger, isOverWrite)
+                    path, trigger, isOverWrite)
         self.checkpoint_config = [path, trigger, isOverWrite]
         return self
 
@@ -461,6 +461,7 @@ class NNModel(JavaTransformer, HasFeaturesCol, HasPredictionCol, HasBatchSize,
     After transform, the prediction column contains the output of the model as Array[T], where
     T (Double or Float) is decided by the model type.
     """
+
     def __init__(self, model, feature_preprocessing=None, jvalue=None, bigdl_type="float"):
         """
         create a NNModel with a BigDL model
@@ -515,6 +516,7 @@ class NNClassifier(NNEstimator):
     classification tasks. It only supports label column of DoubleType, and the fitted
     NNClassifierModel will have the prediction column of DoubleType.
     """
+
     def __init__(self, model, criterion, feature_preprocessing=None,
                  jvalue=None, bigdl_type="float"):
         """
@@ -559,7 +561,8 @@ class NNClassifierModel(NNModel, HasThreshold):
     NNClassifierModel is a specialized [[NNModel]] for classification tasks. The prediction
     column will have the datatype of Double.
     """
-    def __init__(self,  model, feature_preprocessing=None, jvalue=None,
+
+    def __init__(self, model, feature_preprocessing=None, jvalue=None,
                  bigdl_type="float"):
         """
         :param model: trained BigDL model to use in prediction.

--- a/pyzoo/zoo/pipeline/nnframes/nn_classifier.py
+++ b/pyzoo/zoo/pipeline/nnframes/nn_classifier.py
@@ -17,6 +17,7 @@
 from pyspark.ml.param.shared import *
 from pyspark.ml.wrapper import JavaModel, JavaEstimator, JavaTransformer
 from bigdl.optim.optimizer import SGD
+from zoo.common.utils import callZooFunc
 from bigdl.util.common import *
 from zoo.feature.common import *
 
@@ -67,7 +68,7 @@ class HasSamplePreprocessing:
         Sets samplePreprocessing
         """
         pythonBigDL_method_name = "setSamplePreprocessing"
-        callBigDlFunc(self.bigdl_type, pythonBigDL_method_name, self.value, val)
+        callZooFunc(self.bigdl_type, pythonBigDL_method_name, self.value, val)
         self.samplePreprocessing = val
         return self
 
@@ -87,7 +88,7 @@ class HasOptimMethod:
         default: SGD()
         """
         pythonBigDL_method_name = "setOptimMethod"
-        callBigDlFunc(self.bigdl_type, pythonBigDL_method_name, self.value, val)
+        callZooFunc(self.bigdl_type, pythonBigDL_method_name, self.value, val)
         self.optimMethod = val
         return self
 
@@ -201,7 +202,7 @@ class NNEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, 
 
         sample_preprocessing = FeatureLabelPreprocessing(feature_preprocessing, label_preprocessing)
 
-        self.value = jvalue if jvalue else callBigDlFunc(
+        self.value = jvalue if jvalue else callZooFunc(
             bigdl_type, self.jvm_class_constructor(), model, criterion, sample_preprocessing)
         self.model = model
         self.samplePreprocessing = sample_preprocessing
@@ -246,7 +247,7 @@ class NNEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, 
         When to stop the training, passed in a Trigger. E.g. maxIterations(100)
         """
         pythonBigDL_method_name = "setEndWhen"
-        callBigDlFunc(self.bigdl_type, pythonBigDL_method_name, self.value, trigger)
+        callZooFunc(self.bigdl_type, pythonBigDL_method_name, self.value, trigger)
         self.endWhen = trigger
         return self
 
@@ -267,7 +268,7 @@ class NNEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, 
                   memory.
         """
         pythonBigDL_method_name = "setDataCacheLevel"
-        callBigDlFunc(self.bigdl_type, pythonBigDL_method_name, self.value, level, numSlice)
+        callZooFunc(self.bigdl_type, pythonBigDL_method_name, self.value, level, numSlice)
         self.dataCacheLevel = level if numSlice is None else (level, numSlice)
         return self
 
@@ -326,7 +327,7 @@ class NNEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, 
         :param summary: a TrainSummary object
         """
         pythonBigDL_method_name = "setTrainSummary"
-        callBigDlFunc(self.bigdl_type, pythonBigDL_method_name, self.value, val)
+        callZooFunc(self.bigdl_type, pythonBigDL_method_name, self.value, val)
         self.train_summary = val
         return self
 
@@ -345,7 +346,7 @@ class NNEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, 
         Default: None
         """
         pythonBigDL_method_name = "setValidationSummary"
-        callBigDlFunc(self.bigdl_type, pythonBigDL_method_name, self.value, val)
+        callZooFunc(self.bigdl_type, pythonBigDL_method_name, self.value, val)
         self.validation_summary = val
         return self
 
@@ -365,7 +366,7 @@ class NNEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, 
         :param batch_size: validation batch size
         """
         pythonBigDL_method_name = "setValidation"
-        callBigDlFunc(self.bigdl_type, pythonBigDL_method_name, self.value,
+        callZooFunc(self.bigdl_type, pythonBigDL_method_name, self.value,
                       trigger, val_df, val_method, batch_size)
         self.validation_config = [trigger, val_df, val_method, batch_size]
         return self
@@ -383,7 +384,7 @@ class NNEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, 
         Clear clipping params, in this case, clipping will not be applied.
         In order to take effect, it needs to be called before fit.
         """
-        callBigDlFunc(self.bigdl_type, "nnEstimatorClearGradientClipping",
+        callZooFunc(self.bigdl_type, "nnEstimatorClearGradientClipping",
                       self.value)
         return self
 
@@ -396,7 +397,7 @@ class NNEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, 
         min: The minimum value to clip by. Float.
         max: The maximum value to clip by. Float.
         """
-        callBigDlFunc(self.bigdl_type, "nnEstimatorSetConstantGradientClipping",
+        callZooFunc(self.bigdl_type, "nnEstimatorSetConstantGradientClipping",
                       self.value,
                       float(min),
                       float(max))
@@ -410,7 +411,7 @@ class NNEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, 
         # Arguments
         clip_norm: Gradient L2-Norm threshold. Float.
         """
-        callBigDlFunc(self.bigdl_type, "nnEstimatorSetGradientClippingByL2Norm",
+        callZooFunc(self.bigdl_type, "nnEstimatorSetGradientClippingByL2Norm",
                       self.value,
                       float(clip_norm))
         return self
@@ -424,7 +425,7 @@ class NNEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, 
         :return: self
         """
         pythonBigDL_method_name = "setCheckpoint"
-        callBigDlFunc(self.bigdl_type, pythonBigDL_method_name, self.value,
+        callZooFunc(self.bigdl_type, pythonBigDL_method_name, self.value,
                       path, trigger, isOverWrite)
         self.checkpoint_config = [path, trigger, isOverWrite]
         return self
@@ -488,7 +489,7 @@ class NNModel(JavaTransformer, HasFeaturesCol, HasPredictionCol, HasBatchSize,
                     feature_preprocessing = SeqToTensor(feature_preprocessing)
 
             sample_preprocessing = ChainedPreprocessing([feature_preprocessing, TensorToSample()])
-            self.value = callBigDlFunc(
+            self.value = callZooFunc(
                 bigdl_type, self.jvm_class_constructor(), model, sample_preprocessing)
             self.samplePreprocessing = sample_preprocessing
 
@@ -499,12 +500,12 @@ class NNModel(JavaTransformer, HasFeaturesCol, HasPredictionCol, HasBatchSize,
 
     def save(self, path):
         self._transfer_params_to_java()
-        callBigDlFunc(self.bigdl_type, "saveNNModel", self.value, path)
+        callZooFunc(self.bigdl_type, "saveNNModel", self.value, path)
         return self
 
     @staticmethod
     def load(path):
-        jvalue = callBigDlFunc("float", "loadNNModel", path)
+        jvalue = callZooFunc("float", "loadNNModel", path)
         return NNModel(model=None, feature_preprocessing=None, jvalue=jvalue)
 
 
@@ -573,5 +574,5 @@ class NNClassifierModel(NNModel, HasThreshold):
 
     @staticmethod
     def load(path):
-        jvalue = callBigDlFunc("float", "loadNNClassifierModel", path)
+        jvalue = callZooFunc("float", "loadNNClassifierModel", path)
         return NNClassifierModel(model=None, feature_preprocessing=None, jvalue=jvalue)

--- a/pyzoo/zoo/pipeline/nnframes/nn_image_reader.py
+++ b/pyzoo/zoo/pipeline/nnframes/nn_image_reader.py
@@ -15,7 +15,7 @@
 #
 
 import sys
-from bigdl.util.common import callBigDlFunc
+from zoo.common.utils import callZooFunc
 
 if sys.version >= '3':
     long = int
@@ -48,7 +48,7 @@ class NNImageReader:
         :return DataFrame with a single column "image"; Each record in the column represents
                 one image record: Row (uri, height, width, channels, CvType, bytes).
         """
-        df = callBigDlFunc(bigdl_type, "nnReadImage", path, sc, minPartitions, resizeH,
+        df = callZooFunc(bigdl_type, "nnReadImage", path, sc, minPartitions, resizeH,
                            resizeW, image_codec)
         df._sc._jsc = sc._jsc
         return df

--- a/pyzoo/zoo/pipeline/nnframes/nn_image_reader.py
+++ b/pyzoo/zoo/pipeline/nnframes/nn_image_reader.py
@@ -49,6 +49,6 @@ class NNImageReader:
                 one image record: Row (uri, height, width, channels, CvType, bytes).
         """
         df = callZooFunc(bigdl_type, "nnReadImage", path, sc, minPartitions, resizeH,
-                           resizeW, image_codec)
+                         resizeW, image_codec)
         df._sc._jsc = sc._jsc
         return df

--- a/pyzoo/zoo/pipeline/nnframes/nn_image_schema.py
+++ b/pyzoo/zoo/pipeline/nnframes/nn_image_schema.py
@@ -15,7 +15,7 @@
 #
 
 import sys
-from bigdl.util.common import callBigDlFunc
+from zoo.common.utils import callZooFunc
 
 if sys.version >= '3':
     long = int
@@ -23,4 +23,4 @@ if sys.version >= '3':
 
 
 def with_origin_column(dataset, imageColumn="image", originColumn="origin", bigdl_type="float"):
-    return callBigDlFunc(bigdl_type, "withOriginColumn", dataset, imageColumn, originColumn)
+    return callZooFunc(bigdl_type, "withOriginColumn", dataset, imageColumn, originColumn)

--- a/pyzoo/zoo/ray/util/raycontext.py
+++ b/pyzoo/zoo/ray/util/raycontext.py
@@ -41,8 +41,8 @@ class JVMGuard():
             from zoo.common.utils import callZooFunc
             import zoo
             callZooFunc("float",
-                          "jvmGuardRegisterPids",
-                          pids)
+                        "jvmGuardRegisterPids",
+                        pids)
         except Exception as err:
             print(traceback.format_exc())
             print("Cannot sucessfully register pid into JVMGuard")

--- a/pyzoo/zoo/ray/util/raycontext.py
+++ b/pyzoo/zoo/ray/util/raycontext.py
@@ -38,9 +38,9 @@ class JVMGuard():
     def registerPids(pids):
         import traceback
         try:
-            from bigdl.util.common import callBigDlFunc
+            from zoo.common.utils import callZooFunc
             import zoo
-            callBigDlFunc("float",
+            callZooFunc("float",
                           "jvmGuardRegisterPids",
                           pids)
         except Exception as err:


### PR DESCRIPTION
When finding the right java method, callBigDlFunc will convert the python arguments to java a lot of times in [this failover](https://github.com/intel-analytics/BigDL/blob/a11e02e09279401b23ed77a42765b1e38282d24c/pyspark/bigdl/util/common.py#L585). This will lead to a very bad performance when arguments is very large.
To work around this issue, add a new callZooFunc and move the arguments converting out of the for loop.  
Change all callBigDlFunc in zoo to callZooFunc.
fixed #1425 