### PR TITLE
Add orca.data.partition, which can partition and send local ndarrays to remote workers

### DIFF
--- a/pyzoo/test/zoo/orca/data/test_partition.py
+++ b/pyzoo/test/zoo/orca/data/test_partition.py
@@ -1,0 +1,108 @@
+#
+# Copyright 2018 Analytics Zoo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from unittest import TestCase
+import pytest
+
+
+class TestSparkBackend(TestCase):
+
+    def test_partition_ndarray(self):
+        import numpy as np
+        import zoo.orca.data as orca_data
+        data = np.random.randn(10, 4)
+
+        xshards = orca_data.partition(data)
+
+        data_parts = xshards.rdd.collect()
+
+        reconstructed = np.concatenate(data_parts)
+        assert np.allclose(data, reconstructed)
+
+    def test_partition_tuple(self):
+        import numpy as np
+        import zoo.orca.data as orca_data
+        data1 = np.random.randn(10, 4)
+        data2 = np.random.randn(10, 4)
+
+        xshards = orca_data.partition((data1, data2))
+
+        data_parts = xshards.rdd.collect()
+
+        data1_parts = [part[0] for part in data_parts]
+        data2_parts = [part[1] for part in data_parts]
+
+        reconstructed1 = np.concatenate(data1_parts)
+        reconstructed2 = np.concatenate(data2_parts)
+        assert np.allclose(data1, reconstructed1)
+        assert np.allclose(data2, reconstructed2)
+
+    def test_partition_list(self):
+        import numpy as np
+        import zoo.orca.data as orca_data
+        data1 = np.random.randn(10, 4)
+        data2 = np.random.randn(10, 4)
+
+        xshards = orca_data.partition([data1, data2])
+
+        data_parts = xshards.rdd.collect()
+
+        data1_parts = [part[0] for part in data_parts]
+        data2_parts = [part[1] for part in data_parts]
+
+        reconstructed1 = np.concatenate(data1_parts)
+        reconstructed2 = np.concatenate(data2_parts)
+        assert np.allclose(data1, reconstructed1)
+        assert np.allclose(data2, reconstructed2)
+
+    def test_partition_dict(self):
+        import numpy as np
+        import zoo.orca.data as orca_data
+        data1 = np.random.randn(10, 4)
+        data2 = np.random.randn(10, 4)
+
+        xshards = orca_data.partition({"x": data1, "y": data2})
+
+        data_parts = xshards.rdd.collect()
+
+        data1_parts = [part["x"] for part in data_parts]
+        data2_parts = [part["y"] for part in data_parts]
+
+        reconstructed1 = np.concatenate(data1_parts)
+        reconstructed2 = np.concatenate(data2_parts)
+        assert np.allclose(data1, reconstructed1)
+        assert np.allclose(data2, reconstructed2)
+
+    def test_partition_nested(self):
+        import numpy as np
+        import zoo.orca.data as orca_data
+        data1 = np.random.randn(10, 4)
+        data2 = np.random.randn(10, 4)
+
+        xshards = orca_data.partition({"x": (data1, ), "y": [data2]})
+
+        data_parts = xshards.rdd.collect()
+
+        data1_parts = [part["x"][0] for part in data_parts]
+        data2_parts = [part["y"][0] for part in data_parts]
+
+        reconstructed1 = np.concatenate(data1_parts)
+        reconstructed2 = np.concatenate(data2_parts)
+        assert np.allclose(data1, reconstructed1)
+        assert np.allclose(data2, reconstructed2)
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/pyzoo/zoo/orca/data/__init__.py
+++ b/pyzoo/zoo/orca/data/__init__.py
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-from .shard import SparkXShards, SharedValue
+from .shard import SparkXShards, SharedValue, partition

--- a/pyzoo/zoo/orca/data/shard.py
+++ b/pyzoo/zoo/orca/data/shard.py
@@ -378,7 +378,9 @@ The types supported in zoo.orca.data.shard are
 1. np.ndarray
 2. a tuple, list, dict of np.ndarray
 3. nested structure made of tuple, list, dict with ndarray as the leaf value
-    """
+
+But got data of type {}
+    """.format(type(data))
     supported_types = {list, tuple, dict}
     if isinstance(data, np.ndarray):
         arrays = np.array_split(data, total_core_num)

--- a/pyzoo/zoo/orca/data/shard.py
+++ b/pyzoo/zoo/orca/data/shard.py
@@ -368,6 +368,7 @@ class SharedValue(object):
     def unpersist(self):
         self.broadcast_data.unpersist()
 
+
 def partition(data):
     sc = init_nncontext()
     node_num, core_num = get_node_and_core_number()

--- a/pyzoo/zoo/orca/data/shard.py
+++ b/pyzoo/zoo/orca/data/shard.py
@@ -377,7 +377,7 @@ def partition(data):
 The types supported in zoo.orca.data.shard are
 1. np.ndarray
 2. a tuple, list, dict of np.ndarray
-3. nested structure of a tuple, list or dict of np.ndarray
+3. nested structure made of tuple, list, dict with ndarray as the leaf value
     """
     supported_types = {list, tuple, dict}
     if isinstance(data, np.ndarray):

--- a/pyzoo/zoo/orca/data/shard.py
+++ b/pyzoo/zoo/orca/data/shard.py
@@ -17,7 +17,8 @@ from py4j.protocol import Py4JError
 
 from zoo.orca.data.utils import *
 from zoo.common.nncontext import init_nncontext
-from zoo import ZooContext
+from zoo import ZooContext, get_node_and_core_number
+from zoo.util import nest
 
 
 class XShards(object):
@@ -366,3 +367,39 @@ class SharedValue(object):
 
     def unpersist(self):
         self.broadcast_data.unpersist()
+
+def partition(data):
+    sc = init_nncontext()
+    node_num, core_num = get_node_and_core_number()
+    total_core_num = node_num * core_num
+    import numpy as np
+    type_err_msg = """
+The types supported in zoo.orca.data.shard are
+1. np.ndarray
+2. a tuple, list, dict of np.ndarray
+3. nested structure of a tuple, list or dict of np.ndarray
+    """
+    supported_types = {list, tuple, dict}
+    if isinstance(data, np.ndarray):
+        arrays = np.array_split(data, total_core_num)
+        rdd = sc.parallelize(arrays)
+    else:
+        assert type(data) in supported_types, type_err_msg
+        flattened = nest.flatten(data)
+        data_length = len(flattened[0])
+        data_to_be_shard = []
+        for i in range(total_core_num):
+            data_to_be_shard.append([])
+        for x in flattened:
+            assert len(x) == data_length, \
+                "the ndarrays in data must all have the same size in first dimension, " \
+                "got first ndarray of size {} and another {}".format(data_length, len(x))
+            x_parts = np.array_split(x, total_core_num)
+            for idx, x_part in enumerate(x_parts):
+                data_to_be_shard[idx].append(x_part)
+
+        data_to_be_shard = [nest.pack_sequence_as(data, shard) for shard in data_to_be_shard]
+        rdd = sc.parallelize(data_to_be_shard)
+
+    data_shards = SparkXShards(rdd)
+    return data_shards


### PR DESCRIPTION
Usage:

```python
import zoo.orca.data as orca_data
xshards = orca_data.partition({"x": np.random.randn(100, 10), "y": np.random.randint(0, 10, shape=(100,))})
estimator.train(xshards)
```

Supported types:

1. a single ndarray
2. a tuple, list or dict of ndarray
3. nested structure made of tuple, list, dict with ndarray as the leaf value 

issue https://github.com/analytics-zoo/orca/issues/59