### PR TITLE
Fix Spark configurations in RayContext

### DIFF
--- a/pyzoo/test/zoo/ray/test_ray_on_local.py
+++ b/pyzoo/test/zoo/ray/test_ray_on_local.py
@@ -31,8 +31,8 @@ class TestRayLocal(TestCase):
                 import socket
                 return socket.gethostname()
 
-        sc = init_spark_on_local(cores=4)
-        ray_ctx = RayContext(sc=sc, object_store_memory="1g")
+        sc = init_spark_on_local(cores=8)
+        ray_ctx = RayContext(sc=sc, object_store_memory="1g", ray_node_cpu_cores=4)
         address_info = ray_ctx.init()
         assert "object_store_address" in address_info
         actors = [TestRay.remote() for i in range(0, 4)]

--- a/pyzoo/zoo/ray/raycontext.py
+++ b/pyzoo/zoo/ray/raycontext.py
@@ -204,7 +204,7 @@ class RayContext(object):
 
         - For Spark local mode: The total available cores for Ray is equal to the number of
         Spark local cores.
-        - For Spark cluster mode: The number of raylets to be created is equal to number of
+        - For Spark cluster mode: The number of raylets to be created is equal to the number of
         Spark executors. The number of cores allocated for each raylet is equal to number of
         Spark executor cores.
         You are allowed to specify num_ray_nodes and ray_node_cpu_cores for configurations
@@ -251,8 +251,8 @@ class RayContext(object):
             if ray_node_cpu_cores:
                 ray_node_cpu_cores = int(ray_node_cpu_cores)
                 if ray_node_cpu_cores > spark_cores:
-                    warnings.warn("ray_node_cpu_cores is larger than available Spark cores, make sure "
-                                  "there are enough resources on your machine")
+                    warnings.warn("ray_node_cpu_cores is larger than available Spark cores, "
+                                  "make sure there are enough resources on your machine")
                 self.ray_node_cpu_cores = ray_node_cpu_cores
             else:
                 self.ray_node_cpu_cores = spark_cores
@@ -267,8 +267,8 @@ class RayContext(object):
             if ray_node_cpu_cores:
                 ray_node_cpu_cores = int(ray_node_cpu_cores)
                 if executor_cores and ray_node_cpu_cores > executor_cores:
-                    warnings.warn("ray_node_cpu_cores is larger than Spark executor cores, make sure "
-                                  "there are enough resources on your cluster")
+                    warnings.warn("ray_node_cpu_cores is larger than Spark executor cores, "
+                                  "make sure there are enough resources on your cluster")
                 self.ray_node_cpu_cores = ray_node_cpu_cores
             elif executor_cores:
                 self.ray_node_cpu_cores = executor_cores
@@ -287,8 +287,8 @@ class RayContext(object):
             if num_ray_nodes:
                 num_ray_nodes = int(num_ray_nodes)
                 if num_executors and num_ray_nodes > num_executors:
-                    warnings.warn("num_ray_nodes is larger than the number of Spark executors, make sure "
-                                  "there are enough resources on your cluster")
+                    warnings.warn("num_ray_nodes is larger than the number of Spark executors, "
+                                  "make sure there are enough resources on your cluster")
                 self.num_ray_nodes = num_ray_nodes
             elif num_executors:
                 self.num_ray_nodes = num_executors

--- a/pyzoo/zoo/ray/raycontext.py
+++ b/pyzoo/zoo/ray/raycontext.py
@@ -205,7 +205,7 @@ class RayContext(object):
         - For Spark local mode: The total available cores for Ray is equal to the number of
         Spark local cores.
         - For Spark cluster mode: The number of raylets to be created is equal to the number of
-        Spark executors. The number of cores allocated for each raylet is equal to number of
+        Spark executors. The number of cores allocated for each raylet is equal to the number of
         Spark executor cores.
         You are allowed to specify num_ray_nodes and ray_node_cpu_cores for configurations
         to start raylets.

--- a/pyzoo/zoo/ray/raycontext.py
+++ b/pyzoo/zoo/ray/raycontext.py
@@ -206,7 +206,7 @@ class RayContext(object):
         Spark local cores.
         - For Spark cluster mode: The number of raylets to be created is equal to the number of
         Spark executors. The number of cores allocated for each raylet is equal to the number of
-        Spark executor cores.
+        cores for each Spark executor.
         You are allowed to specify num_ray_nodes and ray_node_cpu_cores for configurations
         to start raylets.
 
@@ -229,10 +229,11 @@ class RayContext(object):
         Spark executors to make sure there are enough resources in your cluster.
         :param ray_node_cpu_cores: The number of available cores for each raylet.
         For Spark local mode, it is default to be the number of Spark local cores.
-        For Spark cluster mode, it is default to be the number of Spark executor cores. If
+        For Spark cluster mode, it is default to be the number of cores for each Spark executor. If
         spark.executor.cores or spark.cores.max can't be detected in your SparkContext, you need to
         explicitly specify this. It is recommended that ray_node_cpu_cores is not larger than the
-        number of Spark executor cores to make sure there are enough resources in your cluster.
+        number of cores for each Spark executor to make sure there are enough resources in your
+        cluster.
         """
         assert sc is not None, "sc cannot be None, please create a SparkContext first"
         self.sc = sc


### PR DESCRIPTION
Fix https://github.com/intel-analytics/analytics-zoo/issues/2594

num of executors and executor cores may not be detected in spark conf; allow users to input manually.