### PR TITLE
reuse Jtensor's float array

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/common/PythonZoo.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/common/PythonZoo.scala
@@ -58,23 +58,27 @@ class PythonZoo[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonBigDLK
       case "float" =>
         if (null == jTensor.indices) {
           if (jTensor.shape == null || jTensor.shape.product == 0) {
-            Tensor()
+            Tensor[Float]().asInstanceOf[Tensor[T]]
           } else {
-            Tensor(jTensor.storage.map(x => ev.fromType(x)), jTensor.shape)
+            Tensor[Float](jTensor.storage, jTensor.shape)
+              .asInstanceOf[Tensor[T]]
           }
         } else {
-          Tensor.sparse(jTensor.indices, jTensor.storage.map(x => ev.fromType(x)), jTensor.shape)
+          Tensor.sparse[Float](jTensor.indices, jTensor.storage, jTensor.shape)
+            .asInstanceOf[Tensor[T]]
         }
       case "double" =>
         if (null == jTensor.indices) {
           if (jTensor.shape == null || jTensor.shape.product == 0) {
-            Tensor()
+            Tensor[Double]().asInstanceOf[Tensor[T]]
           } else {
-            Tensor(jTensor.storage.map(x => ev.fromType(x.toDouble)), jTensor.shape)
+            Tensor[Double](jTensor.storage.map(_.toDouble), jTensor.shape)
+              .asInstanceOf[Tensor[T]]
           }
         } else {
-          Tensor.sparse(jTensor.indices,
-            jTensor.storage.map(x => ev.fromType(x.toDouble)), jTensor.shape)
+          Tensor.sparse[Double](jTensor.indices,
+            jTensor.storage.map(_.toDouble), jTensor.shape)
+            .asInstanceOf[Tensor[T]]
         }
       case t: String =>
         throw new IllegalArgumentException(s"Not supported type: ${t}")


### PR DESCRIPTION
reuse jtensor's float array.
To float tensor, `map` will clone a new float array, we can reuse the origin float array rather than clone a new one.