### PR TITLE
Fix ray get in related unit tests

### DIFF
--- a/pyzoo/test/zoo/ray/integration/ray_on_yarn.py
+++ b/pyzoo/test/zoo/ray/integration/ray_on_yarn.py
@@ -69,8 +69,8 @@ class TestRay():
 
 
 actors = [TestRay.remote() for i in range(0, slave_num)]
-print([ray.get(actor.hostname.remote()) for actor in actors])
-print([ray.get(actor.ip.remote()) for actor in actors])
-# print([ray.get(actor.network.remote()) for actor in actors])
+print(ray.get([actor.hostname.remote() for actor in actors]))
+print(ray.get([actor.ip.remote() for actor in actors]))
+# print(ray.get([actor.network.remote() for actor in actors]))
 
 ray_ctx.stop()

--- a/pyzoo/test/zoo/ray/integration/test_yarn_reinit_raycontext.py
+++ b/pyzoo/test/zoo/ray/integration/test_yarn_reinit_raycontext.py
@@ -47,13 +47,13 @@ sc = init_spark_on_yarn(
 ray_ctx = RayContext(sc=sc, object_store_memory="2g")
 ray_ctx.init()
 actors = [TestRay.remote() for i in range(0, node_num)]
-print([ray.get(actor.hostname.remote()) for actor in actors])
+print(ray.get([actor.hostname.remote() for actor in actors]))
 ray_ctx.stop()
 # repeat
 ray_ctx = RayContext(sc=sc, object_store_memory="1g")
 ray_ctx.init()
 actors = [TestRay.remote() for i in range(0, node_num)]
-print([ray.get(actor.hostname.remote()) for actor in actors])
+print(ray.get([actor.hostname.remote() for actor in actors]))
 ray_ctx.stop()
 
 sc.stop()

--- a/pyzoo/test/zoo/ray/test_ray_on_local.py
+++ b/pyzoo/test/zoo/ray/test_ray_on_local.py
@@ -42,7 +42,7 @@ class TestUtil(TestCase):
         ray_ctx = RayContext(sc=sc, object_store_memory="1g")
         ray_ctx.init()
         actors = [TestRay.remote() for i in range(0, node_num)]
-        print([ray.get(actor.hostname.remote()) for actor in actors])
+        print(ray.get([actor.hostname.remote() for actor in actors]))
         ray_ctx.stop()
         sc.stop()
         time.sleep(1)

--- a/pyzoo/test/zoo/ray/test_reinit_raycontext.py
+++ b/pyzoo/test/zoo/ray/test_reinit_raycontext.py
@@ -42,7 +42,7 @@ class TestUtil(TestCase):
             ray_ctx = RayContext(sc=sc, object_store_memory="1g")
             ray_ctx.init()
             actors = [TestRay.remote() for i in range(0, node_num)]
-            print([ray.get(actor.hostname.remote()) for actor in actors])
+            print(ray.get([actor.hostname.remote() for actor in actors]))
             ray_ctx.stop()
             time.sleep(3)
             # repeat
@@ -50,7 +50,7 @@ class TestUtil(TestCase):
             ray_ctx = RayContext(sc=sc, object_store_memory="1g")
             ray_ctx.init()
             actors = [TestRay.remote() for i in range(0, node_num)]
-            print([ray.get(actor.hostname.remote()) for actor in actors])
+            print(ray.get([actor.hostname.remote() for actor in actors]))
             ray_ctx.stop()
             sc.stop()
             time.sleep(3)


### PR DESCRIPTION
The previous code is not running in parallelism, as ray.get is a blocking operation.
Update in this PR in order not to mislead others.