### PR TITLE
fix java version check failure when java version is not in format 1.x,e.g java 11.01

### DIFF
--- a/make-dist.sh
+++ b/make-dist.sh
@@ -36,12 +36,12 @@ MVN_OPTS_LIST="-Xmx2g -XX:ReservedCodeCacheSize=512m"
 
 if [[ "$_java" ]]; then
     version=$("$_java" -version 2>&1 | awk -F '"' '/version/ {print $2}')
-    if [[ "$version" < "1.7" ]]; then
+    if [[ "expr $version" < "1.7" ]]; then
         echo Require a java version not lower than 1.7
         exit 1
     fi
     # For jdk7
-    if [[ "$version" < "1.8" ]]; then
+    if [[ "expr $version" < "1.8" ]]; then
         MVN_OPTS_LIST="$MVN_OPTS_LIST -XX:MaxPermSize=1G"
     fi
 fi


### PR DESCRIPTION
java version check will throw "Require a java version not lower than 1.7" when java version is not in form 1.x, e.g. java 11.0.7. 