### PR TITLE
Add OrcaContext and make spark default read file backend

### DIFF
--- a/pyzoo/test/zoo/orca/data/conftest.py
+++ b/pyzoo/test/zoo/orca/data/conftest.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 import os
-from zoo import ZooContext
+from zoo.orca import OrcaContext
 
 import pytest
 
@@ -26,7 +26,7 @@ ray_ctx = None
 def orca_data_fixture():
     from zoo import init_spark_on_local
     from zoo.ray import RayContext
-    ZooContext._orca_eager_mode = True
+    OrcaContext.orca_eager_mode = True
     sc = init_spark_on_local(cores=4, spark_log_level="INFO")
     access_key_id = os.getenv("AWS_ACCESS_KEY_ID")
     secret_access_key = os.getenv("AWS_SECRET_ACCESS_KEY")

--- a/pyzoo/test/zoo/orca/data/conftest.py
+++ b/pyzoo/test/zoo/orca/data/conftest.py
@@ -26,7 +26,7 @@ ray_ctx = None
 def orca_data_fixture():
     from zoo import init_spark_on_local
     from zoo.ray import RayContext
-    OrcaContext.orca_eager_mode = True
+    OrcaContext._eager_mode = True
     sc = init_spark_on_local(cores=4, spark_log_level="INFO")
     access_key_id = os.getenv("AWS_ACCESS_KEY_ID")
     secret_access_key = os.getenv("AWS_SECRET_ACCESS_KEY")

--- a/pyzoo/test/zoo/orca/data/test_pandas_backend.py
+++ b/pyzoo/test/zoo/orca/data/test_pandas_backend.py
@@ -30,10 +30,10 @@ from zoo.common.nncontext import *
 class TestSparkXShards(TestCase):
     def setup_method(self, method):
         self.resource_path = os.path.join(os.path.split(__file__)[0], "../../resources")
-        OrcaContext.orca_pandas_read_backend = "pandas"
+        OrcaContext.pandas_read_backend = "pandas"
 
     def tearDown(self):
-        OrcaContext.orca_pandas_read_backend = "spark"
+        OrcaContext.pandas_read_backend = "spark"
 
     def test_read_local_csv(self):
         file_path = os.path.join(self.resource_path, "orca/data/csv")

--- a/pyzoo/test/zoo/orca/data/test_pandas_backend.py
+++ b/pyzoo/test/zoo/orca/data/test_pandas_backend.py
@@ -22,6 +22,7 @@ from unittest import TestCase
 
 import zoo.orca.data
 import zoo.orca.data.pandas
+from zoo.orca import OrcaContext
 from zoo.orca.data import SharedValue
 from zoo.common.nncontext import *
 
@@ -29,6 +30,10 @@ from zoo.common.nncontext import *
 class TestSparkXShards(TestCase):
     def setup_method(self, method):
         self.resource_path = os.path.join(os.path.split(__file__)[0], "../../resources")
+        OrcaContext.orca_pandas_read_backend = "pandas"
+
+    def tearDown(self):
+        OrcaContext.orca_pandas_read_backend = "spark"
 
     def test_read_local_csv(self):
         file_path = os.path.join(self.resource_path, "orca/data/csv")
@@ -48,7 +53,6 @@ class TestSparkXShards(TestCase):
         self.assertTrue('Error tokenizing data' in str(context.exception))
 
     def test_read_local_json(self):
-        ZooContext.orca_pandas_read_backend = "pandas"
         file_path = os.path.join(self.resource_path, "orca/data/json")
         data_shard = zoo.orca.data.pandas.read_json(file_path, orient='columns', lines=True)
         data = data_shard.collect()

--- a/pyzoo/test/zoo/orca/data/test_spark_backend.py
+++ b/pyzoo/test/zoo/orca/data/test_spark_backend.py
@@ -26,10 +26,6 @@ from zoo.common.nncontext import *
 class TestSparkBackend(TestCase):
     def setup_method(self, method):
         self.resource_path = os.path.join(os.path.split(__file__)[0], "../../resources")
-        ZooContext.orca_pandas_read_backend = "spark"
-
-    def tearDown(self):
-        ZooContext.orca_pandas_read_backend = "pandas"
 
     def test_header_and_names(self):
         file_path = os.path.join(self.resource_path, "orca/data/csv")

--- a/pyzoo/test/zoo/orca/learn/ray/mxnet/test_mxnet_spark_xshards.py
+++ b/pyzoo/test/zoo/orca/learn/ray/mxnet/test_mxnet_spark_xshards.py
@@ -22,6 +22,7 @@ import numpy as np
 import mxnet as mx
 from mxnet import gluon
 from mxnet.gluon import nn
+from zoo.orca import OrcaContext
 import zoo.orca.data.pandas
 from zoo.orca.learn.mxnet import Estimator, create_config
 
@@ -81,6 +82,13 @@ def get_gluon_model(config):
 
 
 class TestMXNetSparkXShards(TestCase):
+    def setup_method(self, method):
+        self.resource_path = os.path.join(os.path.split(__file__)[0], "../../resources")
+        OrcaContext.pandas_read_backend = "pandas"
+
+    def tearDown(self):
+        OrcaContext.pandas_read_backend = "spark"
+
     def test_xshards_symbol_with_val(self):
         resource_path = os.path.join(os.path.split(__file__)[0], "../../../../resources")
         train_file_path = os.path.join(resource_path, "orca/learn/single_input_json/train")

--- a/pyzoo/test/zoo/zouwu/test_model_forecast.py
+++ b/pyzoo/test/zoo/zouwu/test_model_forecast.py
@@ -183,8 +183,10 @@ class TestZouwuModelForecast(ZooTestCase):
 
     def test_forecast_tcmf_xshards(self):
         from zoo.zouwu.model.forecast import TCMFForecaster
+        from zoo.orca import OrcaContext
         import zoo.orca.data.pandas
         import tempfile
+        OrcaContext.pandas_read_backend = "pandas"
 
         def preprocessing(df, id_name, y_name):
             id = df.index
@@ -259,6 +261,7 @@ class TestZouwuModelForecast(ZooTestCase):
         final_df = pd.concat(final_df_list)
         final_df.sort_values("datetime", inplace=True)
         assert final_df.shape == (300 * horizon, 3)
+        OrcaContext.pandas_read_backend = "spark"
 
 
 if __name__ == "__main__":

--- a/pyzoo/zoo/common/nncontext.py
+++ b/pyzoo/zoo/common/nncontext.py
@@ -117,30 +117,17 @@ def init_spark_on_yarn(hadoop_conf,
     return sc
 
 
-class ZooContextMeta(type):
-
-    _log_output = False
+class ZooContext:
 
     @property
-    def log_output(cls):
-        """
-        Whether to redirect Spark driver JVM's stdout and stderr to the current
-        python process. This is useful when running Analytics Zoo in jupyter notebook.
-        Default to False. Needs to be set before initializing SparkContext.
-        """
-        return cls._log_output
+    def log_output(self):
+        from zoo.orca import OrcaContext
+        return OrcaContext.log_output
 
-    @log_output.setter
-    def log_output(cls, value):
-        if SparkContext._active_spark_context is not None:
-            raise AttributeError("log_output cannot be set after SparkContext is created."
-                                 " Please set it before init_nncontext, init_spark_on_local"
-                                 "or init_spark_on_yarn")
-        cls._log_output = value
-
-
-class ZooContext(metaclass=ZooContextMeta):
-    pass
+    @staticmethod
+    def log_output(value):
+        from zoo.orca import OrcaContext
+        OrcaContext.log_output = value
 
 
 # The following function copied from

--- a/pyzoo/zoo/common/nncontext.py
+++ b/pyzoo/zoo/common/nncontext.py
@@ -120,8 +120,6 @@ def init_spark_on_yarn(hadoop_conf,
 class ZooContextMeta(type):
 
     _log_output = False
-    __orca_eager_mode = True
-    _orca_pandas_read_backend = "pandas"
 
     @property
     def log_output(cls):
@@ -139,36 +137,6 @@ class ZooContextMeta(type):
                                  " Please set it before init_nncontext, init_spark_on_local"
                                  "or init_spark_on_yarn")
         cls._log_output = value
-
-    @property
-    def _orca_eager_mode(cls):
-        """
-        Default to True. Needs to be set before initializing SparkContext.
-        """
-        return cls.__orca_eager_mode
-
-    @_orca_eager_mode.setter
-    def _orca_eager_mode(cls, value):
-        if SparkContext._active_spark_context is not None:
-            raise AttributeError("orca_eager_mode cannot be set after SparkContext is created."
-                                 " Please set it before init_nncontext, init_spark_on_local"
-                                 "or init_spark_on_yarn")
-        cls.__orca_eager_mode = value
-
-    @property
-    def orca_pandas_read_backend(cls):
-        """
-        The backend for reading csv/json files. Either "spark" or "pandas".
-        spark backend would call spark.read and pandas backend would call pandas.read.
-        """
-        return cls._orca_pandas_read_backend
-
-    @orca_pandas_read_backend.setter
-    def orca_pandas_read_backend(cls, value):
-        value = value.lower()
-        assert value == "spark" or value == "pandas", \
-            "orca_pandas_read_backend must be either spark or pandas"
-        cls._orca_pandas_read_backend = value
 
 
 class ZooContext(metaclass=ZooContextMeta):

--- a/pyzoo/zoo/common/nncontext.py
+++ b/pyzoo/zoo/common/nncontext.py
@@ -117,19 +117,6 @@ def init_spark_on_yarn(hadoop_conf,
     return sc
 
 
-class ZooContext:
-
-    @property
-    def log_output(self):
-        from zoo.orca import OrcaContext
-        return OrcaContext.log_output
-
-    @staticmethod
-    def log_output(value):
-        from zoo.orca import OrcaContext
-        OrcaContext.log_output = value
-
-
 # The following function copied from
 # https://github.com/Valassis-Digital-Media/spylon-kernel/blob/master/
 # spylon_kernel/scala_interpreter.py
@@ -168,7 +155,8 @@ def init_nncontext(conf=None, redirect_spark_log=True):
     # The following code copied and modified from
     # https://github.com/Valassis-Digital-Media/spylon-kernel/blob/master/
     # spylon_kernel/scala_interpreter.py
-    if ZooContext.log_output:
+    from zoo.orca import OrcaContext
+    if OrcaContext.log_output:
         import subprocess
         import pyspark.java_gateway
         spark_jvm_proc = None
@@ -196,7 +184,7 @@ def init_nncontext(conf=None, redirect_spark_log=True):
     else:
         sc = getOrCreateSparkContext(conf=conf)
 
-    if ZooContext.log_output:
+    if OrcaContext.log_output:
         if spark_jvm_proc.stdout is not None:
             stdout_reader = threading.Thread(target=_read_stream,
                                              daemon=True,

--- a/pyzoo/zoo/orca/__init__.py
+++ b/pyzoo/zoo/orca/__init__.py
@@ -13,3 +13,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from .common import OrcaContext

--- a/pyzoo/zoo/orca/common.py
+++ b/pyzoo/zoo/orca/common.py
@@ -1,0 +1,54 @@
+#
+# Copyright 2018 Analytics Zoo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+class OrcaContextMeta(type):
+
+    _orca_eager_mode = True
+    _orca_pandas_read_backend = "spark"
+
+    @property
+    def orca_eager_mode(cls):
+        """
+        Whether to compute eagerly for SparkXShards.
+        Default to be True.
+        """
+        return cls._orca_eager_mode
+
+    @orca_eager_mode.setter
+    def orca_eager_mode(cls, value):
+        assert isinstance(value, bool), "orca_eager_mode should either be True or False"
+        cls._orca_eager_mode = value
+
+    @property
+    def orca_pandas_read_backend(cls):
+        """
+        The backend for reading csv/json files. Either "spark" or "pandas".
+        spark backend would call spark.read and pandas backend would call pandas.read.
+        Default to be "spark".
+        """
+        return cls._orca_pandas_read_backend
+
+    @orca_pandas_read_backend.setter
+    def orca_pandas_read_backend(cls, value):
+        value = value.lower()
+        assert value == "spark" or value == "pandas", \
+            "orca_pandas_read_backend must be either spark or pandas"
+        cls._orca_pandas_read_backend = value
+
+
+class OrcaContext(metaclass=OrcaContextMeta):
+    pass

--- a/pyzoo/zoo/orca/common.py
+++ b/pyzoo/zoo/orca/common.py
@@ -14,12 +14,11 @@
 # limitations under the License.
 #
 
-from pyspark import SparkContext
+from zoo import ZooContext
 
 
 class OrcaContextMeta(type):
 
-    _log_output = False
     _pandas_read_backend = "spark"
     __eager_mode = True
 
@@ -30,16 +29,11 @@ class OrcaContextMeta(type):
         python process. This is useful when running Analytics Zoo in jupyter notebook.
         Default to be False. Needs to be set before initializing SparkContext.
         """
-        return cls._log_output
+        return ZooContext.log_output
 
     @log_output.setter
     def log_output(cls, value):
-        if SparkContext._active_spark_context is not None:
-            raise AttributeError("log_output cannot be set after SparkContext is created."
-                                 " Please set it before init_nncontext, init_spark_on_local"
-                                 "or init_spark_on_yarn")
-        assert isinstance(value, bool), "log_output should either be True or False"
-        cls._log_output = value
+        ZooContext.log_output = value
 
     @property
     def pandas_read_backend(cls):

--- a/pyzoo/zoo/orca/common.py
+++ b/pyzoo/zoo/orca/common.py
@@ -17,37 +17,37 @@
 
 class OrcaContextMeta(type):
 
-    _orca_eager_mode = True
-    _orca_pandas_read_backend = "spark"
+    _pandas_read_backend = "spark"
+    __eager_mode = True
 
     @property
-    def orca_eager_mode(cls):
+    def _eager_mode(cls):
         """
         Whether to compute eagerly for SparkXShards.
         Default to be True.
         """
-        return cls._orca_eager_mode
+        return cls.__eager_mode
 
-    @orca_eager_mode.setter
-    def orca_eager_mode(cls, value):
-        assert isinstance(value, bool), "orca_eager_mode should either be True or False"
-        cls._orca_eager_mode = value
+    @_eager_mode.setter
+    def _eager_mode(cls, value):
+        assert isinstance(value, bool), "_eager_mode should either be True or False"
+        cls.__eager_mode = value
 
     @property
-    def orca_pandas_read_backend(cls):
+    def pandas_read_backend(cls):
         """
         The backend for reading csv/json files. Either "spark" or "pandas".
         spark backend would call spark.read and pandas backend would call pandas.read.
         Default to be "spark".
         """
-        return cls._orca_pandas_read_backend
+        return cls._pandas_read_backend
 
-    @orca_pandas_read_backend.setter
-    def orca_pandas_read_backend(cls, value):
+    @pandas_read_backend.setter
+    def pandas_read_backend(cls, value):
         value = value.lower()
         assert value == "spark" or value == "pandas", \
-            "orca_pandas_read_backend must be either spark or pandas"
-        cls._orca_pandas_read_backend = value
+            "pandas_read_backend must be either spark or pandas"
+        cls._pandas_read_backend = value
 
 
 class OrcaContext(metaclass=OrcaContextMeta):

--- a/pyzoo/zoo/orca/data/pandas/preprocessing.py
+++ b/pyzoo/zoo/orca/data/pandas/preprocessing.py
@@ -15,7 +15,8 @@
 #
 
 from bigdl.util.common import get_node_and_core_number
-from zoo import init_nncontext, ZooContext
+from zoo import init_nncontext
+from zoo.orca import OrcaContext
 from zoo.orca.data import SparkXShards
 from zoo.orca.data.utils import *
 
@@ -48,7 +49,7 @@ def read_file_spark(file_path, file_type, **kwargs):
     sc = init_nncontext()
     node_num, core_num = get_node_and_core_number()
 
-    if ZooContext.orca_pandas_read_backend == "pandas":
+    if OrcaContext.orca_pandas_read_backend == "pandas":
         file_url_splits = file_path.split("://")
         prefix = file_url_splits[0]
 

--- a/pyzoo/zoo/orca/data/pandas/preprocessing.py
+++ b/pyzoo/zoo/orca/data/pandas/preprocessing.py
@@ -258,8 +258,8 @@ def read_file_spark(file_path, file_type, **kwargs):
         data_shards = SparkXShards(pd_rdd)
     except Exception as e:
         alternative_backend = "pandas" if backend == "spark" else "spark"
-        print("An error occurred when reading files with '%s' backend, you may switch to '%s' backend "
-              "for another try. You can set the backend using "
+        print("An error occurred when reading files with '%s' backend, you may switch to '%s' "
+              "backend for another try. You can set the backend using "
               "OrcaContext.pandas_read_backend" % (backend, alternative_backend))
         raise e
     return data_shards

--- a/pyzoo/zoo/orca/data/pandas/preprocessing.py
+++ b/pyzoo/zoo/orca/data/pandas/preprocessing.py
@@ -259,6 +259,7 @@ def read_file_spark(file_path, file_type, **kwargs):
     except Exception as e:
         alternative_backend = "pandas" if backend == "spark" else "spark"
         print("An error occurred when reading files with '%s' backend, you may switch '%s' backend "
-              "to have another try" % (backend, alternative_backend))
+              "to have another try. You can set the backend using "
+              "OrcaContext.orca_pandas_read_backend" % (backend, alternative_backend))
         raise e
     return data_shards

--- a/pyzoo/zoo/orca/data/pandas/preprocessing.py
+++ b/pyzoo/zoo/orca/data/pandas/preprocessing.py
@@ -48,7 +48,7 @@ def read_json(file_path, **kwargs):
 def read_file_spark(file_path, file_type, **kwargs):
     sc = init_nncontext()
     node_num, core_num = get_node_and_core_number()
-    backend = OrcaContext.orca_pandas_read_backend
+    backend = OrcaContext.pandas_read_backend
 
     if backend == "pandas":
         file_url_splits = file_path.split("://")
@@ -258,8 +258,8 @@ def read_file_spark(file_path, file_type, **kwargs):
         data_shards = SparkXShards(pd_rdd)
     except Exception as e:
         alternative_backend = "pandas" if backend == "spark" else "spark"
-        print("An error occurred when reading files with '%s' backend, you may switch '%s' backend "
-              "to have another try. You can set the backend using "
-              "OrcaContext.orca_pandas_read_backend" % (backend, alternative_backend))
+        print("An error occurred when reading files with '%s' backend, you may switch to '%s' backend "
+              "for another try. You can set the backend using "
+              "OrcaContext.pandas_read_backend" % (backend, alternative_backend))
         raise e
     return data_shards

--- a/pyzoo/zoo/orca/data/shard.py
+++ b/pyzoo/zoo/orca/data/shard.py
@@ -16,8 +16,8 @@
 from py4j.protocol import Py4JError
 
 from zoo.orca.data.utils import *
+from zoo.orca import OrcaContext
 from zoo.common.nncontext import init_nncontext
-from zoo import ZooContext
 
 
 class XShards(object):
@@ -137,7 +137,7 @@ class SparkXShards(XShards):
         if transient:
             self.eager = False
         else:
-            self.eager = ZooContext._orca_eager_mode
+            self.eager = OrcaContext.orca_eager_mode
             self.rdd.cache()
         if self.eager:
             self.compute()

--- a/pyzoo/zoo/orca/data/shard.py
+++ b/pyzoo/zoo/orca/data/shard.py
@@ -137,7 +137,7 @@ class SparkXShards(XShards):
         if transient:
             self.eager = False
         else:
-            self.eager = OrcaContext.orca_eager_mode
+            self.eager = OrcaContext._eager_mode
             self.rdd.cache()
         if self.eager:
             self.compute()


### PR DESCRIPTION
- Move properties to OrcaContext.
@jason-dai Since log_output is used in init_nncontext, it can't be moved to OrcaContext?
- Make spark the default backend for reading csv/json files.
- When error occurs, add a message to hint users to switch backend.