### PR TITLE
Remove repartition in wide and deep notebook

### DIFF
--- a/apps/recommendation-wide-n-deep/wide_n_deep.ipynb
+++ b/apps/recommendation-wide-n-deep/wide_n_deep.ipynb
@@ -244,9 +244,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "rdds = allDF.rdd\\\n",
-    ".map(lambda row: to_user_item_feature(row, column_info))\\\n",
-    ".repartition(4)\n",
+    "rdds = allDF.rdd.map(lambda row: to_user_item_feature(row, column_info))\n",
     "trainPairFeatureRdds, valPairFeatureRdds = rdds.randomSplit([0.8, 0.2], seed= 1)\n",
     "valPairFeatureRdds.persist()\n",
     "train_data= trainPairFeatureRdds.map(lambda pair_feature: pair_feature.sample)\n",


### PR DESCRIPTION
This is unnecessary and may cause performance overhead.
repartition(4) the assumption of 4 cores locally is also not reasonable.