### PR TITLE
Fix num_partitions in orca spark read

### DIFF
--- a/pyzoo/test/zoo/orca/data/test_spark_pandas.py
+++ b/pyzoo/test/zoo/orca/data/test_spark_pandas.py
@@ -74,7 +74,7 @@ class TestSparkXShards(ZooTestCase):
         data_shard = zoo.orca.data.pandas.read_json(file_path, self.sc,
                                                     orient='columns', lines=True)
         partitions_num_1 = data_shard.rdd.getNumPartitions()
-        assert partitions_num_1 == 4, "number of partition should be 4"
+        assert partitions_num_1 == 2, "number of partition should be 2"
         data_shard.cache()
         partitioned_shard = data_shard.repartition(1)
         assert data_shard.is_cached(), "data_shard should be cached"
@@ -110,7 +110,7 @@ class TestSparkXShards(ZooTestCase):
     def test_partition_by_single_column(self):
         file_path = os.path.join(self.resource_path, "orca/data/csv")
         data_shard = zoo.orca.data.pandas.read_csv(file_path, self.sc)
-        partitioned_shard = data_shard.partition_by(cols="location")
+        partitioned_shard = data_shard.partition_by(cols="location", num_partitions=4)
         partitions = partitioned_shard.rdd.glom().collect()
         assert len(partitions) == 4
 

--- a/pyzoo/zoo/orca/data/pandas/preprocessing.py
+++ b/pyzoo/zoo/orca/data/pandas/preprocessing.py
@@ -107,7 +107,11 @@ def read_file_spark(context, file_path, file_type, **kwargs):
     if not file_paths:
         raise Exception("The file path is invalid/empty or does not include csv/json files")
 
-    rdd = context.parallelize(file_paths, node_num * core_num)
+    num_files = len(file_paths)
+    total_cores = node_num * core_num
+    num_partitions = num_files if num_files < total_cores else total_cores
+
+    rdd = context.parallelize(file_paths, num_partitions)
 
     if prefix == "hdfs":
         def loadFile(iterator):

--- a/pyzoo/zoo/orca/learn/mxnet/mxnet_trainer.py
+++ b/pyzoo/zoo/orca/learn/mxnet/mxnet_trainer.py
@@ -89,10 +89,14 @@ class MXNetTrainer(object):
 
         from zoo.orca.data import RayXShards, SparkXShards
         if isinstance(train_data, SparkXShards):
-            train_data = train_data.repartition(self.num_workers).to_ray()
+            if train_data.num_partitions() != self.num_workers:
+                train_data = train_data.repartition(self.num_workers)
+            train_data = train_data.to_ray()
             if test_data:
                 assert isinstance(test_data, SparkXShards)
-                test_data = test_data.repartition(self.num_workers).to_ray()
+                if test_data.num_partitions() != self.num_workers:
+                    test_data = test_data.repartition(self.num_workers)
+                test_data = test_data.to_ray()
         if isinstance(train_data, RayXShards):
             if train_data.num_partitions() != self.num_workers:
                 train_data.repartition(self.num_workers)


### PR DESCRIPTION
When the number of files is smaller than the total cores, the partition num should be equal to the number of files but not the total cores. Otherwise there would be empty partitions.