### PR TITLE
support bn when TorchModel export model to pure pytorch

### DIFF
--- a/pyzoo/test/zoo/pipeline/api/torch/test_torch.py
+++ b/pyzoo/test/zoo/pipeline/api/torch/test_torch.py
@@ -92,6 +92,28 @@ class TestPytorch(TestCase):
         p = list(exported_model.parameters())
         assert p[0][0][0] == 1.0
 
+    def test_model_with_bn_to_pytorch(self):
+        class SimpleTorchModel(nn.Module):
+            def __init__(self):
+                super(SimpleTorchModel, self).__init__()
+                self.dense1 = nn.Linear(2, 4)
+                self.bn1 = torch.nn.BatchNorm1d(4)
+                self.dense2 = nn.Linear(4, 1)
+
+            def forward(self, x):
+                x = self.dense1(x)
+                x = self.bn1(x)
+                x = torch.sigmoid(self.dense2(x))
+                return x
+
+        torch_model = SimpleTorchModel()
+        az_model = TorchModel.from_pytorch(torch_model)
+        dummy_input = torch.ones(16, 2)
+        zoo_result = az_model.forward(dummy_input.numpy())
+
+        exported_model = az_model.to_pytorch()
+        print(list(exported_model.named_buffers()))
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/pyzoo/test/zoo/pipeline/api/torch/test_torch.py
+++ b/pyzoo/test/zoo/pipeline/api/torch/test_torch.py
@@ -83,6 +83,7 @@ class TestPytorch(TestCase):
 
         torch_model = SimpleTorchModel()
         az_model = TorchModel.from_pytorch(torch_model)
+        az_model.training()
 
         weights = az_model.get_weights()
         weights[0][0] = 1.0

--- a/pyzoo/test/zoo/pipeline/api/torch/test_torch.py
+++ b/pyzoo/test/zoo/pipeline/api/torch/test_torch.py
@@ -83,7 +83,6 @@ class TestPytorch(TestCase):
 
         torch_model = SimpleTorchModel()
         az_model = TorchModel.from_pytorch(torch_model)
-        az_model.training()
 
         weights = az_model.get_weights()
         weights[0][0] = 1.0

--- a/pyzoo/zoo/pipeline/api/torch/torch_model.py
+++ b/pyzoo/zoo/pipeline/api/torch/torch_model.py
@@ -69,7 +69,7 @@ class TorchModel(Layer):
         w = torch.Tensor(new_weight[0])
         torch.nn.utils.vector_to_parameters(w, m.parameters())
 
-        # set running mean and running var
+        # set named buffers
         new_extra_params = callZooFunc(self.bigdl_type, "getModuleExtraParameters", self.value)
         if len(new_extra_params) != 0:
             idx = 0

--- a/pyzoo/zoo/pipeline/api/torch/torch_model.py
+++ b/pyzoo/zoo/pipeline/api/torch/torch_model.py
@@ -72,9 +72,9 @@ class TorchModel(Layer):
         # set running mean and running var
         new_extra_params = callZooFunc(self.bigdl_type, "getModuleExtraParameters", self.value)
         if len(new_extra_params) != 0:
-          idx = 0
-          for named_buffer in m.named_buffers():
-              named_buffer[1].copy_(torch.reshape(
-                  torch.Tensor(new_extra_params[idx].to_ndarray()), named_buffer[1].size()))
-              idx += 1
+            idx = 0
+            for named_buffer in m.named_buffers():
+                named_buffer[1].copy_(torch.reshape(
+                    torch.Tensor(new_extra_params[idx].to_ndarray()), named_buffer[1].size()))
+                idx += 1
         return m

--- a/pyzoo/zoo/pipeline/api/torch/torch_model.py
+++ b/pyzoo/zoo/pipeline/api/torch/torch_model.py
@@ -73,6 +73,7 @@ class TorchModel(Layer):
         new_extra_params = callZooFunc(self.bigdl_type, "getModuleExtraParameters", self.value)
         idx = 0
         for named_buffer in m.named_buffers():
-            named_buffer[1].copy_(torch.Tensor(new_extra_params[idx].to_ndarray()))
+            named_buffer[1].copy_(torch.reshape(
+                torch.Tensor(new_extra_params[idx].to_ndarray()), named_buffer[1].size()))
             idx += 1
         return m

--- a/pyzoo/zoo/pipeline/api/torch/torch_model.py
+++ b/pyzoo/zoo/pipeline/api/torch/torch_model.py
@@ -73,8 +73,6 @@ class TorchModel(Layer):
         new_extra_params = callZooFunc(self.bigdl_type, "getModuleExtraParameters", self.value)
         idx = 0
         for named_buffer in m.named_buffers():
-            name = named_buffer[0].split(".")[-1]
-            if name == 'running_mean' or name == 'running_var':
-                named_buffer[1].copy_(torch.Tensor(new_extra_params[idx].to_ndarray()))
-                idx += 1
+            named_buffer[1].copy_(torch.Tensor(new_extra_params[idx].to_ndarray()))
+            idx += 1
         return m

--- a/pyzoo/zoo/pipeline/api/torch/torch_model.py
+++ b/pyzoo/zoo/pipeline/api/torch/torch_model.py
@@ -71,9 +71,10 @@ class TorchModel(Layer):
 
         # set running mean and running var
         new_extra_params = callZooFunc(self.bigdl_type, "getModuleExtraParameters", self.value)
-        idx = 0
-        for named_buffer in m.named_buffers():
-            named_buffer[1].copy_(torch.reshape(
-                torch.Tensor(new_extra_params[idx].to_ndarray()), named_buffer[1].size()))
-            idx += 1
+        if len(new_extra_params) != 0:
+          idx = 0
+          for named_buffer in m.named_buffers():
+              named_buffer[1].copy_(torch.reshape(
+                  torch.Tensor(new_extra_params[idx].to_ndarray()), named_buffer[1].size()))
+              idx += 1
         return m

--- a/zoo/src/main/resources/spark-analytics-zoo.conf
+++ b/zoo/src/main/resources/spark-analytics-zoo.conf
@@ -30,5 +30,6 @@
 spark.shuffle.reduceLocality.enabled                false
 spark.shuffle.blockTransferService                  nio
 spark.scheduler.minRegisteredResourcesRatio         1.0
+spark.scheduler.maxRegisteredResourcesWaitingTime   100s
 spark.speculation                                   false
 spark.serializer                                    org.apache.spark.serializer.JavaSerializer

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/python/PythonFeatureSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/python/PythonFeatureSet.scala
@@ -132,7 +132,7 @@ class PythonFeatureSet[T: ClassTag](implicit ev: TensorNumeric[T]) extends Pytho
            |  ${loaderName}_epoch = 0
            |else:
            |  ${loaderName}_epoch += 1
-           |${loaderName}_random_sampler.set_epoch(${loaderName}_epoch)
+           |${loaderName}_rand_sampler.set_epoch(${loaderName}_epoch)
            |${iterName} = enumerate(${loaderName}${trainPostfix})
            |""".stripMargin
       } else {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
@@ -1613,7 +1613,8 @@ object InternalDistriOptimizer {
         val (weights, gradients) = models.mapPartitions(iter => {
           val cached = iter.next()
           val curPartitionId = TaskContext.getPartitionId()
-          val (offset, size) = InternalOptimizerUtil.getLocalPartitionRangeFromParameters(parameters)
+          val (offset, size) =
+            InternalOptimizerUtil.getLocalPartitionRangeFromParameters(parameters)
           val weightTensor = Tensor[T](size)
           weightTensor.copy(cached.modelWeights.head.narrow(1, offset, size))
           Iterator.single((Map(curPartitionId -> weightTensor),

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
@@ -47,7 +47,7 @@ import com.intel.analytics.zoo.pipeline.api.autograd.{Lambda, Variable}
 import com.intel.analytics.zoo.pipeline.api.autograd._
 import com.intel.analytics.zoo.pipeline.api.keras.layers.Input
 import com.intel.analytics.zoo.pipeline.api.keras.layers.utils._
-import com.intel.analytics.zoo.pipeline.api.net.{NetUtils, TorchNet}
+import com.intel.analytics.zoo.pipeline.api.net.{NetUtils, TorchModel, TorchNet}
 import com.intel.analytics.zoo.pipeline.estimator.{AbstractEstimator, ConstantClipping, GradientClipping, L2NormClipping}
 import com.intel.analytics.zoo.tfpark.{TFTrainingHelper, TFTrainingHelperV2}
 import org.apache.commons.lang.exception.ExceptionUtils
@@ -1032,6 +1032,42 @@ private[zoo] object InternalOptimizerUtil {
       args: _*)
   }
 
+  // TODO: Delete this when switch to Bigdl 0.11.0.
+  def getTorchModel[T: ClassTag](
+      models: RDD[Cache[T]],
+      parameters: AllReduceParameter[T],
+      trainingModel: TorchModel)(implicit ev: TensorNumeric[T]): TorchModel = {
+    val partitionNum = models.partitions.length
+    val extraState = models.map(_.localModels.head.getExtraParameter()).first()
+    trainingModel.setExtraParam(extraState.asInstanceOf[Array[Tensor[Float]]])
+    val (weights, gradients) = models.mapPartitions(iter => {
+      val cached = iter.next()
+      val curPartitionId = TaskContext.getPartitionId()
+      Iterator.single((Map(curPartitionId -> parameters.weightPartition),
+        Map(curPartitionId -> parameters.gradientPartition)))
+    }).reduce((a, b) => (a._1 ++ b._1, a._2 ++ b._2))
+
+    val parameterArray = trainingModel.parameters()
+    (0 until parameterArray._2.length).foreach(i =>
+      parameterArray._2(i).resizeAs(parameterArray._1(i))
+    )
+    val (parameter, gradientParameter) = getParametersFromModel(trainingModel)
+    val parameterLength = parameter.nElement()
+    val taskSize = parameterLength / partitionNum
+    require(taskSize != 0, "parameter length should not less than partition number")
+    val extraSize = parameterLength % partitionNum
+
+    (0 until partitionNum).map(pid => {
+      val start = pid * taskSize + math.min(pid, extraSize)
+      val length = taskSize + (if (pid < extraSize) 1 else 0)
+      parameter.narrow(1, start + 1, length).copy(weights(pid).asInstanceOf[Tensor[Float]])
+      gradientParameter.narrow(1, start + 1, length)
+        .copy(gradients(pid).asInstanceOf[Tensor[Float]])
+    })
+
+    trainingModel
+  }
+
   def releaseBroadcast[T: ClassTag](
         uuid: String)(implicit ev: TensorNumeric[T]): Unit = {
     KerasUtils.invokeMethodWithEv(
@@ -1554,47 +1590,52 @@ object InternalDistriOptimizer {
                             trainingModel: Module[T])(implicit ev: TensorNumeric[T])
   : Module[T] = {
 
-    if (!trainingModel.isInstanceOf[TFTrainingHelperV2]) {
-      InternalOptimizerUtil.getModel(models, parameters, trainingModel)
-    } else {
-      val partitionNum = models.partitions.length
-      models.mapPartitions(iter => {
-        iter.next().localModels.head.asInstanceOf[TFTrainingHelperV2].moveWeightsOutOfTF()
-        Iterator.single(1)
-      }).reduce(_ + _)
-      val extraState = models.map(_.localModels.head.getExtraParameter()).first()
-      trainingModel.setExtraParameter(extraState)
+    trainingModel match {
+      case _: TFTrainingHelperV2 =>
+        val partitionNum = models.partitions.length
+        models.mapPartitions(iter => {
+          iter.next().localModels.head.asInstanceOf[TFTrainingHelperV2].moveWeightsOutOfTF()
+          Iterator.single(1)
+        }).reduce(_ + _)
+        val extraState = models.map(_.localModels.head.getExtraParameter()).first()
+        trainingModel.setExtraParameter(extraState)
 
-      // make sure gradient is as the same length as weight
-      val parameterArray = trainingModel.parameters()
-      (0 until parameterArray._2.length).foreach(i =>
-        parameterArray._2(i).resizeAs(parameterArray._1(i))
-      )
+        // make sure gradient is as the same length as weight
+        val parameterArray = trainingModel.parameters()
+        (0 until parameterArray._2.length).foreach(i =>
+          parameterArray._2(i).resizeAs(parameterArray._1(i))
+        )
 
-      val (parameter, gradientParameter) =
-        InternalOptimizerUtil.getParametersFromModel(trainingModel)
+        val (parameter, gradientParameter) =
+          InternalOptimizerUtil.getParametersFromModel(trainingModel)
 
 
-      val (weights, gradients) = models.mapPartitions(iter => {
-        val cached = iter.next()
-        val curPartitionId = TaskContext.getPartitionId()
-        val (offset, size) = InternalOptimizerUtil.getLocalPartitionRangeFromParameters(parameters)
-        val weightTensor = Tensor[T](size)
-        weightTensor.copy(cached.modelWeights.head.narrow(1, offset, size))
-        Iterator.single((Map(curPartitionId -> weightTensor),
-          Map(curPartitionId -> parameters.gradientPartition)))
-      }).reduce((a, b) => (a._1 ++ b._1, a._2 ++ b._2))
+        val (weights, gradients) = models.mapPartitions(iter => {
+          val cached = iter.next()
+          val curPartitionId = TaskContext.getPartitionId()
+          val (offset, size) = InternalOptimizerUtil.getLocalPartitionRangeFromParameters(parameters)
+          val weightTensor = Tensor[T](size)
+          weightTensor.copy(cached.modelWeights.head.narrow(1, offset, size))
+          Iterator.single((Map(curPartitionId -> weightTensor),
+            Map(curPartitionId -> parameters.gradientPartition)))
+        }).reduce((a, b) => (a._1 ++ b._1, a._2 ++ b._2))
 
-      val taskSize = parameters.size / partitionNum
-      require(taskSize != 0, "parameter length should not less than partition number")
-      val extraSize = parameters.size % partitionNum
+        val taskSize = parameters.size / partitionNum
+        require(taskSize != 0, "parameter length should not less than partition number")
+        val extraSize = parameters.size % partitionNum
 
-      (0 until partitionNum).map(pid => {
-        val start = parameters.paramOffset + pid * taskSize + math.min(pid, extraSize)
-        val length = taskSize + (if (pid < extraSize) 1 else 0)
-        parameter.narrow(1, start, length).copy(weights(pid))
-        gradientParameter.narrow(1, start, length).copy(gradients(pid))
-      })
+        (0 until partitionNum).map(pid => {
+          val start = parameters.paramOffset + pid * taskSize + math.min(pid, extraSize)
+          val length = taskSize + (if (pid < extraSize) 1 else 0)
+          parameter.narrow(1, start, length).copy(weights(pid))
+          gradientParameter.narrow(1, start, length).copy(gradients(pid))
+        })
+      case model: TorchModel =>
+        // TODO: delete this when switch to bigdl 0.11.0 and TorchModel override setExtraParameters
+        InternalOptimizerUtil.getTorchModel(
+          models, parameters, model)
+      case _ =>
+        InternalOptimizerUtil.getModel(models, parameters, trainingModel)
     }
     trainingModel
   }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
@@ -1427,7 +1427,6 @@ private[zoo] class InternalDistriOptimizer[T: ClassTag] (
       ): Map[ValidationMethod[T], ValidationResult] = {
     val validateRDD = validationSet.toDistributed().data(train = false)
     val sc = validateRDD.sparkContext
-    val cachedModels = InternalOptimizerUtil.getModelCacheFromOptimizer(this)
 
     val coresPerNode = EngineRef.getCoreNumber()
     val _subModelNumber = EngineRef.getEngineType() match {
@@ -1454,7 +1453,7 @@ private[zoo] class InternalDistriOptimizer[T: ClassTag] (
       }
     } else {
       val bcVMethods = validateRDD.sparkContext.broadcast(validationMethod)
-      val bcModel = ModelBroadcast[T]().broadcast(sc, model)
+      val bcModel = ModelBroadcast[T]().broadcast(sc, _model)
       validateRDD.mapPartitions{_ =>
         Iterator.single(Cache[T](
           Array.tabulate(_subModelNumber)(_ => bcModel.value()),

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModel.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModel.scala
@@ -35,7 +35,8 @@ class TorchModel private(private val modelHolder: TorchModel2Holder, init_weight
   extends AbstractModule[Activity, Activity, Float]{
   import TorchModel._
 
-  protected lazy val loaded = {
+  protected var loaded = false
+  protected lazy val load = {
     PythonInterpreter.set("model_bytes", modelHolder.torchBytes)
     val loadModelCode =
       s"""
@@ -50,6 +51,7 @@ class TorchModel private(private val modelHolder: TorchModel2Holder, init_weight
          |${getName()} = CloudPickleSerializer.loads(CloudPickleSerializer, by)
          |""".stripMargin
     PythonInterpreter.exec(loadModelCode)
+    loaded = true
     true
   }
 
@@ -73,7 +75,7 @@ class TorchModel private(private val modelHolder: TorchModel2Holder, init_weight
        |""".stripMargin
 
   override def updateOutput(input: Activity): Activity = {
-    loaded
+    load
     // TODO: delete this time counting
     val startTime = System.nanoTime()
     // _data is come from FeatureSet.
@@ -118,7 +120,7 @@ class TorchModel private(private val modelHolder: TorchModel2Holder, init_weight
   }
 
   override def updateGradInput(input: Activity, gradOutput: Activity): Activity = {
-    loaded
+    load
     val startTime = System.nanoTime()
     val backwardCode =
       s"""
@@ -162,16 +164,58 @@ class TorchModel private(private val modelHolder: TorchModel2Holder, init_weight
 
   override def evaluate(): this.type = {
     super.evaluate()
-    loaded
+    load
     PythonInterpreter.set("newWeight", new NDArray[Array[Float]](weights.storage().array()))
     PythonInterpreter.exec(setWeightCode)
     PythonInterpreter.exec(s"${getName()}.eval()")
     this
   }
 
+  protected var extraParams: Array[Tensor[Float]] = null
+  override def getExtraParameter(): Array[Tensor[Float]] = {
+    if (loaded) {
+      val getExtraParamCode =
+        s"""
+           |${getName()}_extra_parameters = []
+           |for named_buffer in ${this.getName()}.named_buffers():
+           |    name = named_buffer[0].split(".")[-1]
+           |    if name == 'running_mean' or name == 'running_var':
+           |        ${getName()}_extra_parameters.append(named_buffer[1].data.numpy())
+           |""".stripMargin
+      PythonInterpreter.exec(getExtraParamCode)
+      val extraParams = PythonInterpreter.getValue[AnyRef](s"${getName()}_extra_parameters")
+      PythonFeatureSet.toArrayTensor(extraParams)
+    } else {
+      extraParams
+    }
+  }
+
+  // TODO: change to override setExtraParameter when switch to bigdl 0.11.0
+  private[zoo] def setExtraParam(extraParams: Array[Tensor[Float]]): this.type = {
+    if (loaded) {
+      val params = extraParams.map(param => new NDArray[Array[Float]](param.storage().array(), param.size(): _*))
+      val paramName = s"${getName()}_new_extra_param"
+      val idxName = s"${getName()}_buffer_idx"
+      PythonInterpreter.set(paramName, params)
+      val setExtraParamCode =
+        s"""
+           |${idxName} = 0
+           |for named_buffer in ${this.getName()}.named_buffers():
+           |    name = named_buffer[0].split(".")[-1]
+           |    if name == 'running_mean' or name == 'running_var':
+           |        named_buffer[1].copy_(torch.Tensor(${paramName}[${idxName}]))
+           |        ${idxName} += 1
+           |""".stripMargin
+      PythonInterpreter.exec(setExtraParamCode)
+    } else {
+      this.extraParams = extraParams
+    }
+    this
+  }
+
   override def training(): this.type = {
     super.training()
-    loaded
+    load
     PythonInterpreter.exec(s"${getName()}.train()")
     this
   }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModel.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModel.scala
@@ -201,10 +201,8 @@ class TorchModel private(private val modelHolder: TorchModel2Holder, init_weight
         s"""
            |${idxName} = 0
            |for named_buffer in ${this.getName()}.named_buffers():
-           |    name = named_buffer[0].split(".")[-1]
-           |    if name == 'running_mean' or name == 'running_var':
-           |        named_buffer[1].copy_(torch.Tensor(${paramName}[${idxName}]))
-           |        ${idxName} += 1
+           |    named_buffer[1].copy_(torch.Tensor(${paramName}[${idxName}]))
+           |    ${idxName} += 1
            |""".stripMargin
       PythonInterpreter.exec(setExtraParamCode)
     } else {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModel.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModel.scala
@@ -51,6 +51,9 @@ class TorchModel private(private val modelHolder: TorchModel2Holder, init_weight
          |${getName()} = CloudPickleSerializer.loads(CloudPickleSerializer, by)
          |""".stripMargin
     PythonInterpreter.exec(loadModelCode)
+    if (extraParams.length != 0) {
+      setExtraParam(extraParams)
+    }
     loaded = true
     true
   }
@@ -204,9 +207,8 @@ class TorchModel private(private val modelHolder: TorchModel2Holder, init_weight
            |    ${idxName} += 1
            |""".stripMargin
       PythonInterpreter.exec(setExtraParamCode)
-    } else {
-      this.extraParams = extraParams
     }
+    this.extraParams = extraParams
     this
   }
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModel.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModel.scala
@@ -193,7 +193,8 @@ class TorchModel private(private val modelHolder: TorchModel2Holder, init_weight
   // TODO: change to override setExtraParameter when switch to bigdl 0.11.0
   private[zoo] def setExtraParam(extraParams: Array[Tensor[Float]]): this.type = {
     if (loaded) {
-      val params = extraParams.map(param => new NDArray[Array[Float]](param.storage().array(), param.size(): _*))
+      val params = extraParams.map(param =>
+          new NDArray[Array[Float]](param.storage().array(), param.size(): _*))
       val paramName = s"${getName()}_new_extra_param"
       val idxName = s"${getName()}_buffer_idx"
       PythonInterpreter.set(paramName, params)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModel.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModel.scala
@@ -171,7 +171,7 @@ class TorchModel private(private val modelHolder: TorchModel2Holder, init_weight
     this
   }
 
-  protected var extraParams: Array[Tensor[Float]] = null
+  protected var extraParams: Array[Tensor[Float]] = Array()
   override def getExtraParameter(): Array[Tensor[Float]] = {
     if (loaded) {
       val getExtraParamCode =

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModel.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModel.scala
@@ -191,12 +191,7 @@ class TorchModel private(private val modelHolder: TorchModel2Holder, init_weight
   // TODO: change to override setExtraParameter when switch to bigdl 0.11.0
   private[zoo] def setExtraParam(extraParams: Array[Tensor[Float]]): this.type = {
     if (loaded) {
-      val params = extraParams.map(param =>
-        if (param.isScalar) {
-          new NDArray[Array[Float]](param.storage().array())
-        } else {
-          new NDArray[Array[Float]](param.storage().array(), param.size(): _*)
-        })
+      val params = extraParams.map(param => new NDArray[Array[Float]](param.storage().array()))
       val paramName = s"${getName()}_new_extra_param"
       val idxName = s"${getName()}_buffer_idx"
       PythonInterpreter.set(paramName, params)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModel.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModel.scala
@@ -178,9 +178,7 @@ class TorchModel private(private val modelHolder: TorchModel2Holder, init_weight
         s"""
            |${getName()}_extra_parameters = []
            |for named_buffer in ${this.getName()}.named_buffers():
-           |    name = named_buffer[0].split(".")[-1]
-           |    if name == 'running_mean' or name == 'running_var':
-           |        ${getName()}_extra_parameters.append(named_buffer[1].data.numpy())
+           |    ${getName()}_extra_parameters.append(named_buffer[1].data.numpy())
            |""".stripMargin
       PythonInterpreter.exec(getExtraParamCode)
       val extraParams = PythonInterpreter.getValue[AnyRef](s"${getName()}_extra_parameters")

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/python/PythonZooNet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/python/PythonZooNet.scala
@@ -164,6 +164,10 @@ class PythonZooNet[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonZoo
     pids.asScala.foreach(pid => processToBeKill.add(pid + ""))
   }
 
+  def getModuleExtraParameters(model: AbstractModule[_, _, T]): Array[JTensor] = {
+    model.getExtraParameter().map(toJTensor)
+  }
+
   def createTorchNet(modelPath: String): TorchNet = {
       TorchNet(modelPath)
   }

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModelSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModelSpec.scala
@@ -186,7 +186,13 @@ class TorchModelSpec extends ZooSpecHelper{
     val model = TorchModel(bys, w)
     model.training()
     val extraParams = model.getExtraParameter()
-    extraParams.foreach(_.fill(3))
+    extraParams.foreach{v =>
+      if (v.isScalar) {
+        v.fill(3)
+      } else {
+        v.rand()
+      }
+    }
     model.setExtraParam(extraParams)
     val newExtraParams = model.getExtraParameter()
     extraParams.zip(newExtraParams).foreach{v =>

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModelSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModelSpec.scala
@@ -186,7 +186,7 @@ class TorchModelSpec extends ZooSpecHelper{
     val model = TorchModel(bys, w)
     model.training()
     val extraParams = model.getExtraParameter()
-    extraParams.foreach(_.rand())
+    extraParams.foreach(_.fill(3))
     model.setExtraParam(extraParams)
     val newExtraParams = model.getExtraParameter()
     extraParams.zip(newExtraParams).foreach{v =>

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModelSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModelSpec.scala
@@ -163,4 +163,34 @@ class TorchModelSpec extends ZooSpecHelper{
     val gradOutput = criterion.backward(input, target)
     model.backward(input, gradOutput)
   }
+
+  "TorchModel's get/set param" should "works" in {
+    ifskipTest()
+    val code = lenet +
+      s"""
+         |import torch
+         |import torchvision
+         |model = torchvision.models.resnet18()
+         |from pyspark.serializers import CloudPickleSerializer
+         |weights=[]
+         |for param in model.parameters():
+         |    weights.append(param.view(-1))
+         |flatten_weight = torch.nn.utils.parameters_to_vector(weights).data.numpy()
+         |bym = CloudPickleSerializer.dumps(CloudPickleSerializer, model)
+         |
+         |""".stripMargin
+    PythonInterpreter.exec(code)
+
+    val w = PythonInterpreter.getValue[NDArray[Array[Float]]]("flatten_weight").getData()
+    val bys = PythonInterpreter.getValue[Array[Byte]]("bym")
+    val model = TorchModel(bys, w)
+    model.training()
+    val extraParams = model.getExtraParameter()
+    extraParams.foreach(_.rand())
+    model.setExtraParam(extraParams)
+    val newExtraParams = model.getExtraParameter()
+    extraParams.zip(newExtraParams).foreach{v =>
+      v._1 should be (v._2)
+    }
+  }
 }


### PR DESCRIPTION
support bn when TorchModel export model to pure pytorch

As setExtraParameters is final in BigDL's AbstractModule, so I find a way to walk around.
We can remove this walk around when update to bigdl 0.11.0.(https://github.com/intel-analytics/BigDL/pull/3014 remove the final)