### PR TITLE
Raise exception when the files in BIGDL_JRAS does not exist

### DIFF
--- a/pyzoo/zoo/util/engine.py
+++ b/pyzoo/zoo/util/engine.py
@@ -107,6 +107,9 @@ def get_analytics_zoo_classpath():
     Get and return the jar path for analytics-zoo if exists.
     """
     if os.getenv("BIGDL_CLASSPATH"):
+        for path in os.getenv("BIGDL_CLASSPATH").split(":"):
+            if not os.path.exists(path):
+                raise ValueError("Path {} specified BIGDL_CLASSPATH does not exists.".format(path))
         return os.environ["BIGDL_CLASSPATH"]
     jar_dir = os.path.abspath(__file__ + "/../../")
     jar_paths = glob.glob(os.path.join(jar_dir, "share/lib/*.jar"))

--- a/pyzoo/zoo/util/engine.py
+++ b/pyzoo/zoo/util/engine.py
@@ -109,7 +109,7 @@ def get_analytics_zoo_classpath():
     if os.getenv("BIGDL_CLASSPATH"):
         for path in os.getenv("BIGDL_CLASSPATH").split(":"):
             if not os.path.exists(path):
-                raise ValueError("Path {} specified BIGDL_CLASSPATH does not exists.".format(path))
+                raise ValueError("Path {} specified BIGDL_CLASSPATH does not exist.".format(path))
         return os.environ["BIGDL_CLASSPATH"]
     jar_dir = os.path.abspath(__file__ + "/../../")
     jar_paths = glob.glob(os.path.join(jar_dir, "share/lib/*.jar"))


### PR DESCRIPTION
This PR improves the error message when the files specified in BIGDL_JRAS does not exists.

This error is not uncommon when developing using IDE.