### PR TITLE
Support read_csv/read_json with 'names' of partial columns

### DIFF
--- a/pyzoo/test/zoo/orca/data/test_spark_backend.py
+++ b/pyzoo/test/zoo/orca/data/test_spark_backend.py
@@ -77,10 +77,10 @@ class TestSparkBackend(TestCase):
         df = data[0]
         assert df.location.dtype == "float64"
         assert df.ID.dtype == "float64"
-        data_shard = zoo.orca.data.pandas.read_csv(file_path, dtype={"sale_price": "float"})
+        data_shard = zoo.orca.data.pandas.read_csv(file_path, dtype={"sale_price": np.float32})
         data = data_shard.collect()
         df2 = data[0]
-        assert df2.sale_price.dtype == "float64" and df2.ID.dtype == "int64"
+        assert df2.sale_price.dtype == "float32" and df2.ID.dtype == "int64"
 
     def test_squeeze(self):
         import pandas as pd
@@ -96,6 +96,36 @@ class TestSparkBackend(TestCase):
         data = data_shard.collect()
         df = data[0]
         assert 100529 in df.index
+
+    def test_mix(self):
+        file_path = os.path.join(self.resource_path, "orca/data/csv")
+        data_shard = zoo.orca.data.pandas.read_csv(file_path, header=0, names=['user', 'item'],
+                                                   usecols=[0, 1])
+        data = data_shard.collect()
+        df = data[0]
+        assert "user" in df.columns
+        assert "item" in df.columns
+        with self.assertRaises(Exception) as context:
+            data_shard = zoo.orca.data.pandas.read_csv(file_path, header=0,
+                                                       names=['ID', 'location'], usecols=["ID"])
+            data = data_shard.collect()
+        self.assertTrue('Passed names did not match usecols'
+                        in str(context.exception))
+        data_shard = zoo.orca.data.pandas.read_csv(file_path, header=0,
+                                                   names=['user','item'], usecols=[0, 1],
+                                                   dtype={0: np.float32, 1: np.int32})
+        data = data_shard.collect()
+        df2 = data[0]
+        assert df2.user.dtype == "float32" and df2.item.dtype == "int32"
+
+        data_shard = zoo.orca.data.pandas.read_csv(file_path, header=0,
+                                                   names=['user', 'item', 'location'],
+                                                   usecols=[1, 2])
+        data = data_shard.collect()
+        df2 = data[0]
+        assert "user" not in df2.columns
+        assert "item" in df2.columns
+        assert "location" in df2.columns
 
     def test_read_invalid_path(self):
         file_path = os.path.join(self.resource_path, "abc")

--- a/pyzoo/test/zoo/orca/data/test_spark_backend.py
+++ b/pyzoo/test/zoo/orca/data/test_spark_backend.py
@@ -127,6 +127,22 @@ class TestSparkBackend(TestCase):
         assert "item" in df2.columns
         assert "location" in df2.columns
 
+        data_shard = zoo.orca.data.pandas.read_csv(file_path, header=0,
+                                                   names=['user', 'item', 'rating'],
+                                                   usecols=['user', 'item'],
+                                                   dtype={0: np.float32, 1: np.int32})
+        data = data_shard.collect()
+        df2 = data[0]
+        assert df2.user.dtype == "float32" and df2.item.dtype == "int32"
+
+        with self.assertRaises(Exception) as context:
+            data_shard = zoo.orca.data.pandas.read_csv(file_path, header=0,
+                                                       names=['user', 'item'], usecols=[0, 1],
+                                                       dtype={1: np.float32, 2: np.int32})
+            data = data_shard.collect()
+        self.assertTrue('column index to be set type is not in current dataframe'
+                        in str(context.exception))
+
     def test_read_invalid_path(self):
         file_path = os.path.join(self.resource_path, "abc")
         with self.assertRaises(Exception) as context:

--- a/pyzoo/test/zoo/orca/data/test_spark_backend.py
+++ b/pyzoo/test/zoo/orca/data/test_spark_backend.py
@@ -112,7 +112,7 @@ class TestSparkBackend(TestCase):
         self.assertTrue('Passed names did not match usecols'
                         in str(context.exception))
         data_shard = zoo.orca.data.pandas.read_csv(file_path, header=0,
-                                                   names=['user','item'], usecols=[0, 1],
+                                                   names=['user', 'item'], usecols=[0, 1],
                                                    dtype={0: np.float32, 1: np.int32})
         data = data_shard.collect()
         df2 = data[0]

--- a/pyzoo/zoo/orca/data/pandas/preprocessing.py
+++ b/pyzoo/zoo/orca/data/pandas/preprocessing.py
@@ -176,8 +176,8 @@ def read_file_spark(file_path, file_type, **kwargs):
                         "string." % (len(names), len(df.schema))
                     )
                 df = df.selectExpr(
-                        *["`%s` as `%s`" % (field.name, name) for field, name
-                          in zip(df.schema, names)]
+                    *["`%s` as `%s`" % (field.name, name) for field, name
+                      in zip(df.schema, names)]
                 )
                 renamed = True
         index_map = dict([(i, field.name) for i, field in enumerate(df.schema)])

--- a/pyzoo/zoo/orca/data/pandas/preprocessing.py
+++ b/pyzoo/zoo/orca/data/pandas/preprocessing.py
@@ -163,19 +163,21 @@ def read_file_spark(file_path, file_type, **kwargs):
                         )
                 if len(names) == len(df.schema):
                     df = df.selectExpr(
-                        *["`%s` as `%s`" % (field.name, name) for field, name in zip(df.schema, names)]
+                        *["`%s` as `%s`" % (field.name, name) for field, name
+                          in zip(df.schema, names)]
                     )
                     renamed = True
 
             else:
                 if len(names) != len(df.schema):
                     raise ValueError(
-                            "The number of names [%s] does not match the number "
-                            "of columns [%d]. Try names by a Spark SQL DDL-formatted "
-                            "string." % (len(names), len(df.schema))
+                        "The number of names [%s] does not match the number "
+                        "of columns [%d]. Try names by a Spark SQL DDL-formatted "
+                        "string." % (len(names), len(df.schema))
                     )
                 df = df.selectExpr(
-                        *["`%s` as `%s`" % (field.name, name) for field, name in zip(df.schema, names)]
+                        *["`%s` as `%s`" % (field.name, name) for field, name
+                          in zip(df.schema, names)]
                 )
                 renamed = True
         index_map = dict([(i, field.name) for i, field in enumerate(df.schema)])
@@ -208,8 +210,8 @@ def read_file_spark(file_path, file_type, **kwargs):
                 if isinstance(names, list):
                     if not renamed:
                         df = df.selectExpr(
-                                *["`%s` as `%s`" % (col, name) for col, name in zip(cols, names)]
-                            )
+                            *["`%s` as `%s`" % (col, name) for col, name in zip(cols, names)]
+                        )
                         # update index map after rename
                         for index, col in index_map.items():
                             if col in cols:

--- a/pyzoo/zoo/orca/data/pandas/preprocessing.py
+++ b/pyzoo/zoo/orca/data/pandas/preprocessing.py
@@ -148,25 +148,47 @@ def read_file_spark(file_path, file_type, **kwargs):
             df = spark.read.json(file_paths, **kwargs)
 
         # Handle pandas-compatible postprocessing arguments
+        if usecols is not None and not callable(usecols):
+            usecols = list(usecols)
+        renamed = False
         if isinstance(names, list):
             if len(set(names)) != len(names):
                 raise ValueError("Found duplicate names, please check your names input")
-            if len(names) != len(df.schema):
-                raise ValueError(
-                    "The number of names [%s] does not match the number "
-                    "of columns [%d]. Try names by a Spark SQL DDL-formatted "
-                    "string." % (len(names), len(df.schema))
+            if usecols is not None:
+                if not callable(usecols):
+                    # usecols is list
+                    if len(names) != len(usecols) and len(names) != len(df.schema):
+                        raise ValueError(
+                            "Passed names did not match usecols"
+                        )
+                if len(names) == len(df.schema):
+                    df = df.selectExpr(
+                        *["`%s` as `%s`" % (field.name, name) for field, name in zip(df.schema, names)]
+                    )
+                    renamed = True
+
+            else:
+                if len(names) != len(df.schema):
+                    raise ValueError(
+                            "The number of names [%s] does not match the number "
+                            "of columns [%d]. Try names by a Spark SQL DDL-formatted "
+                            "string." % (len(names), len(df.schema))
+                    )
+                df = df.selectExpr(
+                        *["`%s` as `%s`" % (field.name, name) for field, name in zip(df.schema, names)]
                 )
-            df = df.selectExpr(
-                *["`%s` as `%s`" % (field.name, name) for field, name in zip(df.schema, names)]
-            )
-        if usecols is not None and not callable(usecols):
-            usecols = list(usecols)
+                renamed = True
+        index_map = {}
         if usecols is not None:
             if callable(usecols):
                 cols = [field.name for field in df.schema if usecols(field.name)]
                 missing = []
             elif all(isinstance(col, int) for col in usecols):
+                new_index = 0
+                for i, field in enumerate(df.schema):
+                    if i in usecols:
+                        index_map[i] = new_index
+                        new_index += 1
                 cols = [field.name for i, field in enumerate(df.schema) if i in usecols]
                 missing = [
                     col
@@ -175,7 +197,10 @@ def read_file_spark(file_path, file_type, **kwargs):
                 ]
             elif all(isinstance(col, str) for col in usecols):
                 cols = [field.name for field in df.schema if field.name in usecols]
-                missing = [col for col in usecols if col not in cols]
+                if isinstance(names, list):
+                    missing = [c for c in usecols if c not in names]
+                else:
+                    missing = [col for col in usecols if col not in cols]
             else:
                 raise ValueError(
                     "usecols must only be list-like of all strings, "
@@ -183,16 +208,13 @@ def read_file_spark(file_path, file_type, **kwargs):
             if len(missing) > 0:
                 raise ValueError(
                     "usecols do not match columns, columns expected but not found: %s" % missing)
-
             if len(cols) > 0:
                 df = df.select(cols)
-        if dtype is not None:
-            if isinstance(dtype, dict):
-                for col, type in dtype.items():
-                    df = df.withColumn(col, df[col].astype(type))
-            else:
-                for col in df.columns:
-                    df = df.withColumn(col, df[col].astype(dtype))
+                if isinstance(names, list):
+                    if not renamed:
+                        df = df.selectExpr(
+                                *["`%s` as `%s`" % (col, name) for col, name in zip(cols, names)]
+                            )
 
         if df.rdd.getNumPartitions() < node_num:
             df = df.repartition(node_num)
@@ -202,10 +224,20 @@ def read_file_spark(file_path, file_type, **kwargs):
                 import pandas as pd
                 data = list(iter)
                 pd_df = pd.DataFrame(data, columns=columns)
+                if dtype is not None:
+                    if isinstance(dtype, dict):
+                        for col, type in dtype.items():
+                            if isinstance(col, str):
+                                pd_df[col] = pd_df[col].astype(type)
+                            elif isinstance(col, int):
+                                pd_df.iloc[:, index_map[col]] = pd_df.iloc[:, index_map[col]].astype(type)
+                    else:
+                        pd_df = pd_df.astype(dtype)
                 if squeeze and len(pd_df.columns) == 1:
                     pd_df = pd_df.iloc[:, 0]
                 if index_col:
                     pd_df = pd_df.set_index(index_col)
+
                 return [pd_df]
 
             return f


### PR DESCRIPTION
Support read_csv/read_json with 'names' of partial columns. If 'names' is not for all columns, it should be of the same length of 'usecols'.
Change 'dtype' type conversion from spark dataframe to pandas dataframe in mapPartitions to support numpy types.
Related issue: https://github.com/intel-analytics/analytics-zoo/issues/2569
Tested on mastercard code.

