### PR TITLE
pip install deleted tensorflow dependency tmp fix

### DIFF
--- a/pyzoo/dev/release.sh
+++ b/pyzoo/dev/release.sh
@@ -64,7 +64,6 @@ $build_command
 # delete org/tensorflow/util here
 export ANALYTICS_ZOO_JAR=`find ${ANALYTICS_ZOO_HOME}/dist/lib -type f -name "analytics-zoo*jar-with-dependencies.jar"`
 echo "analytics zoo jar location is at ${ANALYTICS_ZOO_JAR}"
-zip -d ${ANALYTICS_ZOO_JAR} org/tensorflow/util/*
 
 cd $ANALYTICS_ZOO_PYTHON_DIR
 sdist_command="python setup.py sdist"

--- a/pyzoo/dev/release.sh
+++ b/pyzoo/dev/release.sh
@@ -64,6 +64,7 @@ $build_command
 # delete org/tensorflow/util here
 export ANALYTICS_ZOO_JAR=`find ${ANALYTICS_ZOO_HOME}/dist/lib -type f -name "analytics-zoo*jar-with-dependencies.jar"`
 echo "analytics zoo jar location is at ${ANALYTICS_ZOO_JAR}"
+zip -d ${ANALYTICS_ZOO_JAR} org/tensorflow/util/Event*
 
 cd $ANALYTICS_ZOO_PYTHON_DIR
 sdist_command="python setup.py sdist"


### PR DESCRIPTION
@jason-dai as @yangw1234 meets error in #2204 

Cluster Serving will switch to flink in few days and new summary would be support, so I think we could use this old version, and write new summary support for cluster serving.