### PR TITLE
Generate object ids for plasma error handling

### DIFF
--- a/pyzoo/zoo/orca/data/shard.py
+++ b/pyzoo/zoo/orca/data/shard.py
@@ -338,7 +338,7 @@ class SparkXShards(XShards):
                 if not client.contains(target_id):
                     object_id = client.put(res, target_id)
                     assert object_id == target_id, \
-                        "Error occurred when putting data into plasma object store"
+                        "Errors occurred when putting data into plasma object store"
                 client.disconnect()
                 yield target_id, get_node_ip()
             return f

--- a/pyzoo/zoo/orca/data/shard.py
+++ b/pyzoo/zoo/orca/data/shard.py
@@ -322,33 +322,27 @@ class SparkXShards(XShards):
 
     # Tested on pyarrow 0.17.0; 0.16.0 would get errors.
     def to_ray(self):
-        import random
-        import string
         from zoo.ray import RayContext
         ray_ctx = RayContext.get()
         object_store_address = ray_ctx.address_info["object_store_address"]
 
-        # TODO: Handle failure when doing this?
-        # TODO: delete the data in the plasma?
-        def put_to_plasma(seed):
+        def put_to_plasma(ids):
             def f(index, iterator):
                 import pyarrow.plasma as plasma
                 from zoo.orca.data.utils import get_node_ip
-                # mapPartition would set the same random seed for each partition?
-                # Here use the partition index to override the random seed so that there won't be
-                # identical object_ids in plasma.
-                random.seed(seed+str(index))
                 res = list(iterator)
                 client = plasma.connect(object_store_address)
-                object_id = client.put(res)
-                yield object_id, get_node_ip()
+                target_id = ids[index]
+                if not client.contains(target_id):
+                    object_id = client.put(res, target_id)
+                    assert object_id == target_id
+                yield target_id, get_node_ip()
             return f
 
-        # Generate a random string here to make sure that when this method is called twice, the
-        # seeds to generate plasma ObjectID are different.
-        random_str = ''.join(
-            [random.choice(string.ascii_letters + string.digits) for i in range(32)])
-        object_id_node_ips = self.rdd.mapPartitionsWithIndex(put_to_plasma(random_str)).collect()
+        # Create plasma ObjectIDs beforehand instead of creating a random one every time.
+        import pyarrow.plasma as plasma
+        object_ids = [plasma.ObjectID.from_random() for i in range(self.rdd.getNumPartitions())]
+        object_id_node_ips = self.rdd.mapPartitionsWithIndex(put_to_plasma(object_ids)).collect()
         self.uncache()
         # Sort the data according to the node_ips.
         object_id_node_ips.sort(key=lambda x: x[1])

--- a/pyzoo/zoo/orca/data/shard.py
+++ b/pyzoo/zoo/orca/data/shard.py
@@ -336,6 +336,7 @@ class SparkXShards(XShards):
                 if not client.contains(target_id):
                     object_id = client.put(res, target_id)
                     assert object_id == target_id
+                client.disconnect()
                 yield target_id, get_node_ip()
             return f
 


### PR DESCRIPTION
Previously if putting into plasma tasks fail, each spark retrial would create a new object id to put the data. This would lead to memory leak if only some tasks fail.

Generate an ObjectID for each partition beforehand for plasma.
In case tasks fail, spark would retry to put into plasma. If the target id already exists, we suppose that the task on that partition succeeds and does nothing. Otherwise, still use this id to put into plasma.