### PR TITLE
Fix RayOnSpark for k8s and add docs

### DIFF
--- a/pyzoo/test/zoo/orca/learn/ray/mxnet/conftest.py
+++ b/pyzoo/test/zoo/orca/learn/ray/mxnet/conftest.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import ray
 import pytest
 
 

--- a/pyzoo/test/zoo/orca/learn/ray/pytorch/conftest.py
+++ b/pyzoo/test/zoo/orca/learn/ray/pytorch/conftest.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import ray
 import pytest
 
 

--- a/pyzoo/zoo/common/nncontext.py
+++ b/pyzoo/zoo/common/nncontext.py
@@ -36,7 +36,8 @@ def init_spark_on_local(cores=2, conf=None, python_location=None, spark_log_leve
     :param conf: You can append extra conf for Spark in key-value format.
            i.e conf={"spark.executor.extraJavaOptions": "-XX:+PrintGCDetails"}.
            Default to be None.
-    :param python_location: The path to your running python executable.
+    :param python_location: The path to your running Python executable. If not specified, the
+           default Python interpreter in effect would be used.
     :param spark_log_level: The log level for Spark. Default to be 'WARN'.
     :param redirect_spark_log: Whether to redirect the Spark log to local file. Default to be True.
     :return: An instance of SparkContext.
@@ -132,6 +133,7 @@ def init_spark_standalone(num_executors,
                           redirect_spark_log=True,
                           conf=None,
                           jars=None,
+                          python_location=None,
                           enable_numa_binding=False):
     """
     Create a SparkContext with Analytics Zoo configurations on Spark standalone cluster of
@@ -159,6 +161,8 @@ def init_spark_standalone(num_executors,
     :param conf: You can append extra conf for Spark in key-value format.
            i.e conf={"spark.executor.extraJavaOptions": "-XX:+PrintGCDetails"}.
            Default to be None.
+    :param python_location: The path to your running Python executable. If not specified, the
+           default Python interpreter in effect would be used.
     :param enable_numa_binding: Whether to use numactl to start spark worker in order to bind
            different worker processes to different cpus and memory areas. This is may lead to
            better performance on a multi-sockets machine. Defaults to False.
@@ -179,6 +183,7 @@ def init_spark_standalone(num_executors,
         extra_python_lib=extra_python_lib,
         conf=conf,
         jars=jars,
+        python_location=python_location,
         enable_numa_binding=enable_numa_binding)
     return sc
 
@@ -197,7 +202,35 @@ def init_spark_on_k8s(master,
                       jars=None,
                       conf=None,
                       python_location=None):
+    """
+    Create a SparkContext with Analytics Zoo configurations on Kubernetes cluster for k8s client
+    mode. You are recommended to use the Docker image intelanalytics/hyperzoo:latest.
+    You can refer to https://github.com/intel-analytics/analytics-zoo/tree/master/docker/hyperzoo
+    to build your own Docker image.
 
+    :param master: The master address of your k8s cluster.
+    :param container_image: The name of the docker container image for Spark executors.
+           For example, intelanalytics/hyperzoo:latest
+    :param num_executors: The number of Spark executors.
+    :param executor_cores: The number of cores for each executor.
+    :param executor_memory: The memory for each executor. Default to be '2g'.
+    :param driver_cores: The number of cores for the Spark driver. Default to be 4.
+    :param driver_memory: The memory for the Spark driver. Default to be '1g'.
+    :param extra_executor_memory_for_ray: The extra memory for Ray services. Default to be None.
+    :param extra_python_lib: Extra python files or packages needed for distribution.
+           Default to be None.
+    :param spark_log_level: The log level for Spark. Default to be 'WARN'.
+    :param redirect_spark_log: Whether to redirect the Spark log to local file. Default to be True.
+    :param jars: Comma-separated list of jars to be included on driver and executor's classpath.
+           Default to be None.
+    :param conf: You can append extra conf for Spark in key-value format.
+           i.e conf={"spark.executor.extraJavaOptions": "-XX:+PrintGCDetails"}.
+           Default to be None.
+    :param python_location: The path to your running Python executable. If not specified, the
+           default Python interpreter in effect would be used.
+
+    :return: An instance of SparkContext.
+    """
     from zoo.util.spark import SparkRunner
     runner = SparkRunner(spark_log_level=spark_log_level,
                          redirect_spark_log=redirect_spark_log)
@@ -285,13 +318,14 @@ def init_nncontext(conf=None, spark_log_level="WARN", redirect_spark_log=True):
     or the properties file before calling this method. In this case, you are recommended
     to use the launching scripts under `analytics-zoo/scripts`.
 
-    :param conf: You can append extra conf for Spark in key-value format.
-           i.e conf={"spark.executor.extraJavaOptions": "-XX:+PrintGCDetails"}.
-           Default to be None.
+    :param conf: An instance of SparkConf. If not specified, a new SparkConf with
+           Analytics Zoo and BigDL configurations would be created and used.
+           You can also input a string here to indicate the name of the application.
     :param spark_log_level: The log level for Spark. Default to be 'WARN'.
     :param redirect_spark_log: Whether to redirect the Spark log to local file. Default to be True.
-    """
 
+    :return: An instance of SparkContext.
+    """
     # The following code copied and modified from
     # https://github.com/Valassis-Digital-Media/spylon-kernel/blob/master/
     # spylon_kernel/scala_interpreter.py
@@ -349,11 +383,13 @@ def init_nncontext(conf=None, spark_log_level="WARN", redirect_spark_log=True):
 
 def getOrCreateSparkContext(conf=None, appName=None):
     """
-    Get the current active spark context and create one if no active instance
-    :param conf: combining bigdl configs into spark conf
-    :return: SparkContext
-    """
+    Get the current active SparkContext or create a new SparkContext.
+    :param conf: An instance of SparkConf. If not specified, a new SparkConf with
+           Analytics Zoo and BigDL configurations would be created and used.
+    :param appName: The name of the application if any.
 
+    :return: An instance of SparkContext.
+    """
     with SparkContext._lock:
         if SparkContext._active_spark_context is None:
             spark_conf = init_spark_conf() if conf is None else conf

--- a/pyzoo/zoo/orca/common.py
+++ b/pyzoo/zoo/orca/common.py
@@ -159,9 +159,8 @@ def init_orca_context(cluster_mode="local", cores=2, memory="2g", num_nodes=1,
         if cluster_mode == "k8s-cluster":
             raise ValueError('For k8s-cluster mode, please set cluster_mode to "spark-submit" '
                              'and submit the application via spark-submit instead')
-        assert "master" in kwargs, "k8s master address must be specified for k8s-client mode"
-        assert "container_image" in kwargs, "The name of the docker container image for Spark " \
-                                            "executors must be specified for k8s-client mode"
+        assert "master" in kwargs, "Please specify master for k8s-client mode"
+        assert "container_image" in kwargs, "Please specify container_image for k8s-client mode"
         for key in ["driver_cores", "driver_memory", "extra_executor_memory_for_ray",
                     "extra_python_lib", "jars", "python_location"]:
             if key in kwargs:

--- a/pyzoo/zoo/orca/common.py
+++ b/pyzoo/zoo/orca/common.py
@@ -92,8 +92,8 @@ def init_orca_context(cluster_mode="local", cores=2, memory="2g", num_nodes=1,
     Creates or gets a SparkContext for different Spark cluster modes (and launch Ray services
     across the cluster if necessary).
 
-    :param cluster_mode: The mode for the Spark cluster. One of "local", "yarn-client", "k8s-client",
-           "standalone" and "spark-submit". Default to be "local".
+    :param cluster_mode: The mode for the Spark cluster. One of "local", "yarn-client",
+           "k8s-client", "standalone" and "spark-submit". Default to be "local".
 
            For "spark-submit", you are supposed to use spark-submit to submit the application.
            In this case, please set the Spark configurations through command line options or

--- a/pyzoo/zoo/orca/common.py
+++ b/pyzoo/zoo/orca/common.py
@@ -92,12 +92,12 @@ def init_orca_context(cluster_mode="local", cores=2, memory="2g", num_nodes=1,
     Creates or gets a SparkContext for different Spark cluster modes (and launch Ray services
     across the cluster if necessary).
 
-    :param cluster_mode: The mode for the Spark cluster. One of "local", "yarn-client",
+    :param cluster_mode: The mode for the Spark cluster. One of "local", "yarn-client", "k8s-client",
            "standalone" and "spark-submit". Default to be "local".
 
            For "spark-submit", you are supposed to use spark-submit to submit the application.
            In this case, please set the Spark configurations through command line options or
-           the properties file. You need to use "spark-submit" for yarn-cluster mode.
+           the properties file. You need to use "spark-submit" for yarn-cluster or k8s-cluster mode.
            To make things easier, you are recommended to use the launching scripts under
            `analytics-zoo/scripts`.
 
@@ -155,9 +155,25 @@ def init_orca_context(cluster_mode="local", cores=2, memory="2g", num_nodes=1,
                                 conda_name=python_location.split("/")[-3],
                                 num_executors=num_nodes, executor_cores=cores,
                                 executor_memory=memory, **spark_args)
+    elif cluster_mode.startswith("k8s"):  # k8s or k8s-client
+        if cluster_mode == "k8s-cluster":
+            raise ValueError('For k8s-cluster mode, please set cluster_mode to "spark-submit" '
+                             'and submit the application via spark-submit instead')
+        assert "master" in kwargs, "k8s master address must be specified for k8s-client mode"
+        assert "container_image" in kwargs, "The name of the docker container image for Spark " \
+                                            "executors must be specified for k8s-client mode"
+        for key in ["driver_cores", "driver_memory", "extra_executor_memory_for_ray",
+                    "extra_python_lib", "jars", "python_location"]:
+            if key in kwargs:
+                spark_args[key] = kwargs[key]
+        from zoo import init_spark_on_k8s
+        sc = init_spark_on_k8s(master=kwargs["master"],
+                               container_image=kwargs["container_image"],
+                               num_executors=num_nodes, executor_cores=cores,
+                               executor_memory=memory, **spark_args)
     elif cluster_mode == "standalone":
         for key in ["driver_cores", "driver_memory", "extra_executor_memory_for_ray",
-                    "extra_python_lib", "jars", "master", "enable_numa_binding"]:
+                    "extra_python_lib", "jars", "master", "python_location", "enable_numa_binding"]:
             if key in kwargs:
                 spark_args[key] = kwargs[key]
         from zoo import init_spark_standalone

--- a/pyzoo/zoo/ray/raycontext.py
+++ b/pyzoo/zoo/ray/raycontext.py
@@ -189,35 +189,39 @@ class RayServiceFuncGenerator(object):
         return process_info
 
     def _get_ray_exec(self):
-        python_bin_dir = "/".join(self.python_loc.split("/")[:-1])
-        return "{}/python {}/ray".format(python_bin_dir, python_bin_dir)
+        if "envs" in self.python_loc:  # conda environment
+            python_bin_dir = "/".join(self.python_loc.split("/")[:-1])
+            return "{}/python {}/ray".format(python_bin_dir, python_bin_dir)
+        else:  # system environment with ray installed; for example: /usr/local/bin/ray
+            return "ray"
 
-    def gen_ray_start(self):
+    def gen_ray_start(self, master_ip):
         def _start_ray_services(iter):
             from pyspark import BarrierTaskContext
+            from zoo.util.utils import get_node_ip
             tc = BarrierTaskContext.get()
-            # The address is sorted by partitionId according to the comments
-            # Partition 0 is the Master
-            task_addrs = [taskInfo.address for taskInfo in tc.getTaskInfos()]
-            print(task_addrs)
-            master_ip = task_addrs[0].split(":")[0]
-            print("current address {}".format(task_addrs[tc.partitionId()]))
+            current_ip = get_node_ip()
+            print("current address {}".format(current_ip))
             print("master address {}".format(master_ip))
             redis_address = "{}:{}".format(master_ip, self.redis_port)
             process_info = None
-            if tc.partitionId() == 0:
-                print("partition id is : {}".format(tc.partitionId()))
-                process_info = self._start_ray_node(command=self._gen_master_command(),
-                                                    tag="ray-master")
-                process_info.master_addr = redis_address
+            import tempfile
+            import filelock
+            base_path = tempfile.gettempdir()
+            if current_ip == master_ip:  # It is possible that multiple executors are on one node.
+                lock_path = os.path.join(base_path, "ray_master_start.lock")
+                flag_path = os.path.join(base_path, "ray_master_initialized")
+                with filelock.FileLock(lock_path):
+                    if not os.path.exists(flag_path):
+                        print("partition id is : {}".format(tc.partitionId()))
+                        process_info = self._start_ray_node(command=self._gen_master_command(),
+                                                            tag="ray-master")
+                        process_info.master_addr = redis_address
+                        os.mknod(flag_path)
 
             tc.barrier()
-            if tc.partitionId() != 0:
-                import tempfile
-                import filelock
-
-                base_path = tempfile.gettempdir()
-                lock_path = os.path.join(base_path, "ray_on_spark_start.lock")
+            if not process_info:
+                lock_path = os.path.join(base_path, "raylet_start.lock")
                 with filelock.FileLock(lock_path):
                     print("partition id is : {}".format(tc.partitionId()))
                     process_info = self._start_ray_node(
@@ -342,7 +346,8 @@ class RayContext(object):
                                 "you need to manually specify num_ray_nodes and ray_node_cpu_cores "
                                 "for RayContext to start ray services")
 
-            self.python_loc = os.environ['PYSPARK_PYTHON']
+            from zoo.util.utils import detect_python_location
+            self.python_loc = os.environ.get("PYSPARK_PYTHON", detect_python_location())
             self.redis_port = random.randint(10000, 65535) if not redis_port else int(redis_port)
             self.ray_service = RayServiceFuncGenerator(
                 python_loc=self.python_loc,
@@ -353,11 +358,6 @@ class RayContext(object):
                 verbose=self.verbose,
                 env=self.env,
                 extra_params=self.extra_params)
-            self._gather_cluster_ips()
-            from bigdl.util.common import init_executor_gateway
-            print("Start to launch the JVM guarding process")
-            init_executor_gateway(sc)
-            print("JVM guarding process has been successfully launched")
         RayContext._active_ray_context = self
 
     @classmethod
@@ -371,18 +371,17 @@ class RayContext(object):
             raise Exception("No active RayContext. Please create a RayContext and init it first")
 
     def _gather_cluster_ips(self):
-        total_cores = int(self.num_ray_nodes) * int(self.ray_node_cpu_cores)
-
+        """
+        Get the ips of all Spark executors in the cluster. The first ip returned would be the
+        ray master.
+        """
         def info_fn(iter):
-            from pyspark import BarrierTaskContext
-            tc = BarrierTaskContext.get()
-            task_addrs = [taskInfo.address.split(":")[0] for taskInfo in tc.getTaskInfos()]
-            yield task_addrs
-            tc.barrier()
+            from zoo.util.utils import get_node_ip
+            yield get_node_ip()
 
-        ips = self.sc.range(0, total_cores,
-                            numSlices=total_cores).barrier().mapPartitions(info_fn).collect()
-        return ips[0]
+        ips = self.sc.range(0, self.num_ray_nodes,
+                            numSlices=self.num_ray_nodes).barrier().mapPartitions(info_fn).collect()
+        return ips
 
     def stop(self):
         if not self.initialized:
@@ -443,6 +442,10 @@ class RayContext(object):
                                               object_store_memory=self.object_store_memory,
                                               resources=self.extra_params)
             else:
+                self.cluster_ips = self._gather_cluster_ips()
+                from bigdl.util.common import init_executor_gateway
+                init_executor_gateway(self.sc)
+                print("JavaGatewayServer has been successfully launched on executors")
                 self._start_cluster()
                 self._address_info = self._start_driver(num_cores=driver_cores)
 
@@ -462,8 +465,9 @@ class RayContext(object):
         print("Start to launch ray on cluster")
         ray_rdd = self.sc.range(0, self.num_ray_nodes,
                                 numSlices=self.num_ray_nodes)
+        # The first ip would be used to launch ray master.
         process_infos = ray_rdd.barrier().mapPartitions(
-            self.ray_service.gen_ray_start()).collect()
+            self.ray_service.gen_ray_start(self.cluster_ips[0])).collect()
 
         self.ray_processesMonitor = ProcessMonitor(process_infos, self.sc, ray_rdd, self,
                                                    verbose=self.verbose)
@@ -481,8 +485,10 @@ class RayContext(object):
             ray_node_cpu_cores=num_cores,
             object_store_memory=self.object_store_memory,
             extra_params=extra_param)
+        modified_env = self.ray_service._prepare_env()
         print("Executing command: {}".format(command))
-        process_info = session_execute(command=command, fail_fast=True)
+        process_info = session_execute(command=command, env=modified_env,
+                                       tag="raylet", fail_fast=True)
         ProcessMonitor.register_shutdown_hook(pgid=process_info.pgid)
 
     def _start_driver(self, num_cores=0):

--- a/pyzoo/zoo/ray/raycontext.py
+++ b/pyzoo/zoo/ray/raycontext.py
@@ -209,7 +209,7 @@ class RayServiceFuncGenerator(object):
             import filelock
             base_path = tempfile.gettempdir()
             master_flag_path = os.path.join(base_path, "ray_master_initialized")
-            if current_ip == master_ip:
+            if current_ip == master_ip:  # Start the ray master.
                 lock_path = os.path.join(base_path, "ray_master_start.lock")
                 # It is possible that multiple executors are on one node. In this case,
                 # the first executor that gets the lock would be the master and it would
@@ -225,7 +225,7 @@ class RayServiceFuncGenerator(object):
                         os.mknod(master_flag_path)
 
             tc.barrier()
-            if not process_info:
+            if not process_info:  # Start raylets.
                 lock_path = os.path.join(base_path, "raylet_start.lock")
                 with filelock.FileLock(lock_path):
                     print("partition id is : {}".format(tc.partitionId()))

--- a/pyzoo/zoo/util/spark.py
+++ b/pyzoo/zoo/util/spark.py
@@ -231,6 +231,7 @@ class SparkRunner:
                           conf=None,
                           jars=None,
                           python_location=None):
+        print("Initializing SparkContext for k8s-client mode")
         if "PYSPARK_PYTHON" not in os.environ:
             os.environ["PYSPARK_PYTHON"] = \
                 python_location if python_location else detect_python_location()

--- a/pyzoo/zoo/util/spark.py
+++ b/pyzoo/zoo/util/spark.py
@@ -132,13 +132,15 @@ class SparkRunner:
                               extra_python_lib=None,
                               conf=None,
                               jars=None,
+                              python_location=None,
                               enable_numa_binding=False):
         import subprocess
         import pyspark
         from zoo.util.utils import get_node_ip
 
         if "PYSPARK_PYTHON" not in os.environ:
-            os.environ["PYSPARK_PYTHON"] = detect_python_location()
+            os.environ["PYSPARK_PYTHON"] = \
+                python_location if python_location else detect_python_location()
         if not master:
             pyspark_home = os.path.abspath(pyspark.__file__ + "/../")
             zoo_standalone_home = os.path.abspath(__file__ + "/../../share/bin/standalone")
@@ -229,8 +231,9 @@ class SparkRunner:
                           conf=None,
                           jars=None,
                           python_location=None):
-        if python_location:
-            os.environ["PYSPARK_PYTHON"] = python_location
+        if "PYSPARK_PYTHON" not in os.environ:
+            os.environ["PYSPARK_PYTHON"] = \
+                python_location if python_location else detect_python_location()
 
         submit_args = "--master " + master + " --deploy-mode client"
         submit_args = submit_args + gen_submit_args(


### PR DESCRIPTION
- Fix issues for running RayOnSpark on k8s cluster (described below). (Tested on PyTorchTrainer and MXNet Estimator)
- Add inline docs for init_spark_on_k8s.
- Some code updates of Ray related. Move init_executor_gateway to ray_ctx.init().
- Wrap k8s into init_orca_context.