### PR TITLE
Remove warning for finding jar

### DIFF
--- a/pyzoo/zoo/util/engine.py
+++ b/pyzoo/zoo/util/engine.py
@@ -113,9 +113,6 @@ def get_analytics_zoo_classpath():
     if jar_paths:
         assert len(jar_paths) == 1, "Expecting one jar: %s" % len(jar_paths)
         return jar_paths[0]
-    import logging
-    logging.warning(
-        "Trying to search from: {}, but can not find the jar for Analytics-Zoo".format(jar_dir))
     return ""
 
 


### PR DESCRIPTION
Fix #1991 
This is unnecessary as discussed in the above issue.