### PR TITLE
fix duplicated ray worker logs

### DIFF
--- a/pyzoo/zoo/ray/raycontext.py
+++ b/pyzoo/zoo/ray/raycontext.py
@@ -49,6 +49,32 @@ class JVMGuard:
             raise err
 
 
+def kill_redundant_log_monitors(redis_address):
+
+    """
+    killing additional log_monitor.py process
+    if starting multiple ray nodes on the the machine,
+    there will be multiple ray log_monitor.py process
+    monitoring the same log dir. As a result, the logs
+    will be replicated multiple times and forward to driver.
+    see issue https://github.com/ray-project/ray/issues/10392
+    """
+
+    import psutil
+    import subprocess
+    log_monitor_processes = []
+    for proc in psutil.process_iter(["name", "cmdline"]):
+        cmdline = subprocess.list2cmdline(proc.cmdline())
+        is_log_monitor = "log_monitor.py" in cmdline
+        is_same_redis = "--redis-address={}".format(redis_address)
+        if is_log_monitor and is_same_redis in cmdline:
+            log_monitor_processes.append(proc)
+
+    if len(log_monitor_processes) > 1:
+        for proc in log_monitor_processes[1:]:
+            proc.kill()
+
+
 class RayServiceFuncGenerator(object):
     """
     This should be a pickable class.
@@ -204,6 +230,7 @@ class RayServiceFuncGenerator(object):
                             object_store_memory=self.object_store_memory,
                             extra_params=self.extra_params),
                         tag="raylet")
+                    kill_redundant_log_monitors(redis_address=redis_address)
 
             yield process_info
         return _start_ray_services
@@ -417,6 +444,9 @@ class RayContext(object):
             else:
                 self._start_cluster()
                 self._address_info = self._start_driver(num_cores=driver_cores)
+
+            print(self._address_info)
+            kill_redundant_log_monitors(self._address_info["redis_address"])
             self.initialized = True
         return self._address_info
 

--- a/pyzoo/zoo/ray/raycontext.py
+++ b/pyzoo/zoo/ray/raycontext.py
@@ -52,7 +52,7 @@ class JVMGuard:
 def kill_redundant_log_monitors(redis_address):
 
     """
-    Killing additional log_monitor.py processes.
+    Killing redundant log_monitor.py processes.
     If multiple ray nodes are started on the same machine,
     there will be multiple ray log_monitor.py processes
     monitoring the same log dir. As a result, the logs

--- a/pyzoo/zoo/ray/raycontext.py
+++ b/pyzoo/zoo/ray/raycontext.py
@@ -52,12 +52,12 @@ class JVMGuard:
 def kill_redundant_log_monitors(redis_address):
 
     """
-    killing additional log_monitor.py process
-    if starting multiple ray nodes on the the machine,
-    there will be multiple ray log_monitor.py process
+    Killing additional log_monitor.py processes.
+    If multiple ray nodes are started on the same machine,
+    there will be multiple ray log_monitor.py processes
     monitoring the same log dir. As a result, the logs
-    will be replicated multiple times and forward to driver.
-    see issue https://github.com/ray-project/ray/issues/10392
+    will be replicated multiple times and forwarded to driver.
+    See issue https://github.com/ray-project/ray/issues/10392
     """
 
     import psutil


### PR DESCRIPTION
Workers' output is duplicated n times if n ray nodes are started on the same machine.

![91535616-ff180180-e945-11ea-8e64-14d469897824](https://user-images.githubusercontent.com/10561966/91689026-ddad5480-eb95-11ea-838f-f4ccd6a9cd6d.png)

See ray issue https://github.com/ray-project/ray/issues/10392 for details.

This pr works around it by killing the redundant log_monitor processes. 

