### PR TITLE
Orca save_pickle and load_pickle for XShards on Spark

### DIFF
--- a/pyzoo/test/zoo/orca/data/test_spark_pandas.py
+++ b/pyzoo/test/zoo/orca/data/test_spark_pandas.py
@@ -15,9 +15,11 @@
 #
 
 import os.path
+import shutil
 
 import pytest
 
+import zoo.orca.data
 import zoo.orca.data.pandas
 from test.zoo.pipeline.utils.test_utils import ZooTestCase
 from zoo.common.nncontext import *
@@ -122,6 +124,16 @@ class TestSparkXShards(ZooTestCase):
         data2 = shards_splits[1].collect()
         assert len(data1[0].index) > 1
         assert len(data2[0].index) == 1
+
+    def test_save(self):
+        temp = tempfile.mkdtemp()
+        file_path = os.path.join(self.resource_path, "orca/data/csv")
+        data_shard = zoo.orca.data.pandas.read_csv(file_path, self.sc)
+        path = os.path.join(temp, "data.pkl")
+        data_shard.save_pickle(path)
+        shards = zoo.orca.data.SparkXShards.load_pickle(path, self.sc)
+        assert isinstance(shards, zoo.orca.data.SparkXShards)
+        shutil.rmtree(temp)
 
 
 if __name__ == "__main__":

--- a/pyzoo/zoo/orca/data/__init__.py
+++ b/pyzoo/zoo/orca/data/__init__.py
@@ -13,3 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from zoo.orca.data.shard import XShards, RayXShards, SparkXShards

--- a/pyzoo/zoo/orca/data/shard.py
+++ b/pyzoo/zoo/orca/data/shard.py
@@ -197,3 +197,11 @@ class SparkXShards(XShards):
                         for i in range(list_split_length[0])]
             else:
                 return [self]
+
+    def save_pickle(self, path, batchSize=10):
+        self.rdd.saveAsPickleFile(path, batchSize)
+        return self
+
+    @classmethod
+    def load_pickle(cls, path, sc, minPartitions=None):
+        return SparkXShards(sc.pickleFile(path, minPartitions))


### PR DESCRIPTION
Implement save_pickle and load_pickle for SparkXShards.
Related Issue: https://github.com/analytics-zoo/orca/issues/29