### PR TITLE
align tranform_shard api between spark and ray

### DIFF
--- a/pyzoo/test/zoo/orca/data/test_spark_pandas.py
+++ b/pyzoo/test/zoo/orca/data/test_spark_pandas.py
@@ -78,11 +78,9 @@ class TestSparkDataShards(ZooTestCase):
         data = data_shard.collect()
         assert data[0]["value"].values[0] > 0, "value should be positive"
 
-        def negative(column_name):
-            def process(df):
-                df[column_name] = df[column_name] * (-1)
-                return df
-            return process
+        def negative(df, column_name):
+            df[column_name] = df[column_name] * (-1)
+            return df
 
         data_shard.transform_shard(negative, "value")
         data2 = data_shard.collect()

--- a/pyzoo/zoo/examples/orca/data/spark_pandas.py
+++ b/pyzoo/zoo/examples/orca/data/spark_pandas.py
@@ -21,15 +21,13 @@ import zoo.orca.data.pandas
 from zoo.common.nncontext import init_nncontext
 
 
-def process_feature(awake_begin=6, awake_end=23):
-    def process(df):
-        import pandas as pd
-        df['datetime'] = pd.to_datetime(df['timestamp'])
-        df['hours'] = df['datetime'].dt.hour
-        df['awake'] = (((df['hours'] >= awake_begin) & (df['hours'] <= awake_end))
-                       | (df['hours'] == 0)).astype(int)
-        return df
-    return process
+def process_feature(df, awake_begin=6, awake_end=23):
+    import pandas as pd
+    df['datetime'] = pd.to_datetime(df['timestamp'])
+    df['hours'] = df['datetime'].dt.hour
+    df['awake'] = (((df['hours'] >= awake_begin) & (df['hours'] <= awake_end))
+                   | (df['hours'] == 0)).astype(int)
+    return df
 
 
 if __name__ == "__main__":

--- a/pyzoo/zoo/orca/data/shard.py
+++ b/pyzoo/zoo/orca/data/shard.py
@@ -105,7 +105,7 @@ class SparkDataShards(DataShards):
         self.rdd = rdd
 
     def transform_shard(self, func, *args):
-        self.rdd = self.rdd.map(func(*args))
+        self.rdd = self.rdd.map(lambda data: func(data, *args))
         return self
 
     def collect(self):


### PR DESCRIPTION
In RayDataShard, `transform_shard` requires a function whose first argument is the data and return new data, e.g.
```
def func(data, *args):
    data['count'] += 1
    return data
```
In SparkDataShard, `transform_shard` requires a function that return a single argument function to make the transform.

```
def func(*args):
    def transform(data):
        data['count'] += 1
         return data
    return transform
```

I think the ray version is easier to use.