### PR TITLE
Add columns and repartition parameter in read_parquet

### DIFF
--- a/pyzoo/test/zoo/orca/data/test_spark_backend.py
+++ b/pyzoo/test/zoo/orca/data/test_spark_backend.py
@@ -178,10 +178,17 @@ class TestSparkBackend(TestCase):
         temp = tempfile.mkdtemp()
         df.write.parquet(os.path.join(temp, "test_parquet"))
         data_shard2 = zoo.orca.data.pandas.read_parquet(os.path.join(temp, "test_parquet"))
+        assert data_shard2.num_partitions() == 2, "number of shard should be 2"
         data = data_shard2.collect()
-        assert len(data) == 2, "number of shard should be 2"
         df = data[0]
         assert "location" in df.columns
+
+        data_shard2 = zoo.orca.data.pandas.read_parquet(os.path.join(temp, "test_parquet"),
+                                                        columns=['ID', 'sale_price'])
+        data = data_shard2.collect()
+        df = data[0]
+        assert len(df.columns) == 2
+
         shutil.rmtree(temp)
 
 

--- a/pyzoo/zoo/orca/data/pandas/preprocessing.py
+++ b/pyzoo/zoo/orca/data/pandas/preprocessing.py
@@ -265,28 +265,22 @@ def read_file_spark(file_path, file_type, **kwargs):
     return data_shards
 
 
-def read_parquet(file_path, repartition=True, columns=None, **kwargs):
+def read_parquet(file_path, columns=None, **kwargs):
     """
     Read parquet files to SparkXShards of pandas DataFrames.
 
     :param file_path: Parquet file path, a list of multiple parquet file paths, or a directory
     containing parquet files. Local file system, HDFS, and AWS S3 are supported.
-    :param repartition: Whether to repartition if number of partitions in this XShards is less than
-    spark executer numbers. Default is True.
     :param columns: list of column name, default=None.
     If not None, only these columns will be read from the file.
     :param kwargs: Any additional kwargs.
     :return: An instance of SparkXShards.
     """
     sc = init_nncontext()
-    node_num, core_num = get_node_and_core_number()
     from pyspark.sql import SQLContext
     sqlContext = SQLContext.getOrCreate(sc)
     spark = sqlContext.sparkSession
     df = spark.read.parquet(file_path)
-    if df.rdd.getNumPartitions() < node_num:
-        if repartition:
-            df = df.repartition(node_num)
 
     if columns:
         df = df.select(*columns)

--- a/pyzoo/zoo/orca/data/pandas/preprocessing.py
+++ b/pyzoo/zoo/orca/data/pandas/preprocessing.py
@@ -265,12 +265,17 @@ def read_file_spark(file_path, file_type, **kwargs):
     return data_shards
 
 
-def read_parquet(file_path,):
+def read_parquet(file_path, repartition=True, columns=None, **kwargs):
     """
     Read parquet files to SparkXShards of pandas DataFrames.
 
     :param file_path: Parquet file path, a list of multiple parquet file paths, or a directory
     containing parquet files. Local file system, HDFS, and AWS S3 are supported.
+    :param repartition: Whether to repartition if number of partitions in this XShards is less than
+    spark executer numbers. Default is True.
+    :param columns: list of column name, default=None.
+    If not None, only these columns will be read from the file.
+    :param kwargs: Any additional kwargs.
     :return: An instance of SparkXShards.
     """
     sc = init_nncontext()
@@ -280,7 +285,11 @@ def read_parquet(file_path,):
     spark = sqlContext.sparkSession
     df = spark.read.parquet(file_path)
     if df.rdd.getNumPartitions() < node_num:
-        df = df.repartition(node_num)
+        if repartition:
+            df = df.repartition(node_num)
+
+    if columns:
+        df = df.select(*columns)
 
     def to_pandas(columns):
         def f(iter):


### PR DESCRIPTION
Add columns options in read_parquet if user only needs a few columns among so many columns.  Load all columns and cache to xshards may have memory issue.

Add repartition option if user does not want to repartition when num_partition on xshards < node_number. For big dataset, repartition may take a lot effort if users just do prediction/evaluation.
