### PR TITLE
Add tensorflow version check

### DIFF
--- a/pyzoo/zoo/examples/tensorflow/tfpark/keras/keras_ndarray.py
+++ b/pyzoo/zoo/examples/tensorflow/tfpark/keras/keras_ndarray.py
@@ -15,10 +15,11 @@
 #
 import sys
 
+import tensorflow as tf
 from zoo import init_nncontext
 from bigdl.dataset import mnist
 from zoo.tfpark import KerasModel
-import tensorflow as tf
+
 
 def main(max_epoch):
     _ = init_nncontext()

--- a/pyzoo/zoo/examples/tensorflow/tfpark/keras/keras_ndarray.py
+++ b/pyzoo/zoo/examples/tensorflow/tfpark/keras/keras_ndarray.py
@@ -15,11 +15,10 @@
 #
 import sys
 
-import tensorflow as tf
 from zoo import init_nncontext
 from bigdl.dataset import mnist
 from zoo.tfpark import KerasModel
-
+import tensorflow as tf
 
 def main(max_epoch):
     _ = init_nncontext()

--- a/pyzoo/zoo/tfpark/__init__.py
+++ b/pyzoo/zoo/tfpark/__init__.py
@@ -14,6 +14,32 @@
 # limitations under the License.
 #
 
+
+def check_tf_version():
+    import os
+    import logging
+    do_check = True
+    if "ANALYTICS_ZOO_TF_CHECK" in os.environ and os.environ["ANALYTICS_ZOO_TF_CHECK"] == "false":
+        do_check = False
+    if do_check:
+        import tensorflow as tf
+        v_str = tf.__version__
+        major, minor, patch = v_str.split(".")
+        if v_str != "1.15.0":
+            if int(major) == 1:
+                logging.warning("\n######################### WARNING ##########################\n"
+                                "\nAnalytics Zoo TFPark has only been tested on TensorFlow 1.15.0,"
+                                " but your current TensorFlow installation is {}.".format(v_str) +
+                                "\nYou may encounter some version incompatibility issues. "
+                                "\n##############################################################")
+            else:
+                message = "Analytics Zoo TFPark only supports TensorFlow 1.15.0, " + \
+                          "but your current TensorFlow installation is {}".format(v_str) + \
+                          "\nYou can export ANALYTICS_ZOO_TF_CHECK=false to disable this check."
+                raise RuntimeError(message)
+
+check_tf_version()
+
 from .model import KerasModel
 from .estimator import TFEstimator
 from .tf_optimizer import TFOptimizer

--- a/pyzoo/zoo/tfpark/__init__.py
+++ b/pyzoo/zoo/tfpark/__init__.py
@@ -16,27 +16,25 @@
 
 
 def check_tf_version():
-    import os
     import logging
-    do_check = True
-    if "ANALYTICS_ZOO_TF_CHECK" in os.environ and os.environ["ANALYTICS_ZOO_TF_CHECK"] == "false":
-        do_check = False
-    if do_check:
+    try:
         import tensorflow as tf
-        v_str = tf.__version__
-        major, minor, patch = v_str.split(".")
-        if v_str != "1.15.0":
-            if int(major) == 1:
-                logging.warning("\n######################### WARNING ##########################\n"
-                                "\nAnalytics Zoo TFPark has only been tested on TensorFlow 1.15.0,"
-                                " but your current TensorFlow installation is {}.".format(v_str) +
-                                "\nYou may encounter some version incompatibility issues. "
-                                "\n##############################################################")
-            else:
-                message = "Analytics Zoo TFPark only supports TensorFlow 1.15.0, " + \
-                          "but your current TensorFlow installation is {}".format(v_str) + \
-                          "\nYou can export ANALYTICS_ZOO_TF_CHECK=false to disable this check."
-                raise RuntimeError(message)
+    except Exception as e:
+        raise RuntimeError("Importing TensorFlow failed, please install tensorflow 1.15.0.", e)
+
+    v_str = tf.__version__
+    major, minor, patch = v_str.split(".")
+    if v_str != "1.15.0":
+        if int(major) == 1:
+            logging.warning("\n######################### WARNING ##########################\n"
+                            "\nAnalytics Zoo TFPark has only been tested on TensorFlow 1.15.0,"
+                            " but your current TensorFlow installation is {}.".format(v_str) +
+                            "\nYou may encounter some version incompatibility issues. "
+                            "\n##############################################################")
+        else:
+            message = "Currently Analytics Zoo TFPark only supports TensorFlow 1.15.0, " + \
+                      "but your current TensorFlow installation is {}".format(v_str)
+            raise RuntimeError(message)
 
 check_tf_version()
 


### PR DESCRIPTION
It is not uncommon for our users to install a incorrect version of TensorFlow and face some weird error message. This PR tries to solve this problem.

If users install TF 1.x, they will receive an warning such as
```
######################### WARNING ##########################
Analytics Zoo TFPark has only been tested on TensorFlow 1.15.0, but your current TensorFlow installation is 1.14.0.
##############################################################

```
If users install TF 2.x, they will receive an error, e.g.
```
RuntimeError: Analytics Zoo TFPark only supports TensorFlow 1.15.0, but your current TensorFlow installation is 2.2.0
You can export ANALYTICS_ZOO_TF_CHECK=false to disable this check.
```

Users can export ANALYTICS_ZOO_TF_CHECK=false to disable this check

Fix #2456 

manually tested it