### PR TITLE
Support loading savedmodel by only providing inputs or outputs

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TFNetForInference.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TFNetForInference.scala
@@ -232,7 +232,7 @@ object TFNetForInference {
     val metaGraphDef = MetaGraphDef.parseFrom(savedModelBundle.metaGraphDef())
     val initOp = if (tableInitOp.isDefined) tableInitOp else getInitOp(metaGraphDef)
 
-    val (inputNames: Array[String], outputNames: Array[String]) = if (inputs.isEmpty || outputs.isEmpty) {
+    val (inputNames, outputNames) = if (inputs.isEmpty || outputs.isEmpty) {
 
       if (inputs.isEmpty) {
         logger.warn("Loading TensorFlow SavedModel: inputs is not defined, finding inputs " +

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TFNetForInference.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TFNetForInference.scala
@@ -232,17 +232,27 @@ object TFNetForInference {
     val metaGraphDef = MetaGraphDef.parseFrom(savedModelBundle.metaGraphDef())
     val initOp = if (tableInitOp.isDefined) tableInitOp else getInitOp(metaGraphDef)
 
-    val (inputNames, outputNames) = if (!(inputs.isDefined && outputs.isDefined)) {
+    val (inputNames: Array[String], outputNames: Array[String]) = if (inputs.isEmpty || outputs.isEmpty) {
+
+      if (inputs.isEmpty) {
+        logger.warn("Loading TensorFlow SavedModel: inputs is not defined, finding inputs " +
+          "in signature")
+      }
+
+      if (inputs.isEmpty) {
+        logger.warn("Loading TensorFlow SavedModel: inputs is not defined, finding outputs " +
+          "in signature")
+      }
+
       if (signature.isEmpty) {
         logger.warn("Loading TensorFlow SavedModel: SavedModel signature is not defined," +
-          s"using <$DEFAULT_SIGNATURE>")
+          s"using default signature <$DEFAULT_SIGNATURE>")
       }
-      getInputOutputNames(metaGraphDef, signature.getOrElse(DEFAULT_SIGNATURE))
+
+      val inputNameCandidate, outputNameCandidate = getInputOutputNames(metaGraphDef,
+        signature.getOrElse(DEFAULT_SIGNATURE))
+      (inputs.getOrElse(inputNameCandidate), outputs.getOrElse(outputNameCandidate))
     } else {
-      if (inputs.isEmpty || outputs.isEmpty) {
-        throw new IllegalArgumentException("inputs and outputs tensor names must be defined" +
-          " if signature is not defined")
-      }
       (inputs.get, outputs.get)
     }
 
@@ -339,7 +349,6 @@ object TFNetForInference {
           Tensor[Float](sizes = shapeArr)
       }
     }.toArray
-
 
 
     val inputTypes = inputNames.map(name2type(graph))

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TFNetForInference.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TFNetForInference.scala
@@ -249,8 +249,9 @@ object TFNetForInference {
           s"using default signature <$DEFAULT_SIGNATURE>")
       }
 
-      val inputNameCandidate, outputNameCandidate = getInputOutputNames(metaGraphDef,
+      val (inputNameCandidate, outputNameCandidate) = getInputOutputNames(metaGraphDef,
         signature.getOrElse(DEFAULT_SIGNATURE))
+
       (inputs.getOrElse(inputNameCandidate), outputs.getOrElse(outputNameCandidate))
     } else {
       (inputs.get, outputs.get)

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/net/TFNetSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/net/TFNetSpec.scala
@@ -16,8 +16,6 @@
 package com.intel.analytics.zoo.pipeline.api.net
 
 
-import java.nio.{ByteBuffer, ByteOrder}
-
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.{LayerException, T}
 import com.intel.analytics.zoo.tfpark.TFUtils
@@ -156,6 +154,23 @@ class TFNetSpec extends FlatSpec with Matchers with BeforeAndAfter {
   "TFNet" should "work with saved_model with signature"  in {
     val resource = getClass().getClassLoader().getResource("saved-model-signature")
     val tfnet = TFNet.fromSavedModel(resource.getPath)
+    val output = tfnet.forward(Tensor.ones[Float](4, 4)).toTensor[Float].clone()
+    output.size() should be (Array(4, 10))
+  }
+
+  "TFNet" should "work with saved_model with signature and inputs"  in {
+    val resource = getClass().getClassLoader().getResource("saved-model-signature")
+    val tfnet = TFNet.fromSavedModel(resource.getPath,
+      inputs = Array("Placeholder:0"), outputs = null)
+    val output = tfnet.forward(Tensor.ones[Float](4, 4)).toTensor[Float].clone()
+    output.size() should be (Array(4, 10))
+  }
+
+  "TFNet" should "work with saved_model with signature and outputs"  in {
+    val resource = getClass().getClassLoader().getResource("saved-model-signature")
+    val tfnet = TFNet.fromSavedModel(resource.getPath,
+      inputs = null,
+      outputs = Array("dense/BiasAdd:0"))
     val output = tfnet.forward(Tensor.ones[Float](4, 4)).toTensor[Float].clone()
     output.size() should be (Array(4, 10))
   }


### PR DESCRIPTION
## Current Problem
Currently, there are three ways to load a savedmodel into TFNet.
1. providing both input and output names
2. providing the tag and signature defined in the savedmodel
3. using default tag and signature defined in the savdemodel

Sometimes, user only know the input or only know the output names.

## Solution
Support passing only input or only output, and find the other one in the default signature

## Usage

```scala
TFNet.fromSavedModel(modelPath, inputs=null, outputs=Array("output:0"))
```
or

```scala
TFNet.fromSavedModel(modelPath, inputs=Array("input:0"), outputs=null)
```
## Implementation
Minor modifications in the TFNet loading code.