### PR TITLE
Fix Orca read file path

### DIFF
--- a/pyzoo/test/zoo/orca/data/test_pandas_backend.py
+++ b/pyzoo/test/zoo/orca/data/test_pandas_backend.py
@@ -40,7 +40,7 @@ class TestSparkXShards(TestCase):
         file_path = os.path.join(self.resource_path, "abc")
         with self.assertRaises(Exception) as context:
             xshards = zoo.orca.data.pandas.read_csv(file_path)
-        self.assertTrue('The file path is invalid/empty' in str(context.exception))
+        self.assertTrue('No such file or directory' in str(context.exception))
 
     def test_read_local_json(self):
         ZooContext.orca_pandas_read_backend = "pandas"

--- a/pyzoo/test/zoo/orca/data/test_pandas_backend.py
+++ b/pyzoo/test/zoo/orca/data/test_pandas_backend.py
@@ -41,6 +41,11 @@ class TestSparkXShards(TestCase):
         with self.assertRaises(Exception) as context:
             xshards = zoo.orca.data.pandas.read_csv(file_path)
         self.assertTrue('No such file or directory' in str(context.exception))
+        file_path = os.path.join(self.resource_path, "image3d")
+        with self.assertRaises(Exception) as context:
+            xshards = zoo.orca.data.pandas.read_csv(file_path)
+        # This error is raised by pandas.errors.ParserError
+        self.assertTrue('Error tokenizing data' in str(context.exception))
 
     def test_read_local_json(self):
         ZooContext.orca_pandas_read_backend = "pandas"

--- a/pyzoo/test/zoo/orca/data/test_spark_backend.py
+++ b/pyzoo/test/zoo/orca/data/test_spark_backend.py
@@ -101,7 +101,8 @@ class TestSparkBackend(TestCase):
         file_path = os.path.join(self.resource_path, "abc")
         with self.assertRaises(Exception) as context:
             xshards = zoo.orca.data.pandas.read_csv(file_path)
-        self.assertTrue('The file path is invalid/empty' in str(context.exception))
+        # This error is raised by pyspark.sql.utils.AnalysisException
+        self.assertTrue('Path does not exist' in str(context.exception))
 
     def test_read_json(self):
         file_path = os.path.join(self.resource_path, "orca/data/json")

--- a/pyzoo/zoo/orca/data/pandas/preprocessing.py
+++ b/pyzoo/zoo/orca/data/pandas/preprocessing.py
@@ -46,11 +46,11 @@ def read_json(file_path, **kwargs):
 
 def read_file_spark(file_path, file_type, **kwargs):
     sc = init_nncontext()
+    node_num, core_num = get_node_and_core_number()
 
     if ZooContext.orca_pandas_read_backend == "pandas":
         file_url_splits = file_path.split("://")
         prefix = file_url_splits[0]
-        node_num, core_num = get_node_and_core_number()
 
         file_paths = []
         if isinstance(file_path, list):
@@ -141,12 +141,12 @@ def read_file_spark(file_path, file_type, **kwargs):
                 comment = kwargs["comment"]
                 if not isinstance(comment, str) or len(comment) != 1:
                     raise ValueError("Only length-1 comment characters supported")
-            df = spark.read.csv(file_paths, **kwargs)
+            df = spark.read.csv(file_path, **kwargs)
             if header is None:
                 df = df.selectExpr(
                     *["`%s` as `%s`" % (field.name, i) for i, field in enumerate(df.schema)])
         else:
-            df = spark.read.json(file_paths, **kwargs)
+            df = spark.read.json(file_path, **kwargs)
 
         # Handle pandas-compatible postprocessing arguments
         if isinstance(names, list):

--- a/pyzoo/zoo/orca/data/pandas/preprocessing.py
+++ b/pyzoo/zoo/orca/data/pandas/preprocessing.py
@@ -46,20 +46,21 @@ def read_json(file_path, **kwargs):
 
 def read_file_spark(file_path, file_type, **kwargs):
     sc = init_nncontext()
-    file_url_splits = file_path.split("://")
-    prefix = file_url_splits[0]
-    node_num, core_num = get_node_and_core_number()
-
-    file_paths = []
-    if isinstance(file_path, list):
-        [file_paths.extend(extract_one_path(path, file_type, os.environ)) for path in file_path]
-    else:
-        file_paths = extract_one_path(file_path, file_type, os.environ)
-
-    if not file_paths:
-        raise Exception("The file path is invalid/empty or does not include csv/json files")
 
     if ZooContext.orca_pandas_read_backend == "pandas":
+        file_url_splits = file_path.split("://")
+        prefix = file_url_splits[0]
+        node_num, core_num = get_node_and_core_number()
+
+        file_paths = []
+        if isinstance(file_path, list):
+            [file_paths.extend(extract_one_path(path, os.environ)) for path in file_path]
+        else:
+            file_paths = extract_one_path(file_path, os.environ)
+
+        if not file_paths:
+            raise Exception("The file path is invalid/empty or does not include csv/json files")
+
         num_files = len(file_paths)
         total_cores = node_num * core_num
         num_partitions = num_files if num_files < total_cores else total_cores
@@ -78,7 +79,7 @@ def read_file_spark(file_path, file_type, **kwargs):
                     yield df
 
             pd_rdd = rdd.mapPartitions(loadFile)
-    else:  # Spark backend
+    else:  # Spark backend; spark.read.csv/json accepts a folder path as input
         assert file_type == "json" or file_type == "csv", \
             "Unsupported file type: %s. Only csv and json files are supported for now" % file_type
         from pyspark.sql import SQLContext

--- a/pyzoo/zoo/orca/data/pandas/preprocessing.py
+++ b/pyzoo/zoo/orca/data/pandas/preprocessing.py
@@ -59,7 +59,7 @@ def read_file_spark(file_path, file_type, **kwargs):
             file_paths = extract_one_path(file_path, os.environ)
 
         if not file_paths:
-            raise Exception("The file path is invalid/empty or does not include csv/json files")
+            raise Exception("The file path is invalid or empty, please check your data")
 
         num_files = len(file_paths)
         total_cores = node_num * core_num

--- a/pyzoo/zoo/orca/data/utils.py
+++ b/pyzoo/zoo/orca/data/utils.py
@@ -44,7 +44,7 @@ def list_s3_file(file_path, env):
         return file_paths
 
 
-def extract_one_path(file_path, file_type, env):
+def extract_one_path(file_path, env):
     file_url_splits = file_path.split("://")
     prefix = file_url_splits[0]
     if prefix == "s3":
@@ -56,17 +56,13 @@ def extract_one_path(file_path, file_type, env):
             file_paths = [file_path]
         else:
             file_paths = get_file_list(file_path)
-    else:
-        if os.path.isfile(file_path):
-            file_paths = [file_path]
+    else:  # Local file path; could be a relative path.
+        from os.path import isfile, abspath, join
+        if isfile(file_path):
+            file_paths = [abspath(file_path)]
         else:
-            from os import listdir
-            from os.path import isfile, abspath, join, splitext
             # An error would be already raised here if the path is invalid.
-            file_paths = [abspath(join(file_path, file)) for file in listdir(file_path)]
-    # Only get json/csv files.
-    file_paths = [file for file in file_paths
-                  if os.path.isfile(file) and os.path.splitext(file)[1] == "." + file_type]
+            file_paths = [abspath(join(file_path, file)) for file in os.listdir(file_path)]
     return file_paths
 
 

--- a/pyzoo/zoo/orca/data/utils.py
+++ b/pyzoo/zoo/orca/data/utils.py
@@ -18,7 +18,7 @@ import os
 from zoo.common import get_file_list
 
 
-def list_s3_file(file_path, file_type, env):
+def list_s3_file(file_path, env):
     path_parts = file_path.split('/')
     bucket = path_parts.pop(0)
     key = "/".join(path_parts)
@@ -40,9 +40,7 @@ def list_s3_file(file_path, file_type, env):
                                          Prefix=key)
         for obj in resp['Contents']:
             keys.append(obj['Key'])
-        # only get json/csv files
-        files = [file for file in keys if os.path.splitext(file)[1] == "." + file_type]
-        file_paths = [os.path.join("s3://" + bucket, file) for file in files]
+        file_paths = [os.path.join("s3://" + bucket, file) for file in keys]
         return file_paths
 
 
@@ -50,25 +48,25 @@ def extract_one_path(file_path, file_type, env):
     file_url_splits = file_path.split("://")
     prefix = file_url_splits[0]
     if prefix == "s3":
-        file_paths = list_s3_file(file_url_splits[1], file_type, env)
+        file_paths = list_s3_file(file_url_splits[1], env)
     elif prefix == "hdfs":
         import pyarrow as pa
         fs = pa.hdfs.connect()
         if fs.isfile(file_path):
-            return [file_path]
+            file_paths = [file_path]
         else:
             file_paths = get_file_list(file_path)
-            # only get json/csv files
-            file_paths = [file for file in file_paths
-                          if os.path.splitext(file)[1] == "." + file_type]
     else:
         if os.path.isfile(file_path):
-            return [file_path]
+            file_paths = [file_path]
         else:
-            file_paths = get_file_list(file_path)
-            # only get json/csv files
-            file_paths = [file for file in file_paths
-                          if os.path.splitext(file)[1] == "." + file_type]
+            from os import listdir
+            from os.path import isfile, abspath, join, splitext
+            # An error would be already raised here if the path is invalid.
+            file_paths = [abspath(join(file_path, file)) for file in listdir(file_path)]
+    # Only get json/csv files.
+    file_paths = [file for file in file_paths
+                  if os.path.isfile(file) and os.path.splitext(file)[1] == "." + file_type]
     return file_paths
 
 


### PR DESCRIPTION
- Fix #2521 do not use Scala HadoopFS API to list local file paths.
- Do not filter files by its suffix as neither Spark or Pandas does this. We just pass all the files to Spark or Pandas and let them handle or raise an error. For pandas during read time error would be raised if the file format is wrong. For spark seems it can read anything, but when you do transformation on the resulting DataFrame, the error would be raised if the file format is not as expected.