### PR TITLE
Get the current RayContext

### DIFF
--- a/pyzoo/test/zoo/orca/learn/mxnet/test_mxnet_gluon.py
+++ b/pyzoo/test/zoo/orca/learn/mxnet/test_mxnet_gluon.py
@@ -18,10 +18,10 @@ from unittest import TestCase
 import numpy as np
 import pytest
 
-import ray
 import mxnet as mx
 from mxnet import gluon
 from mxnet.gluon import nn
+from zoo.ray import RayContext
 from zoo.orca.learn.mxnet import MXNetTrainer, create_trainer_config
 
 np.random.seed(1337)  # for reproducibility
@@ -70,6 +70,9 @@ def get_metrics(config):
 
 class TestMXNetGluon(TestCase):
     def test_gluon(self):
+        current_ray_ctx = RayContext.get()
+        address_info = current_ray_ctx.address_info
+        assert "object_store_address" in address_info
         config = create_trainer_config(batch_size=32, log_interval=2, optimizer="adam",
                                        optimizer_params={'learning_rate': 0.02})
         trainer = MXNetTrainer(config, get_train_data_iter, get_model, get_loss,

--- a/pyzoo/zoo/ray/raycontext.py
+++ b/pyzoo/zoo/ray/raycontext.py
@@ -336,7 +336,7 @@ class RayContext(object):
         if self._address_info:
             return self._address_info
         else:
-            raise Exception("Ray cluster hasn't been initiated yet. Please call RayContext.init first")
+            raise Exception("Ray cluster hasn't been initiated yet. Please call init first")
 
     def _start_cluster(self):
         print("Start to launch ray on cluster")

--- a/pyzoo/zoo/ray/raycontext.py
+++ b/pyzoo/zoo/ray/raycontext.py
@@ -222,6 +222,7 @@ class RayContext(object):
         self.ray_processesMonitor = None
         self.env = env
         self.extra_params = extra_params
+        self._address_info = None
         if self.is_local:
             self.num_ray_nodes = 1
             self.ray_node_cpu_cores = self._get_spark_local_cores()
@@ -248,6 +249,13 @@ class RayContext(object):
             init_executor_gateway(sc)
             print("JVM guarding process has been successfully launched")
         RayContext._active_ray_context = self
+
+    @classmethod
+    def get(cls):
+        if RayContext._active_ray_context:
+            return RayContext._active_ray_context
+        else:
+            raise Exception("No active RayContext. Please create a RayContext and init it first")
 
     def _gather_cluster_ips(self):
         total_cores = int(self.num_ray_nodes) * int(self.ray_node_cpu_cores)
@@ -315,13 +323,20 @@ class RayContext(object):
             if self.env:
                 os.environ.update(self.env)
             import ray
-            self.address_info = ray.init(num_cpus=self.ray_node_cpu_cores,
-                                         object_store_memory=self.object_store_memory,
-                                         resources=self.extra_params)
+            self._address_info = ray.init(num_cpus=self.ray_node_cpu_cores,
+                                          object_store_memory=self.object_store_memory,
+                                          resources=self.extra_params)
         else:
             self._start_cluster()
-            self.address_info = self._start_driver(num_cores=driver_cores)
-        return self.address_info
+            self._address_info = self._start_driver(num_cores=driver_cores)
+        return self._address_info
+
+    @property
+    def address_info(self):
+        if self._address_info:
+            return self._address_info
+        else:
+            raise Exception("Ray cluster hasn't been initiated yet. Please call RayContext.init first")
 
     def _start_cluster(self):
         print("Start to launch ray on cluster")

--- a/pyzoo/zoo/ray/raycontext.py
+++ b/pyzoo/zoo/ray/raycontext.py
@@ -188,6 +188,8 @@ class RayServiceFuncGenerator(object):
 
 
 class RayContext(object):
+    _active_ray_context = None
+
     def __init__(self, sc, redis_port=None, password="123456", object_store_memory=None,
                  verbose=False, env=None, extra_params=None):
         """
@@ -245,6 +247,7 @@ class RayContext(object):
             print("Start to launch the JVM guarding process")
             init_executor_gateway(sc)
             print("JVM guarding process has been successfully launched")
+        RayContext._active_ray_context = self
 
     def _gather_cluster_ips(self):
         total_cores = int(self.num_ray_nodes) * int(self.ray_node_cpu_cores)


### PR DESCRIPTION
RayContext.get() to retrieve the current active RayContext.
@jason-dai The OrCreate part is not necessary for now and I don't include it here.
Get the RayContext is enough for usage.