### PR TITLE
Update PythonFeatureSet.scala

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/python/PythonFeatureSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/python/PythonFeatureSet.scala
@@ -41,6 +41,7 @@ object PythonFeatureSet {
   def ofDouble(): PythonFeatureSet[Double] = new PythonFeatureSet[Double]()
 }
 
+@SerialVersionUID(7610684191490849169L)
 class PythonFeatureSet[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonZoo[T] {
   def createFeatureSetFromImageFrame(
         imageFrame: ImageFrame,


### PR DESCRIPTION
Assign a fixed PythonFeatureSet's Serial Version UID to fix the incompatible UID exception