### PR TITLE
Fix read_json arguments in Xshards Ray test and add path empty/invalid handling

### DIFF
--- a/pyzoo/test/zoo/orca/data/test_ray_pandas.py
+++ b/pyzoo/test/zoo/orca/data/test_ray_pandas.py
@@ -51,6 +51,11 @@ class TestRayXShards(ZooTestCase):
         assert len(data) == 2, "number of shard should be 2"
         df = data[0]
         assert "value" in df.columns, "value is not in columns"
+        file_path = os.path.join(self.resource_path, "abc")
+        with self.assertRaises(Exception) as context:
+            xshards = zoo.orca.data.pandas.read_json(file_path, self.ray_ctx, orient='columns',
+                                                     lines=True)
+        self.assertTrue('The file path is invalid/empty' in str(context.exception))
 
     def test_read_s3(self):
         access_key_id = os.getenv("AWS_ACCESS_KEY_ID")
@@ -64,7 +69,8 @@ class TestRayXShards(ZooTestCase):
 
     def test_repartition(self):
         file_path = os.path.join(self.resource_path, "orca/data/json")
-        data_shard = zoo.orca.data.pandas.read_json(file_path, self.ray_ctx)
+        data_shard = zoo.orca.data.pandas.read_json(file_path, self.ray_ctx, orient='columns',
+                                                    lines=True)
         partitions1 = data_shard.get_partitions()
         assert len(partitions1) == 2, "number of partition should be 2"
         data_shard.repartition(1)

--- a/pyzoo/test/zoo/orca/data/test_spark_pandas.py
+++ b/pyzoo/test/zoo/orca/data/test_spark_pandas.py
@@ -44,6 +44,10 @@ class TestSparkXShards(ZooTestCase):
         assert len(data) == 2, "number of shard should be 2"
         df = data[0]
         assert "location" in df.columns, "location is not in columns"
+        file_path = os.path.join(self.resource_path, "abc")
+        with self.assertRaises(Exception) as context:
+            xshards = zoo.orca.data.pandas.read_csv(file_path, self.sc)
+        self.assertTrue('The file path is invalid/empty' in str(context.exception))
 
     def test_read_local_json(self):
         file_path = os.path.join(self.resource_path, "orca/data/json")

--- a/pyzoo/zoo/orca/data/pandas/preprocessing.py
+++ b/pyzoo/zoo/orca/data/pandas/preprocessing.py
@@ -104,6 +104,9 @@ def read_file_spark(context, file_path, file_type, **kwargs):
     else:
         file_paths = extract_one_path(file_path, file_type, os.environ)
 
+    if not file_paths:
+        raise Exception("The file path is invalid/empty or does not include csv/json files")
+
     rdd = context.parallelize(file_paths, node_num * core_num)
 
     if prefix == "hdfs":

--- a/pyzoo/zoo/orca/data/pandas/preprocessing.py
+++ b/pyzoo/zoo/orca/data/pandas/preprocessing.py
@@ -66,6 +66,9 @@ def read_file_ray(context, file_path, file_type, **kwargs):
     else:
         file_paths = extract_one_path(file_path, file_type, context.env)
 
+    if not file_paths:
+        raise Exception("The file path is invalid/empty or does not include csv/json files")
+
     num_executors = context.num_ray_nodes
     num_cores = context.ray_node_cpu_cores
     num_partitions = num_executors * num_cores


### PR DESCRIPTION
Fix Xshards on Ray test case, add required options for read_json.
Related issue: https://github.com/intel-analytics/analytics-zoo/issues/2438
For read_csv/read_json, add path empty/invalid handling.
Related issue: https://github.com/intel-analytics/analytics-zoo/issues/2436
