### PR TITLE
remove long in torchloss

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchLoss.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchLoss.scala
@@ -59,7 +59,7 @@ class TorchLoss(private val criterionHolder: Array[Byte])
           new NDArray[Array[Float]](t.storage().array().slice(
             t.storageOffset() - 1, t.nElement()), t.size(): _*))
       }
-      PythonInterpreter.exec("target = torch.Tensor(nd_target).long()")
+      PythonInterpreter.exec("target = torch.Tensor(nd_target)")
     }
     PythonInterpreter.exec(s"loss = ${name}(output, target)")
     output = PythonInterpreter.getValue("loss.item()").asInstanceOf[Double].toFloat

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModelSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModelSpec.scala
@@ -137,14 +137,15 @@ class TorchModelSpec extends ZooSpecHelper{
     val code = lenet +
       s"""
          |model = LeNet()
-         |criterion = nn.CrossEntropyLoss()
+         |def lossFunc(input, target):
+         |    return nn.CrossEntropyLoss().forward(input, target.flatten().long())
          |from pyspark.serializers import CloudPickleSerializer
          |weights=[]
          |for param in model.parameters():
          |    weights.append(param.view(-1))
          |flatten_weight = torch.nn.utils.parameters_to_vector(weights).data.numpy()
          |bym = CloudPickleSerializer.dumps(CloudPickleSerializer, model)
-         |byc = CloudPickleSerializer.dumps(CloudPickleSerializer, criterion)
+         |byc = CloudPickleSerializer.dumps(CloudPickleSerializer, lossFunc)
          |del _data
          |""".stripMargin
     PythonInterpreter.exec(code)


### PR DESCRIPTION
Because TorchLoss's input from scala are Float tensor currently, so for the loss like CrossEntropyLoss who require long-type target, we can use a lossFunction to wrap the Loss:
```
def lossFunc(input, target):
    return nn.CrossEntropyLoss().forward(input, target.flatten().long())
```