### PR TITLE
[backport] Fix yarn cluster serving bigdl.jar missing error (#1940)

### DIFF
--- a/scripts/cluster-serving/cluster-serving-start
+++ b/scripts/cluster-serving/cluster-serving-start
@@ -88,7 +88,11 @@ if [ -z "${ZOO_JAR}" ]; then
     ZOO_JAR=zoo.jar
 fi
 if [ -z "${BIGDL_JAR}" ]; then
-    BIGDL_JAR=bigdl.jar
+  if [ -f "bigdl.jar" ]; then
+      BIGDL_JAR=bigdl.jar
+  else
+      BIGDL_JAR=
+  fi
 fi
 if [ -z "${SPARK_REDIS_JAR}" ]; then
     SPARK_REDIS_JAR=spark-redis-2.4.0-jar-with-dependencies.jar


### PR DESCRIPTION
* fix bigdl.jar missing