### PR TITLE
Support adding additional archives in init_spark_on_yarn

### DIFF
--- a/pyzoo/zoo/common/nncontext.py
+++ b/pyzoo/zoo/common/nncontext.py
@@ -73,7 +73,7 @@ def init_spark_on_yarn(hadoop_conf,
     :param extra_python_lib:
     :param penv_archive: Ideally, program would auto-pack the conda env which is specified by
            `conda_name`, but you can also pass the path to a packed file in "tar.gz" format here.
-    :param additional_archive: comma seperated additional archive that you want to upload and unpack on executor
+    :param additional_archive: comma seperated additional archives that you want to upload and unpack on executor
     :param hadoop_user_name: User name for running in yarn cluster. Default value is: root
     :param spark_yarn_archive conf value for spark.yarn.archive
     :param spark_log_level: Log level of Spark

--- a/pyzoo/zoo/common/nncontext.py
+++ b/pyzoo/zoo/common/nncontext.py
@@ -73,7 +73,8 @@ def init_spark_on_yarn(hadoop_conf,
     :param extra_python_lib:
     :param penv_archive: Ideally, program would auto-pack the conda env which is specified by
            `conda_name`, but you can also pass the path to a packed file in "tar.gz" format here.
-    :param additional_archive: comma seperated additional archives that you want to upload and unpack on executor
+    :param additional_archive: comma seperated additional archives that you want to upload and
+            unpack on executor
     :param hadoop_user_name: User name for running in yarn cluster. Default value is: root
     :param spark_yarn_archive conf value for spark.yarn.archive
     :param spark_log_level: Log level of Spark

--- a/pyzoo/zoo/common/nncontext.py
+++ b/pyzoo/zoo/common/nncontext.py
@@ -49,6 +49,7 @@ def init_spark_on_yarn(hadoop_conf,
                        extra_executor_memory_for_ray=None,
                        extra_python_lib=None,
                        penv_archive=None,
+                       additional_archive=None,
                        hadoop_user_name="root",
                        spark_yarn_archive=None,
                        spark_log_level="WARN",
@@ -72,7 +73,9 @@ def init_spark_on_yarn(hadoop_conf,
     :param extra_python_lib:
     :param penv_archive: Ideally, program would auto-pack the conda env which is specified by
            `conda_name`, but you can also pass the path to a packed file in "tar.gz" format here.
+    :param additional_archive: comma seperated additional archive that you want to upload and unpack on executor
     :param hadoop_user_name: User name for running in yarn cluster. Default value is: root
+    :param spark_yarn_archive conf value for spark.yarn.archive
     :param spark_log_level: Log level of Spark
     :param redirect_spark_log: Direct the Spark log to local file or not.
     :param jars: Comma-separated list of jars to include on the driver and executor classpaths.
@@ -94,6 +97,7 @@ def init_spark_on_yarn(hadoop_conf,
         extra_executor_memory_for_ray=extra_executor_memory_for_ray,
         extra_python_lib=extra_python_lib,
         penv_archive=penv_archive,
+        additional_archive=additional_archive,
         hadoop_user_name=hadoop_user_name,
         spark_yarn_archive=spark_yarn_archive,
         jars=jars,

--- a/pyzoo/zoo/util/spark.py
+++ b/pyzoo/zoo/util/spark.py
@@ -157,6 +157,7 @@ class SparkRunner():
                            penv_archive=None,
                            hadoop_user_name="root",
                            spark_yarn_archive=None,
+                           spark_yarn_dist_archive=None,
                            spark_conf=None,
                            jars=None):
         os.environ["HADOOP_CONF_DIR"] = hadoop_conf
@@ -186,7 +187,9 @@ class SparkRunner():
             if extra_executor_memory_for_ray:
                 conf["spark.executor.memoryOverhead"] = extra_executor_memory_for_ray
             if spark_yarn_archive:
-                conf.insert("spark.yarn.archive", spark_yarn_archive)
+                conf["spark.yarn.archive"] = spark_yarn_archive
+            if spark_yarn_dist_archive:
+                conf["spark.yarn.dist.archives"] = spark_yarn_dist_archive
             return " --master yarn --deploy-mode client" + _yarn_opt(jars) + ' pyspark-shell ', conf
 
         pack_env = False

--- a/pyzoo/zoo/util/spark.py
+++ b/pyzoo/zoo/util/spark.py
@@ -155,9 +155,9 @@ class SparkRunner():
                            extra_executor_memory_for_ray=None,
                            extra_python_lib=None,
                            penv_archive=None,
+                           additional_archive=None,
                            hadoop_user_name="root",
                            spark_yarn_archive=None,
-                           spark_yarn_dist_archive=None,
                            spark_conf=None,
                            jars=None):
         os.environ["HADOOP_CONF_DIR"] = hadoop_conf
@@ -165,9 +165,13 @@ class SparkRunner():
         os.environ['PYSPARK_PYTHON'] = "{}/bin/python".format(self.PYTHON_ENV)
 
         def _yarn_opt(jars):
-            command = " --archives {}#{} --num-executors {} " \
+
+            archive = "{}#{}".format(penv_archive, self.PYTHON_ENV)
+            if additional_archive:
+                archive = archive + "," + additional_archive
+            command = " --archives {} --num-executors {} " \
                       " --executor-cores {} --executor-memory {}". \
-                format(penv_archive, self.PYTHON_ENV, num_executor, executor_cores, executor_memory)
+                format(archive, num_executor, executor_cores, executor_memory)
 
             if extra_python_lib:
                 command = command + " --py-files {} ".format(extra_python_lib)
@@ -188,8 +192,6 @@ class SparkRunner():
                 conf["spark.executor.memoryOverhead"] = extra_executor_memory_for_ray
             if spark_yarn_archive:
                 conf["spark.yarn.archive"] = spark_yarn_archive
-            if spark_yarn_dist_archive:
-                conf["spark.yarn.dist.archives"] = spark_yarn_dist_archive
             return " --master yarn --deploy-mode client" + _yarn_opt(jars) + ' pyspark-shell ', conf
 
         pack_env = False


### PR DESCRIPTION
## New Feature
Sometimes we need to upload other files besides a virtual environment package, such as config files, data files, and others. 

This PR make init_spark_on_yarn support this requirement.

## Usage
```
sc = init_spark_on_yarn(
        hadoop_conf="/opt/work/hadoop-2.7.2/etc/hadoop",
        conda_name="yang-horovod",
        additional_archive="/opt/work/client/yang/hyperseg.zip#hyperseg",
        extra_executor_memory_for_ray="2g", **other_args)
```