### PR TITLE
support evaluate in orca tf estimator

### DIFF
--- a/pyzoo/zoo/orca/learn/tf/estimator.py
+++ b/pyzoo/zoo/orca/learn/tf/estimator.py
@@ -170,7 +170,6 @@ class TFOptimizerWrapper(Estimator):
         else:
             self.sess = sess
         self.model_dir = model_dir
-        self.real_batch_size = tf.shape(self.inputs[0])[0]
 
     def fit(self, data, steps,
             batch_size=32,

--- a/pyzoo/zoo/orca/learn/tf/estimator.py
+++ b/pyzoo/zoo/orca/learn/tf/estimator.py
@@ -14,13 +14,15 @@
 # limitations under the License.
 #
 from bigdl.optim.optimizer import MaxIteration, SGD
+
+from zoo.tfpark.utils import evaluate_metrics
 from zoo.orca.data.shard import SparkXShards
 from zoo.orca.data.tf.data import Dataset, TFDataDataset2
-from zoo.tfpark import TFEstimator, TFOptimizer, TFPredictor, TFNet, ZooOptimizer
-import pandas as pd
+from zoo.tfpark import TFOptimizer, TFNet, ZooOptimizer
 import tensorflow as tf
 
-from zoo.tfpark.tf_dataset import TFDataset, TensorMeta
+from zoo.tfpark.tf_dataset import TFDataset
+from zoo.tfpark.tf_optimizer import TFModel
 from zoo.util import nest
 
 
@@ -126,6 +128,20 @@ def _xshards_to_tf_dataset(data_shard,
     return dataset
 
 
+def _to_dataset(data, batch_size, batch_per_thread):
+    if isinstance(data, SparkXShards):
+        dataset = _xshards_to_tf_dataset(data,
+                                         batch_size=batch_size,
+                                         batch_per_thread=batch_per_thread)
+    elif isinstance(data, Dataset):
+        dataset = TFDataDataset2(data, batch_size=batch_size,
+                                 batch_per_thread=batch_per_thread)
+    else:
+        raise ValueError("data must be a SparkXShards or an orca.data.tf.Dataset")
+
+    return dataset
+
+
 class TFOptimizerWrapper(Estimator):
 
     def __init__(self, *, inputs, outputs, labels, loss,
@@ -154,6 +170,7 @@ class TFOptimizerWrapper(Estimator):
         else:
             self.sess = sess
         self.model_dir = model_dir
+        self.real_batch_size = tf.shape(self.inputs[0])[0]
 
     def fit(self, data, steps,
             batch_size=32,
@@ -168,17 +185,7 @@ class TFOptimizerWrapper(Estimator):
         assert self.optimizer is not None, \
             "optimizer is None; it not None in training"
 
-        if isinstance(data, SparkXShards):
-            dataset = _xshards_to_tf_dataset(data,
-                                             batch_size=batch_size,
-                                             validation_data_shard=validation_data)
-        elif isinstance(data, Dataset):
-            dataset = TFDataDataset2(data, batch_size=batch_size,
-                                     batch_per_thread=-1,
-                                     validation_dataset=validation_data)
-        else:
-            raise ValueError("data type {} is not supported; "
-                             "it must be created by zoo.orca.data.package")
+        dataset = _to_dataset(data, batch_size=batch_size, batch_per_thread=-1)
 
         if feed_dict is not None:
             tensor_with_value = {key: (value, value) for key, value in feed_dict.items()}
@@ -204,16 +211,22 @@ class TFOptimizerWrapper(Estimator):
         assert self.outputs is not None, \
             "output is None, it should not be None in prediction"
 
-        if isinstance(data, SparkXShards):
-            dataset = _xshards_to_tf_dataset(data,
-                                             batch_per_thread=batch_size)
-        elif isinstance(data, Dataset):
-            dataset = TFDataDataset2(data, batch_size=-1,
-                                     batch_per_thread=batch_size)
-        else:
-            raise ValueError("data must be a SparkXShards or an orca.data.tf.Dataset")
+        dataset = _to_dataset(data, batch_size=-1, batch_per_thread=batch_size)
 
         flat_inputs = nest.flatten(self.inputs)
         flat_outputs = nest.flatten(self.outputs)
         tfnet = TFNet.from_session(sess=self.sess, inputs=flat_inputs, outputs=flat_outputs)
         return tfnet.predict(dataset)
+
+    def evaluate(self, data, batch_size=32):
+        assert self.metrics is not None, \
+            "output is None, it should not be None in prediction"
+
+        dataset = _to_dataset(data, batch_size=-1, batch_per_thread=batch_size)
+
+        flat_inputs = nest.flatten(self.inputs)
+        flat_labels = nest.flatten(self.labels)
+
+        return evaluate_metrics(flat_inputs + flat_labels,
+                                sess=self.sess,
+                                dataset=dataset, metrics=self.metrics)


### PR DESCRIPTION
Usage:
```python
    data_shard = data_shard.transform_shard(transform)

     est = Estimator.from_graph(
         inputs=[model.user, model.item],
         labels=[model.label],
         loss=model.loss,
         optimizer=tf.train.AdamOptimizer(),
         metrics={"loss": model.loss})
     result = est.evaluate(data_shard)
     assert "loss" in result
     print(result)
```

Fix https://github.com/analytics-zoo/orca/issues/51