### PR TITLE
Fix MXNet data locality

### DIFF
--- a/pyzoo/test/zoo/orca/learn/mxnet/test_mxnet_spark_xshards.py
+++ b/pyzoo/test/zoo/orca/learn/mxnet/test_mxnet_spark_xshards.py
@@ -98,6 +98,17 @@ class TestMXNetSparkXShards(TestCase):
                                eval_metrics_creator=get_metrics, num_workers=2)
         trainer.train(nb_epoch=2)
 
+    def test_xshards_symbol_without_val(self):
+        resource_path = os.path.join(os.path.split(__file__)[0], "../../../resources")
+        train_file_path = os.path.join(resource_path, "orca/learn/single_input_json/train")
+        train_data_shard = zoo.orca.data.pandas.read_json(
+            train_file_path, get_spark_ctx(),
+            orient='records', lines=False).transform_shard(prepare_data_symbol)
+        config = create_trainer_config(batch_size=32, log_interval=1, seed=42)
+        trainer = MXNetTrainer(config, train_data_shard, get_symbol_model,
+                               eval_metrics_creator=get_metrics, num_workers=2)
+        trainer.train(nb_epoch=2)
+
     def test_xshards_gluon(self):
         resource_path = os.path.join(os.path.split(__file__)[0], "../../../resources")
         train_file_path = os.path.join(resource_path, "orca/learn/single_input_json/train")

--- a/pyzoo/zoo/orca/learn/mxnet/mxnet_trainer.py
+++ b/pyzoo/zoo/orca/learn/mxnet/mxnet_trainer.py
@@ -128,7 +128,7 @@ class MXNetTrainer(object):
             if self.test_data:
                 test_data_list = self.test_data.get_partitions()
             else:
-                test_data_list = [self.test_data] * self.num_workers
+                test_data_list = [None] * self.num_workers
         else:
             assert callable(self.train_data),\
                 "train_data should be either an instance of XShards or a callable function"

--- a/pyzoo/zoo/orca/learn/mxnet/mxnet_trainer.py
+++ b/pyzoo/zoo/orca/learn/mxnet/mxnet_trainer.py
@@ -130,12 +130,12 @@ class MXNetTrainer(object):
             else:
                 test_data_list = [self.test_data] * self.num_workers
         else:
-            assert callable(self.train_data), "train_data should be either an instance of XShards or " \
-                                              "a callable function, please check your input"
+            assert callable(self.train_data),\
+                "train_data should be either an instance of XShards or a callable function"
             train_data_list = [self.train_data] * self.num_workers
             if self.test_data:
-                assert callable(self.test_data), "test_data should be either an instance of XShards or " \
-                                                 "a callable function, please check your input"
+                assert callable(self.test_data),\
+                    "test_data should be either an instance of XShards or a callable function"
             test_data_list = [self.test_data] * self.num_workers
         self.runners = self.workers + self.servers
         # For servers, data is not used and thus just input a None value.

--- a/pyzoo/zoo/orca/learn/mxnet/mxnet_trainer.py
+++ b/pyzoo/zoo/orca/learn/mxnet/mxnet_trainer.py
@@ -37,7 +37,7 @@ class MXNetTrainer(object):
     You can specify "seed" in config to set random seed.
     You can specify "init" in seed to set model initializer.
 
-    :param train_data: An instance of xShards or a function that takes config and kv as arguments
+    :param train_data: An instance of XShards or a function that takes config and kv as arguments
     and returns an MXNet DataIter/DataLoader for training.
     You can specify data related configurations for this function in the config argument above.
     kv is an instance of MXNet distributed key-value store. kv.num_workers and kv.rank
@@ -56,7 +56,7 @@ class MXNetTrainer(object):
     a list of MXNet metrics or corresponding string representations of metrics, for example,
     'accuracy'. This is not needed if you don't need evaluation on the training data set.
 
-    :param test_data: An instance of xShards or a function that takes config and kv as arguments
+    :param test_data: An instance of XShards or a function that takes config and kv as arguments
     and returns an MXNet DataIter/DataLoader for testing.
     You can specify data related configurations for this function in the config argument above.
     kv is an instance of MXNet distributed key-value store. kv.num_workers and kv.rank
@@ -72,7 +72,7 @@ class MXNetTrainer(object):
     case it would be equal to the number of workers.
 
     :param runner_cores: The number of CPU cores allocated for each MXNet worker and server.
-    Default is None. You may need to specify this for better performance.
+    Default is None. You may need to specify this for better performance when you run in cluster.
     """
     def __init__(self, config, train_data, model_creator,
                  loss_creator=None, train_resize_batch_num=None, eval_metrics_creator=None,
@@ -124,7 +124,23 @@ class MXNetTrainer(object):
 
         if isinstance(self.train_data, RayXShards):
             self.workers = self.train_data.colocate_actors(self.workers)
+            train_data_list = self.train_data.get_partitions()
+            if self.test_data:
+                test_data_list = self.test_data.get_partitions()
+            else:
+                test_data_list = [self.test_data] * self.num_workers
+        else:
+            assert callable(self.train_data), "train_data should be either an instance of XShards or " \
+                                              "a callable function, please check your input"
+            train_data_list = [self.train_data] * self.num_workers
+            if self.test_data:
+                assert callable(self.test_data), "test_data should be either an instance of XShards or " \
+                                                 "a callable function, please check your input"
+            test_data_list = [self.test_data] * self.num_workers
         self.runners = self.workers + self.servers
+        # For servers, data is not used and thus just input a None value.
+        train_data_list += [None] * self.num_servers
+        test_data_list += [None] * self.num_servers
 
         env = {
             "DMLC_PS_ROOT_URI": str(get_host_ip()),
@@ -151,11 +167,11 @@ class MXNetTrainer(object):
 
         ray.get([
             runner.setup_distributed.remote(envs[i], self.config,
-                self.train_data,
+                train_data_list[i],
                 self.model_creator,
                 self.loss_creator,
                 self.validation_metrics_creator,
-                self.test_data,
+                test_data_list[i],
                 self.train_resize_batch_num,
                 self.eval_metrics_creator)
             for i, runner in enumerate(self.runners)


### PR DESCRIPTION
Previously using kv.rank to get the data doesn't mean the worker ips are sorted.

Tested on YARN cluster.