### PR TITLE
Cluster Serving output Tensor to ndarray string

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/ClusterServing.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/ClusterServing.scala
@@ -62,6 +62,8 @@ object ClusterServing {
     val W = helper.dataShape(1)
     val H = helper.dataShape(2)
 
+    val filter = helper.filter
+
     /**
      * chwFlag is to set image input of CHW or HWC
      * if true, the format is CHW
@@ -170,7 +172,7 @@ object ClusterServing {
                 val localPartitionModel = bcModel.value
                 val result = localPartitionModel.doPredict(tensors.addSingletonDimension()).toTensor
 
-                val value = PostProcessing.getInfofromTensor(topN, result.squeeze())
+                val value = PostProcessing(result)
 
                 Record(path, value)
               })
@@ -227,8 +229,7 @@ object ClusterServing {
               }
 
               (0 until thisBatchSize).toParArray.map(i => {
-                val value = PostProcessing.getInfofromTensor(topN,
-                  result.select(1, i + 1).squeeze())
+                val value = PostProcessing(result.select(1, i + 1))
                 Record(pathByteBatch(i)._1, value)
               })
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/utils/ClusterServingHelper.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/utils/ClusterServingHelper.scala
@@ -76,6 +76,7 @@ class ClusterServingHelper {
   var blasFlag: Boolean = false
 
   var dataShape = Array[Int]()
+  var filter: String = "topN"
 
   var logFile: FileWriter = null
   var logErrorFlag: Boolean = true
@@ -128,6 +129,7 @@ class ClusterServingHelper {
     for (i <- shapeList) {
       dataShape = dataShape :+ i.trim.toInt
     }
+    filter = getYaml(dataConfig, "filter", "topN")
 
     val paramsConfig = configList.get("params").asInstanceOf[HM]
     batchSize = getYaml(paramsConfig, "batch_size", "4").toInt

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/utils/TensorUtils.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/utils/TensorUtils.scala
@@ -31,16 +31,4 @@ object TensorUtils {
     l.drop(n).foldLeft(l.take(n).sortWith(_._2 < _._2))(update).
       sortWith(_._2 > _._2)
   }
-
-  def main(args: Array[String]): Unit = {
-    val list = List(3.0f, 2, 8, 2, 9, 1, 5, 5, 9, 1, 7, 3, 4)
-    val t = Tensor[Float](4, 13)
-    val b = t.select(1, 1)
-    (0 until 13).map{ i =>
-      t.setValue(i + 1, list(i))
-    }
-    val a = getTopN(5, t)
-    a
-  }
-
 }

--- a/zoo/src/test/scala/com/intel/analytics/zoo/serving/PostProcessingSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/serving/PostProcessingSpec.scala
@@ -21,6 +21,13 @@ import org.scalatest.{FlatSpec, Matchers}
 import com.intel.analytics.zoo.serving.utils.PostProcessing
 
 class PostProcessingSpec extends FlatSpec with Matchers {
+  "tensor to ndarray string" should "work" in {
+    val t1 = Tensor(Array(4.0f, 5, 3, 4), shape = Array(2, 2))
+    val ansStr = new PostProcessing(t1).tensorToNdArrayString()
+    val truthStr = "[[4.0,5.0],[3.0,4.0]]"
+    assert(ansStr == truthStr)
+  }
+
   "TopN filter" should "work properly" in {
     val t1 = Tensor(Storage(Array(3.0f, 2, 1, 4, 5)))
     val ansTensor = new PostProcessing(t1).topN(2)

--- a/zoo/src/test/scala/com/intel/analytics/zoo/serving/PostProcessingSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/serving/PostProcessingSpec.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018 Analytics Zoo Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.zoo.serving
+
+import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
+import org.scalatest.{FlatSpec, Matchers}
+import com.intel.analytics.zoo.serving.utils.PostProcessing
+
+class PostProcessingSpec extends FlatSpec with Matchers {
+  "TopN filter" should "work properly" in {
+    val t1 = Tensor(Storage(Array(3.0f, 2, 1, 4, 5)))
+    val ansTensor = new PostProcessing(t1).topN(2)
+    val truthTensor = Tensor(Array(4.0f, 5, 3, 4), shape = Array(2, 2))
+    assert(ansTensor == truthTensor)
+  }
+}


### PR DESCRIPTION
This PR outputs the ndarray type of Tensor, e.g. [[1,2],[3,4]]

For object detection, we can use this type of output. But..

We are currently use top-N 1D Tensor filter by default, if using this one by default, we have to modify our quick start example, and add that filter in config file.

Thus I only updated the API but have not given entrance to this method. Maybe when we have more types of output and we can review how to set the entrance here.