### PR TITLE
Support redirecting jvm output to python process (when using notebook)

### DIFF
--- a/pyzoo/zoo/util/spark.py
+++ b/pyzoo/zoo/util/spark.py
@@ -79,13 +79,12 @@ class SparkRunner:
         print("Packing has been completed: {}".format(tmp_path))
         return tmp_path
 
-    def _create_sc(self, submit_args, conf, capture_output):
+    def _create_sc(self, submit_args, conf):
         from pyspark.sql import SparkSession
         print("pyspark_submit_args is: {}".format(submit_args))
         os.environ['PYSPARK_SUBMIT_ARGS'] = submit_args
         zoo_conf = init_spark_conf(conf)
-        sc = init_nncontext(conf=zoo_conf, redirect_spark_log=self.redirect_spark_log,
-                            capture_output=capture_output)
+        sc = init_nncontext(conf=zoo_conf, redirect_spark_log=self.redirect_spark_log)
         sc.setLogLevel(self.spark_log_level)
 
         return sc
@@ -132,15 +131,14 @@ class SparkRunner:
                                                self._get_bigdl_classpath_jar_name_on_driver()[1])
                 ]
 
-    def init_spark_on_local(self, cores, conf=None, python_location=None, capture_output=False):
+    def init_spark_on_local(self, cores, conf=None, python_location=None):
         print("Start to getOrCreate SparkContext")
         if 'PYSPARK_PYTHON' not in os.environ:
             os.environ['PYSPARK_PYTHON'] = \
                 python_location if python_location else self._detect_python_location()
         master = "local[{}]".format(cores)
         zoo_conf = init_spark_conf(conf).setMaster(master)
-        sc = init_nncontext(conf=zoo_conf, redirect_spark_log=self.redirect_spark_log,
-                            capture_output=capture_output)
+        sc = init_nncontext(conf=zoo_conf, redirect_spark_log=self.redirect_spark_log)
         sc.setLogLevel(self.spark_log_level)
         print("Successfully got a SparkContext")
         return sc
@@ -160,8 +158,7 @@ class SparkRunner:
                            hadoop_user_name="root",
                            spark_yarn_archive=None,
                            spark_conf=None,
-                           jars=None,
-                           capture_output=False):
+                           jars=None):
         os.environ["HADOOP_CONF_DIR"] = hadoop_conf
         os.environ['HADOOP_USER_NAME'] = hadoop_user_name
         os.environ['PYSPARK_PYTHON'] = "{}/bin/python".format(self.PYTHON_ENV)
@@ -220,7 +217,7 @@ class SparkRunner:
 
             for item in spark_conf.items():
                 conf[str(item[0])] = str(item[1])
-            sc = self._create_sc(submit_args, conf, capture_output)
+            sc = self._create_sc(submit_args, conf)
         finally:
             if conda_name and penv_archive and pack_env:
                 os.remove(penv_archive)


### PR DESCRIPTION
Usage:
```python
from zoo import ZooContext, init_nncontext
ZooContext.log_output = True
sc = init_nncontext()  # or init_spark_on_local, init_spark_on_yarn
```
Then training logs will be printed to the current notebook.

![image](https://user-images.githubusercontent.com/10561966/84401784-3f64bf00-ac36-11ea-9db7-1109d19e8b1d.png)


Tested manually:

- [x] init_nncontext
- [x] init_spark_on_local
- [x] init_spark_on_yarn