### PR TITLE
Orca add read_parquet support

### DIFF
--- a/pyzoo/test/zoo/orca/data/test_spark_backend.py
+++ b/pyzoo/test/zoo/orca/data/test_spark_backend.py
@@ -185,6 +185,5 @@ class TestSparkBackend(TestCase):
         shutil.rmtree(temp)
 
 
-
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/pyzoo/test/zoo/orca/data/test_spark_backend.py
+++ b/pyzoo/test/zoo/orca/data/test_spark_backend.py
@@ -17,6 +17,7 @@
 import os.path
 import pytest
 from unittest import TestCase
+import shutil
 
 import zoo.orca.data
 import zoo.orca.data.pandas
@@ -164,6 +165,25 @@ class TestSparkBackend(TestCase):
         data = data_shard.collect()
         df4 = data[0]
         assert df4.value.dtype == "float64"
+
+    def test_read_parquet(self):
+        file_path = os.path.join(self.resource_path, "orca/data/csv")
+        sc = init_nncontext()
+        from pyspark.sql import SQLContext
+        from pyspark.sql.functions import col
+        sqlContext = SQLContext.getOrCreate(sc)
+        spark = sqlContext.sparkSession
+        df = spark.read.csv(file_path, header=True)
+        df = df.withColumn('sale_price', col('sale_price').cast('int'))
+        temp = tempfile.mkdtemp()
+        df.write.parquet(os.path.join(temp, "test_parquet"))
+        data_shard2 = zoo.orca.data.pandas.read_parquet(os.path.join(temp, "test_parquet"))
+        data = data_shard2.collect()
+        assert len(data) == 2, "number of shard should be 2"
+        df = data[0]
+        assert "location" in df.columns
+        shutil.rmtree(temp)
+
 
 
 if __name__ == "__main__":

--- a/pyzoo/test/zoo/orca/learn/spark/test_estimator_keras_for_spark.py
+++ b/pyzoo/test/zoo/orca/learn/spark/test_estimator_keras_for_spark.py
@@ -438,6 +438,7 @@ class TestEstimatorForKeras(TestCase):
         data_shard = data_shard.transform_shard(transform)
         predictions = est.predict(data_shard).collect()
         assert predictions[0]['prediction'].shape[1] == 2
+        shutil.rmtree(temp)
 
 
 if __name__ == "__main__":

--- a/pyzoo/zoo/orca/data/pandas/__init__.py
+++ b/pyzoo/zoo/orca/data/pandas/__init__.py
@@ -16,3 +16,4 @@
 
 from zoo.orca.data.pandas.preprocessing import read_csv
 from zoo.orca.data.pandas.preprocessing import read_json
+from zoo.orca.data.pandas.preprocessing import read_parquet

--- a/pyzoo/zoo/orca/data/pandas/preprocessing.py
+++ b/pyzoo/zoo/orca/data/pandas/preprocessing.py
@@ -263,3 +263,39 @@ def read_file_spark(file_path, file_type, **kwargs):
               "OrcaContext.pandas_read_backend" % (backend, alternative_backend))
         raise e
     return data_shards
+
+
+def read_parquet(file_path,):
+    """
+    Read parquet files to SparkXShards of pandas DataFrames.
+
+    :param file_path: Parquet file path, a list of multiple parquet file paths, or a directory
+    containing parquet files. Local file system, HDFS, and AWS S3 are supported.
+    :return: An instance of SparkXShards.
+    """
+    sc = init_nncontext()
+    node_num, core_num = get_node_and_core_number()
+    from pyspark.sql import SQLContext
+    sqlContext = SQLContext.getOrCreate(sc)
+    spark = sqlContext.sparkSession
+    df = spark.read.parquet(file_path)
+    if df.rdd.getNumPartitions() < node_num:
+        df = df.repartition(node_num)
+
+    def to_pandas(columns):
+        def f(iter):
+            import pandas as pd
+            data = list(iter)
+            pd_df = pd.DataFrame(data, columns=columns)
+            return [pd_df]
+
+        return f
+
+    pd_rdd = df.rdd.mapPartitions(to_pandas(df.columns))
+    try:
+        data_shards = SparkXShards(pd_rdd)
+    except Exception as e:
+        print("An error occurred when reading parquet files")
+        raise e
+    return data_shards
+

--- a/pyzoo/zoo/orca/data/pandas/preprocessing.py
+++ b/pyzoo/zoo/orca/data/pandas/preprocessing.py
@@ -298,4 +298,3 @@ def read_parquet(file_path,):
         print("An error occurred when reading parquet files")
         raise e
     return data_shards
-


### PR DESCRIPTION
Read parquet files and return xshards of Pandas dataframe.
Related issue: https://github.com/analytics-zoo/orca/issues/65