### PR TITLE
update http to add pass secret and salt to cluster serving

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/FrontEndApp.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/FrontEndApp.scala
@@ -137,9 +137,8 @@ object FrontEndApp extends Supportive with EncryptSupportive {
             }).toList
             complete(jacksonJsonSerializer.serialize(servingMetrics))
           }
-        } ~(path("model-secure") & parameters('secret.as[String], 'salt.as[String])) {
+        } ~ (path("model-secure") & parameters('secret.as[String], 'salt.as[String])) {
           (secret, salt) => {
-            println(secret, salt)
             try {
               val dycryptSecret = decryptWithAES256(secret, Conventions.INTERNAL_SECRET,
                 Conventions.INTERNAL_SALT)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/actors.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/actors.scala
@@ -28,6 +28,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration.DurationInt
 import akka.pattern.ask
 import akka.util.Timeout
+import com.intel.analytics.zoo.serving.utils.Conventions
 
 trait JedisEnabledActor extends Actor with Supportive {
   val actorName = self.path.name
@@ -95,6 +96,12 @@ class RedisPutActor(
             start = System.currentTimeMillis()
           }
         }
+      }
+    case message: SecuredModelSecretSaltMessage =>
+      silent(s"$actorName put secret and salt in redis")() {
+        jedis.hset(Conventions.MODEL_SECURED_KEY, Conventions.MODEL_SECURED_SECRET, message.secret)
+        jedis.hset(Conventions.MODEL_SECURED_KEY, Conventions.MODEL_SECURED_SALT, message.salt)
+        sender() ! true
       }
   }
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/domains.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/domains.scala
@@ -44,6 +44,8 @@ case class PredictionInputFlushMessage() extends ServingMessage
 
 case class PredictionQueryMessage(ids: Seq[String]) extends ServingMessage
 
+case class SecuredModelSecretSaltMessage(secret: String, salt: String) extends ServingMessage
+
 case class PredictionQueryWithTargetMessage(query: PredictionQueryMessage, target: ActorRef)
   extends ServingMessage
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/utils/Conventions.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/utils/Conventions.scala
@@ -31,7 +31,4 @@ object Conventions {
   val MODEL_SECURED_KEY = "model_secured"
   val MODEL_SECURED_SECRET = "secret"
   val MODEL_SECURED_SALT = "salt"
-
-  val INTERNAL_SECRET = "1234qwer"
-  val INTERNAL_SALT = "intel-analytics-zoo"
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/utils/Conventions.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/utils/Conventions.scala
@@ -31,4 +31,7 @@ object Conventions {
   val MODEL_SECURED_KEY = "model_secured"
   val MODEL_SECURED_SECRET = "secret"
   val MODEL_SECURED_SALT = "salt"
+
+  val INTERNAL_SECRET = "1234qwer"
+  val INTERNAL_SALT = "intel-analytics-zoo"
 }


### PR DESCRIPTION
update http to add pass secret and salt to cluster serving
user can put secret and salt to redis without redis-cli

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-analytics/analytics-zoo/2747)
<!-- Reviewable:end -->
