### PR TITLE
Cluster Serving benchmark throughput ready for Int8

### DIFF
--- a/pyzoo/zoo/serving/server.py
+++ b/pyzoo/zoo/serving/server.py
@@ -81,6 +81,8 @@ class ClusterServing:
             print("spark-redis jar already exist.")
 
     def copy_config(self):
+        if os.path.exists("config.yaml"):
+            return
         print("Trying to find config file in ", self.conf_path)
         if not os.path.exists(self.conf_path):
             print('WARNING: Config file does not exist in your pip directory,'

--- a/zoo/src/test/resources/serving/cluster-serving-enqueue-test
+++ b/zoo/src/test/resources/serving/cluster-serving-enqueue-test
@@ -8,7 +8,8 @@ import time
 input_api = InputQueue()
 base_path = os.getcwd()
 arr = cv2.imread("cat1.jpeg")
-
+input_api.enqueue_image("x", arr)
+time.sleep(5)
 
 for i in range(10000):
     input_api.enqueue_image("x", arr)

--- a/zoo/src/test/resources/serving/offline-benchmark
+++ b/zoo/src/test/resources/serving/offline-benchmark
@@ -1,11 +1,6 @@
 #!/bin/bash
 
 chmod a+x ./*
-fuser -k 6006/tcp
-rm cluster-serving.log
-rm -rf TensorboardEventLogs
-rm running &&
-echo "old logs removed"
 
 export ANALYTICS_ZOO_HOME=$(pwd)/../../../../..
 export PYTHONPATH=$PYTHONPATH:$ANALYTICS_ZOO_HOME/pyzoo


### PR DESCRIPTION
code is mainly clean up, which need no focus, basic logic is as following.

push 1 image to trigger lazy loading, then push 10000

to get benchmark in one query (not including time window), check output log in taskmanager

to get benchmark across multiple queries (including time window), check the time elapsed from first query to the last.