### PR TITLE
Cluster Serving multiple model management

### DIFF
--- a/pyzoo/zoo/serving/client.py
+++ b/pyzoo/zoo/serving/client.py
@@ -177,7 +177,7 @@ class OutputQueue(API):
         return decoded
 
     def query(self, uri):
-        res_dict = self.db.hgetall('cluster-serving_' + self.name + ':' +uri)
+        res_dict = self.db.hgetall('cluster-serving_' + self.name + ':' + uri)
 
         if not res_dict or len(res_dict) == 0:
             return "{}"

--- a/scripts/cluster-serving/cluster-serving-cli
+++ b/scripts/cluster-serving/cluster-serving-cli
@@ -1,0 +1,86 @@
+#!/usr/bin/python3
+
+import yaml
+import httpx
+import os
+
+jobs_yaml = "/tmp/cluster-serving-jobs.yaml"
+
+def get_flink_rest():
+    if not os.path.exists("config.yaml"):
+        raise Exception("You must in Cluster Serving working directory, "
+                        "and have config.yaml to execute the command")
+    with open("config.yaml") as f:
+        conf_dict = yaml.load(f)
+        if not conf_dict['flink']['rest']:
+            flink_rest = "http://localhost:8081"
+        else:
+            flink_rest = "http://" + conf_dict['flink']['rest']
+    print("Sending request to ", flink_rest)
+    return flink_rest
+
+def list_jobs():
+    print("Listing running Cluster Serving jobs:")
+    cnt = 0
+    if os.path.exists(jobs_yaml):
+        with open(jobs_yaml) as f:
+            running_dict = yaml.load(f)
+            for value in running_dict.values():
+                cnt += 1
+                print("Job name:", value['name'],
+                      "| Job id:", value['id'])
+    print("Cluster Serving jobs", cnt, "totally")
+
+
+def stop_job(job_name=None):
+    if os.path.exists(jobs_yaml):
+        with open(jobs_yaml) as f:
+            running_dict = yaml.load(f)
+            if not job_name:
+                os.remove(jobs_yaml)
+                for value in running_dict.values():
+                    this_name = value['name']
+                    this_id = value['id']
+                    stop_job_with_id(this_name, this_id)
+
+            else:
+                to_remove = []
+                for key in running_dict:
+                    this_id = running_dict[key]['id']
+                    this_name = running_dict[key]['name']
+                    if this_name == job_name:
+                        try:
+                            stop_job_with_id(this_name, this_id)
+                            to_remove.append(key)
+                        except Exception as e:
+                            print(e)
+                for k in to_remove:
+                    running_dict.pop(k)
+                with open(jobs_yaml, "w") as f2:
+                    yaml.dump(running_dict, f2)
+
+
+def stop_job_with_id(name, job_id):
+    flink_rest = get_flink_rest()
+    res = httpx.patch(flink_rest + "/jobs/" + job_id)
+    if res.status_code != 202:
+        print("Job", name, "could not be cancelled, please check your Flink REST config")
+        raise Exception("Cancel request to Flink REST failed.")
+    else:
+        print("Job with id", job_id, "terminated.")
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) == 1:
+        exit(1)
+    if (sys.argv[1] == "list"):
+        list_jobs()
+    elif (sys.argv[1] == "stop"):
+        if len(sys.argv) == 2:
+            stop_job()
+        else:
+            stop_job(sys.argv[2])
+    else:
+        raise TypeError("Not supported for command: "
+                        + sys.argv[1] + ", please refer to document.")

--- a/scripts/cluster-serving/cluster-serving-start
+++ b/scripts/cluster-serving/cluster-serving-start
@@ -56,28 +56,31 @@ fi
 parse_yaml $config_path
 eval $(parse_yaml $config_path)
 
+if [ -z "${model_name}" ]; then
+    model_name=serving_stream
+fi
 if [ -z "${spark_master}" ]; then
-    echo "master of spark cluster not set, using default value local[*]"
+    #echo "master of spark cluster not set, using default value local[*]"
     spark_master=local[*]
 fi
 if [ -z "${spark_driver_memory}" ]; then
-    echo "spark driver memory not set, using default value 4g"
+    #echo "spark driver memory not set, using default value 4g"
     spark_driver_memory=4g
 fi
 if [ -z "${spark_executor_memory}" ]; then
-    echo "spark executor memory not set, using default value 1g"
+    #echo "spark executor memory not set, using default value 1g"
     spark_executor_memory=1g
 fi
 if [ -z "${spark_num_executors}" ]; then
-    echo "spark num-executors not set, using default value 1"
+    #echo "spark num-executors not set, using default value 1"
     spark_num_executors=1
 fi
 if [ -z "${spark_executor_cores}" ]; then
-    echo "spark executor-cores not set, using default value 4"
+    #echo "spark executor-cores not set, using default value 4"
     spark_executor_cores=4
 fi
 if [ -z "${spark_total_executor_cores}" ]; then
-    echo "spark executor-cores not set, using default value 4"
+    #echo "spark executor-cores not set, using default value 4"
     spark_total_executor_cores=4
 fi
 
@@ -90,11 +93,12 @@ if [ -z "${redis_maxmem}" ]; then
     redis_maxmem=8G
 fi
 
+LOG_DIR=log-cluster_serving-${model_name}.txt
 # try to start redis server
 if [ -z "${REDIS_HOME}" ]; then
     echo "REDIS_HOME variable is not set, skip redis start. Note that you need to set it otherwise Cluster Serving would not start or stop Redis for you."
 else
-    ${REDIS_HOME}/src/redis-server > redis.log &
+    ${REDIS_HOME}/src/redis-server >> $LOG_DIR &
     echo "redis server started, please check log in redis.log" && sleep 1
 
     # sleep for 1 sec to ensure server is ready and client could connect
@@ -122,7 +126,7 @@ if [ -z "${backend// }" ]; then
       echo "FLINK_HOME variable is not set, you need to set it to start Cluster Serving with Flink backend."
       exit 1
     fi
-    ${FLINK_HOME}/bin/flink run -c com.intel.analytics.zoo.serving.ClusterServing -p $par_num zoo.jar -c $config_path
+    ${FLINK_HOME}/bin/flink run -c com.intel.analytics.zoo.serving.ClusterServing -p $par_num zoo.jar -c $config_path >> $LOG_DIR &
 else
   echo "You are using non-default backend"
   if [ $backend != "spark" ]; then
@@ -160,3 +164,8 @@ else
     fi
     ${SPARK_HOME}/bin/spark-submit --master ${spark_master} --driver-memory ${spark_driver_memory} --executor-memory ${spark_executor_memory} --num-executors ${spark_num_executors} --executor-cores ${spark_executor_cores} --total-executor-cores ${spark_total_executor_cores} --class com.intel.analytics.zoo.serving.SparkStreamingClusterServing ${ZOO_JAR}
 fi
+
+echo "Cluster Serving job submitted, check log in $LOG_DIR"
+echo "To list Cluster Serving job status, use cluster-serving-cli list"
+sleep 3
+tail -1 $LOG_DIR

--- a/scripts/cluster-serving/cluster-serving-stop
+++ b/scripts/cluster-serving/cluster-serving-stop
@@ -33,4 +33,12 @@ else
     echo "Serving is not running, stop operation ignored."
 fi
 
+if cluster-serving-cli; then
+  cluster-serving-cli stop
+else
+  if [ -z "CS_PATH" ]; then
+    echo "If you install Cluster Serving not by pip, please set CS_PATH variable"
+    exit 1
+  ${CS_PATH}/cluster-serving-cli stop
+fi
 

--- a/scripts/cluster-serving/config.yaml
+++ b/scripts/cluster-serving/config.yaml
@@ -2,9 +2,11 @@
 
 model:
   # model path must be provided
-  path: resources/model
+  path: /path/to/model
   # mode, default is recommended, if error is raised, set single
   mode:
+  # name, default is serving_stream, you need to specify if running multiple servings
+  name:
   # the inputs of the tensorflow model, separated by ","
   inputs:
   # the outputs of the tensorflow model, separated by ","
@@ -23,6 +25,8 @@ params:
   model_number:
   # default: OFF
   performance_mode:
+flink:
+  rest:
 redis:
   # default, 4g
   maxmem:

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/inference/OpenVINOModel.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/inference/OpenVINOModel.scala
@@ -110,16 +110,15 @@ class OpenVINOModel(var modelHolder: OpenVINOModelHolder,
   }
 
   override def copy(num: Int): Array[AbstractModel] = {
-    val arr = new Array[AbstractModel](1)
-
-    (0 until 1).foreach(i => {
-      val modelBytes = modelHolder.modelBytes.clone()
-      val weightBytes = modelHolder.weightBytes.clone()
-
-      arr(i) = new OpenVINOModel(
-        new OpenVINOModelHolder(modelBytes, weightBytes), isInt8, batchSize, DeviceType.CPU)
-    })
-    arr
+    Array(this)
+//    val arr = new Array[AbstractModel](num)
+//    val modelBytes = this.modelHolder.modelBytes.clone()
+//    val weightBytes = this.modelHolder.weightBytes.clone()
+//    val modelHolder = new OpenVINOModelHolder(modelBytes, weightBytes)
+//    (0 until num).foreach(i => {
+//      arr(i) = new OpenVINOModel(modelHolder, isInt8, batchSize, DeviceType.CPU)
+//    })
+//    arr
   }
 
   override def release(): Unit = {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/ClusterServing.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/ClusterServing.scala
@@ -20,6 +20,7 @@ package com.intel.analytics.zoo.serving
 
 import com.intel.analytics.zoo.serving.engine.{FlinkInference, FlinkRedisSink, FlinkRedisSource}
 import com.intel.analytics.zoo.serving.utils.{ClusterServingHelper, ClusterServingManager, Conventions, SerParams}
+import org.apache.flink.core.execution.JobClient
 import org.apache.flink.streaming.api.scala.{StreamExecutionEnvironment, _}
 import org.apache.log4j.{Level, Logger}
 import scopt.OptionParser
@@ -27,7 +28,7 @@ import scopt.OptionParser
 
 object ClusterServing {
   case class ServingParams(configPath: String = "config.yaml", testMode: Boolean = false,
-                           timerMode: Boolean = false)
+                           sourceNum: Int = 1)
 
   val parser = new OptionParser[ServingParams]("Text Classification Example") {
     opt[String]('c', "configPath")
@@ -36,22 +37,20 @@ object ClusterServing {
     opt[Boolean]('t', "testMode")
       .text("Text Mode of Parallelism 1")
       .action((x, params) => params.copy(testMode = x))
-    opt[Boolean]("timerMode")
-      .text("Whether to open timer mode")
-      .action((x, params) => params.copy(timerMode = x))
   }
 
   Logger.getLogger("org").setLevel(Level.ERROR)
   Logger.getLogger("com.intel.analytics.zoo").setLevel(Level.INFO)
   var params: SerParams = null
   val logger = Logger.getLogger(getClass)
-  def run(configPath: String = "config.yaml",
-          testMode: Boolean = false,
-          timerMode: Boolean = false): Unit = {
+  def run(configPath: String = "config.yaml", testMode: Boolean = false): Unit = {
     val helper = new ClusterServingHelper(configPath)
     helper.initArgs()
     params = new SerParams(helper)
-    params.timerMode = timerMode
+    if (!helper.checkManagerYaml()) {
+      println(s"ERROR - Cluster Serving with name ${helper.jobName} already exists, exited.")
+      return
+    }
     val serving = StreamExecutionEnvironment.getExecutionEnvironment
     serving.registerCachedFile(configPath, Conventions.SERVING_CONF_TMP_PATH)
     serving.registerCachedFile(params.modelDir, Conventions.SERVING_MODEL_TMP_DIR)
@@ -66,12 +65,32 @@ object ClusterServing {
         .addSink(new FlinkRedisSink(params))
     }
 
-    val jobClient = serving.executeAsync()
-    ClusterServingManager.writeObjectToFile(jobClient)
-//    serving.execute("Cluster Serving - Flink")
+    val jobClient = serving.executeAsync("Cluster Serving - " + helper.jobName)
+    val jobId = ClusterServingManager.getJobIdfromClient(jobClient)
+    Runtime.getRuntime.addShutdownHook(new ShutDownThrd(helper, jobId, jobClient))
+    helper.updateManagerYaml(jobId)
+    while (!jobClient.getJobStatus.get().isTerminalState) {
+//      println(s"Status is ${jobClient.getJobStatus.get().toString}, " +
+//        s"is terminate Boolean value is ${jobClient.getJobStatus.get().isTerminalState}")
+      Thread.sleep(3000)
+    }
+
+
   }
   def main(args: Array[String]): Unit = {
     val param = parser.parse(args, ServingParams()).head
-    run(param.configPath, param.testMode, param.timerMode)
+    run(param.configPath, param.testMode)
+  }
+}
+
+class ShutDownThrd(helper: ClusterServingHelper, jobId: String, jobClient: JobClient) extends Thread {
+  override def run(): Unit = {
+    println(s"Shutdown hook triggered, removing job $jobId in yaml")
+    try {
+      jobClient.cancel()
+    } catch {
+      case _: Exception =>
+    }
+    helper.updateManagerYaml(jobId, remove = true)
   }
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/ClusterServing.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/ClusterServing.scala
@@ -28,7 +28,7 @@ import scopt.OptionParser
 
 object ClusterServing {
   case class ServingParams(configPath: String = "config.yaml", testMode: Boolean = false,
-                           sourceNum: Int = 1)
+                           timerMode: Boolean = false)
 
   val parser = new OptionParser[ServingParams]("Text Classification Example") {
     opt[String]('c', "configPath")
@@ -37,16 +37,22 @@ object ClusterServing {
     opt[Boolean]('t', "testMode")
       .text("Text Mode of Parallelism 1")
       .action((x, params) => params.copy(testMode = x))
+    opt[Boolean]("timerMode")
+      .text("Whether to open timer mode")
+      .action((x, params) => params.copy(timerMode = x))
   }
 
   Logger.getLogger("org").setLevel(Level.ERROR)
   Logger.getLogger("com.intel.analytics.zoo").setLevel(Level.INFO)
   var params: SerParams = null
   val logger = Logger.getLogger(getClass)
-  def run(configPath: String = "config.yaml", testMode: Boolean = false): Unit = {
+  def run(configPath: String = "config.yaml",
+          testMode: Boolean = false,
+          timerMode: Boolean = false): Unit = {
     val helper = new ClusterServingHelper(configPath)
     helper.initArgs()
     params = new SerParams(helper)
+    params.timerMode = timerMode
     if (!helper.checkManagerYaml()) {
       println(s"ERROR - Cluster Serving with name ${helper.jobName} already exists, exited.")
       return
@@ -79,7 +85,7 @@ object ClusterServing {
   }
   def main(args: Array[String]): Unit = {
     val param = parser.parse(args, ServingParams()).head
-    run(param.configPath, param.testMode)
+    run(param.configPath, param.testMode, param.timerMode)
   }
 }
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/ClusterServing.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/ClusterServing.scala
@@ -89,7 +89,8 @@ object ClusterServing {
   }
 }
 
-class ShutDownThrd(helper: ClusterServingHelper, jobId: String, jobClient: JobClient) extends Thread {
+class ShutDownThrd(helper: ClusterServingHelper, jobId: String, jobClient: JobClient)
+  extends Thread {
   override def run(): Unit = {
     println(s"Shutdown hook triggered, removing job $jobId in yaml")
     try {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/SparkStreamingClusterServing.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/SparkStreamingClusterServing.scala
@@ -17,9 +17,11 @@
 package com.intel.analytics.zoo.serving
 
 
+import java.time.LocalDateTime
+
 import com.intel.analytics.zoo.pipeline.inference.{InferenceModel, InferenceSummary}
 import com.intel.analytics.zoo.serving.utils._
-import com.intel.analytics.zoo.serving.engine.InferenceSupportive
+import com.intel.analytics.zoo.serving.engine.ClusterServingInference
 import com.intel.analytics.zoo.serving.engine.ServingReceiver
 import com.intel.analytics.zoo.serving.pipeline.{RedisIO, RedisUtils}
 import org.apache.log4j.{Level, Logger}
@@ -97,12 +99,12 @@ object SparkStreamingClusterServing {
     val acc = new LongAccumulator()
     helper.sc.register(acc)
 
-
+    val dateTime = LocalDateTime.now().toString
 
     val localSerParams = new SerParams(helper)
-    localSerParams.model = new InferenceModel()
+    localSerParams.model = helper.loadInferenceModel()
     localSerParams.model.setInferenceSummary(
-      InferenceSummary("./TensorboardEventLogs", helper.dateTime + "-ClusterServing"))
+      InferenceSummary("./TensorboardEventLogs", dateTime + "-ClusterServing"))
     val bcSer = helper.sc.broadcast(localSerParams)
 
     val jedis = new Jedis(localSerParams.redisHost, localSerParams.redisPort)
@@ -161,7 +163,8 @@ object SparkStreamingClusterServing {
             val serParams = bcSer.value
             println(s"Take Broadcasted model time ${(System.nanoTime() - t1) / 1e9} s")
             it.grouped(serParams.coreNum).flatMap(itemBatch => {
-              InferenceSupportive.multiThreadInference(itemBatch.toIterator, serParams)
+              ClusterServingInference.multiThreadInference(itemBatch.toIterator, serParams.coreNum,
+                serParams.modelType, serParams.filter, serParams.resize, serParams.model)
             })
           })
 
@@ -178,7 +181,8 @@ object SparkStreamingClusterServing {
             val serParams = bcSer.value
             println(s"Take Broadcasted model time ${(System.nanoTime() - t1) / 1e9} s")
             it.grouped(serParams.coreNum).flatMap(itemBatch => {
-              InferenceSupportive.multiThreadInference(itemBatch.toIterator, serParams)
+              ClusterServingInference.multiThreadInference(itemBatch.toIterator, serParams.coreNum,
+                serParams.modelType, serParams.filter, serParams.resize, serParams.model)
             })
           })
         }
@@ -186,7 +190,7 @@ object SparkStreamingClusterServing {
           val serParams = bcSer.value
           val jedis = new Jedis(serParams.redisHost, serParams.redisPort)
           val ppl = jedis.pipelined()
-          it.foreach(v => RedisIO.writeHashMap(ppl, v._1, v._2))
+          it.foreach(v => RedisIO.writeHashMap(ppl, v._1, v._2, serParams.jobName))
           ppl.sync()
           jedis.close()
           Iterator(None)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/SparkStructuredStreamingClusterServing.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/SparkStructuredStreamingClusterServing.scala
@@ -17,11 +17,13 @@
 package com.intel.analytics.zoo.serving
 
 
+import java.time.LocalDateTime
+
 import com.intel.analytics.bigdl.numeric.NumericFloat
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.{T, Table}
 import com.intel.analytics.zoo.pipeline.inference.{InferenceModel, InferenceSummary}
-import com.intel.analytics.zoo.serving.engine.InferenceSupportive
+import com.intel.analytics.zoo.serving.engine.ClusterServingInference
 import com.intel.analytics.zoo.serving.utils._
 import com.intel.analytics.zoo.serving.pipeline._
 import com.intel.analytics.zoo.serving.preprocessing.DataType
@@ -97,9 +99,9 @@ object SparkStructuredStreamingClusterServing {
 
     model = helper.loadInferenceModel()
     bcModel = helper.sc.broadcast(model)
-
+    val dateTime = LocalDateTime.now().toString
     model.setInferenceSummary(
-      InferenceSummary("./TensorboardEventLogs", helper.dateTime + "-ClusterServing"))
+      InferenceSummary("./TensorboardEventLogs", dateTime + "-ClusterServing"))
 
     val spark = helper.getSparkSession()
 
@@ -193,7 +195,8 @@ object SparkStructuredStreamingClusterServing {
             serParams.model = bcModel.value
             println(s"Take Broadcasted model time ${(System.nanoTime() - t1) / 1e9} s")
             it.grouped(serParams.coreNum).flatMap(itemBatch => {
-              InferenceSupportive.multiThreadInference(itemBatch.toIterator, serParams)
+              ClusterServingInference.multiThreadInference(itemBatch.toIterator, serParams.coreNum,
+                serParams.modelType, serParams.filter, serParams.resize, bcModel.value)
             })
           })
 
@@ -210,7 +213,8 @@ object SparkStructuredStreamingClusterServing {
             serParams.model = bcModel.value
             println(s"Take Broadcasted model time ${(System.nanoTime() - t1) / 1e9} s")
             it.grouped(serParams.coreNum).flatMap(itemBatch => {
-              InferenceSupportive.multiThreadInference(itemBatch.toIterator, serParams)
+              ClusterServingInference.multiThreadInference(itemBatch.toIterator, serParams.coreNum,
+                serParams.modelType, serParams.filter, serParams.resize, bcModel.value)
             })
           })
         }
@@ -233,7 +237,7 @@ object SparkStructuredStreamingClusterServing {
           try {
             resDf.write
               .format("org.apache.spark.sql.redis")
-              .option("table", "result")
+              .option("table", "cluster-serving_" + serParams.jobName + ":")
               .option("key.column", "uri")
               .option("iterator.grouping.size", coreNum)
               .mode(SaveMode.Append).save()

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/FlinkRedisSink.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/FlinkRedisSink.scala
@@ -62,7 +62,7 @@ class FlinkRedisSink(params: SerParams) extends RichSinkFunction[List[(String, S
 //    logger.info(s"Preparing to write result to redis")
 
     val ppl = jedis.pipelined()
-    value.foreach(v => RedisIO.writeHashMap(ppl, v._1, v._2))
+    value.foreach(v => RedisIO.writeHashMap(ppl, v._1, v._2, params.jobName))
     ppl.sync()
     jedis.close()
     logger.info(s"${value.size} records written to redis")

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/pipeline/RedisIO.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/pipeline/RedisIO.scala
@@ -47,8 +47,8 @@ object RedisIO {
     }
     return jedis
   }
-  def writeHashMap(ppl: Pipeline, key: String, value: String): Unit = {
-    val hKey = "result:" + key
+  def writeHashMap(ppl: Pipeline, key: String, value: String, name: String): Unit = {
+    val hKey = "cluster-serving_" + name + ":" + key
     val hValue = Map[String, String]("value" -> value).asJava
     ppl.hmset(hKey, hValue)
   }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/utils/ClusterServingHelper.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/utils/ClusterServingHelper.scala
@@ -22,18 +22,19 @@ import java.nio.file.{Files, Path, Paths}
 
 import com.intel.analytics.zoo.common.NNContext
 import com.intel.analytics.zoo.pipeline.api.keras.layers.utils.EngineRef
-
 import com.intel.analytics.zoo.pipeline.inference.InferenceModel
-import java.util.LinkedHashMap
+import java.util.{LinkedHashMap, UUID}
 
 import org.apache.log4j.Logger
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.SparkSession
 import org.yaml.snakeyaml.Yaml
 import java.time.LocalDateTime
+import java.util
 
+import org.apache.flink.core.execution.JobClient
 import redis.clients.jedis.Jedis
-
+import scala.collection.JavaConverters._
 import scala.reflect.ClassTag
 
 /**
@@ -49,15 +50,15 @@ class ClusterServingHelper(_configPath: String = "config.yaml", _modelDir: Strin
   type HM = LinkedHashMap[String, String]
 
   val configPath = _configPath
+  var jobName: String = _
 
   var lastModTime: String = null
   val logger: Logger = Logger.getLogger(getClass)
-  val dateTime = LocalDateTime.now.toString
 
   var sc: SparkContext = null
 
-  var modelInputs: String = null
-  var modelOutputs: String = null
+  var modelInputs: String = ""
+  var modelOutputs: String = ""
   var inferenceMode: String = null
 
   var redisHost: String = null
@@ -106,23 +107,17 @@ class ClusterServingHelper(_configPath: String = "config.yaml", _modelDir: Strin
     } else {
       _modelDir
     }
+    jobName = getYaml(modelConfig, "name", Conventions.SERVING_STREAM_NAME).asInstanceOf[String]
     modelInputs = getYaml(modelConfig, "inputs", "").asInstanceOf[String]
     modelOutputs = getYaml(modelConfig, "outputs", "").asInstanceOf[String]
     inferenceMode = getYaml(modelConfig, "mode", "").asInstanceOf[String]
 
     parseModelType(modelDir)
 
-
     /**
-     * reserved here to change engine type
-     * engine type should be able to change in run time
-     * but BigDL does not support this currently
-     * Once BigDL supports it, engine type could be set here
-     * And also other frameworks supporting multiple engine type
+     * Tensorflow usually use NHWC input
+     * While others use NCHW
      */
-
-
-
     if (modelType.startsWith("tensorflow")) {
       chwFlag = false
     }
@@ -172,11 +167,84 @@ class ClusterServingHelper(_configPath: String = "config.yaml", _modelDir: Strin
       else blasFlag = false
     }
     else blasFlag = false
-
-    new File("running").createNewFile()
-
   }
 
+  /**
+   * To check if one of the running jobs already have this name
+   * If yes, existed name is not allow to used, will not submit
+   * the job
+   * The running jobs info is stored in manager YAML
+   * @return false if running jobs exists this name
+   */
+  def checkManagerYaml(): Boolean = {
+    val yamlParser = new Yaml()
+
+    try {
+      new FileInputStream(new File(Conventions.TMP_MANAGER_YAML))
+    } catch {
+      case _ => new File(Conventions.TMP_MANAGER_YAML).createNewFile()
+    }
+    val input = new FileInputStream(new File(Conventions.TMP_MANAGER_YAML))
+    val loaded = yamlParser.load(input)
+      .asInstanceOf[LinkedHashMap[String, util.LinkedHashMap[String, String]]]
+    val configList = if (loaded != null) {
+      loaded
+    } else {
+      new LinkedHashMap[String, util.LinkedHashMap[String, String]]()
+    }
+    configList.asScala.foreach(m => {
+      if (m._2.get("name") == jobName) {
+        return false
+      }
+    })
+    true
+  }
+
+  /**
+   * Add or remove job info in manager YAML,
+   * manager YAML stores the info of running Cluster Serving jobs
+   * @param jobId the jobId of this job
+   * @param remove the flag to control whether to add job to manager YAML
+   *               or to remove the job in manager YAML
+   */
+  def updateManagerYaml(jobId: String, remove: Boolean = false): Unit = {
+    println("Updating YAML of Cluster Serving Manager")
+    val yamlParser = new Yaml()
+
+    try {
+      new FileInputStream(new File(Conventions.TMP_MANAGER_YAML))
+    } catch {
+      case _ => new File(Conventions.TMP_MANAGER_YAML).createNewFile()
+    }
+    val input = new FileInputStream(new File(Conventions.TMP_MANAGER_YAML))
+    val loaded = yamlParser.load(input)
+      .asInstanceOf[LinkedHashMap[String, util.LinkedHashMap[String, String]]]
+    val configList = if (loaded != null) {
+      loaded
+    } else {
+      new LinkedHashMap[String, util.LinkedHashMap[String, String]]()
+    }
+
+
+    if (remove) {
+      var uuid = ""
+      configList.asScala.foreach(m => {
+        if (m._2.get("id") == jobId) {
+          uuid = m._1
+        }
+      })
+      configList.remove(uuid)
+    } else {
+      val newJob = new HM()
+      newJob.put("name", jobName)
+      newJob.put("id", jobId)
+      println(s"Adding job $jobName to manager YAML")
+      configList.put(UUID.randomUUID().toString, newJob)
+    }
+
+    val outputWriter = new FileWriter(Conventions.TMP_MANAGER_YAML)
+    yamlParser.dump(configList, outputWriter)
+  }
   /**
    * Check stop signal, return true if signal detected
    * @return
@@ -246,8 +314,10 @@ class ClusterServingHelper(_configPath: String = "config.yaml", _modelDir: Strin
    * backend engine type
    * @return
    */
-  def loadInferenceModel(): InferenceModel = {
-
+  def loadInferenceModel(concurrentNum: Int = 0): InferenceModel = {
+    if (concurrentNum > 0) {
+      modelPar = concurrentNum
+    }
     logger.info(s"Cluster Serving load Inference Model with Parallelism $modelPar")
     val model = new InferenceModel(modelPar)
 
@@ -342,7 +412,7 @@ class ClusterServingHelper(_configPath: String = "config.yaml", _modelDir: Strin
    * @param msg
    */
   def logError(msg: String): Unit = {
-    println(dateTime + " --- " + msg + "\n")
+    println("ERROR - " + msg + "\n")
     throw new Error(msg)
   }
 
@@ -462,9 +532,14 @@ object ClusterServingHelper {
    * @param modelDir
    * @return
    */
-  def loadModelfromDir(confPath: String, modelDir: String): InferenceModel = {
+  def loadModelfromDirAndConfig(confPath: String, modelDir: String): InferenceModel = {
     val helper = new ClusterServingHelper(confPath, modelDir)
     helper.initArgs()
     helper.loadInferenceModel()
+  }
+  def loadModelfromDir(modelDir: String, concurrentNumber: Int = 1): (InferenceModel, String) = {
+    val helper = new ClusterServingHelper(_modelDir = modelDir)
+    helper.parseModelType(modelDir)
+    (helper.loadInferenceModel(concurrentNumber), helper.modelType)
   }
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/utils/ClusterServingManager.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/utils/ClusterServingManager.scala
@@ -58,10 +58,6 @@ object ClusterServingManager {
   }
   def writeObjectToFile(cli: JobClient): Unit = {
     try {
-//      val fileOut = new FileOutputStream("/tmp/cluster-serving-job-id")
-//      val objectOut = new ObjectOutputStream(fileOut)
-//      objectOut.writeObject(obj)
-//      objectOut.close()
       new PrintWriter("/tmp/cluster-serving-job-id") {
         write(cli.getJobID.toHexString)
         close
@@ -73,5 +69,8 @@ object ClusterServingManager {
         e.printStackTrace()
         println("Failed to write job id written to file. You may not manager job by id now.")
     }
+  }
+  def getJobIdfromClient(cli: JobClient): String = {
+    cli.getJobID.toHexString
   }
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/utils/Conventions.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/utils/Conventions.scala
@@ -23,6 +23,7 @@ object Conventions {
   val SERVING_STREAM_NAME = "serving_stream"
   val SERVING_MODEL_TMP_DIR = "cluster-serving-model"
   val SERVING_CONF_TMP_PATH = "cluster-serving-conf.yaml"
+  val TMP_MANAGER_YAML = "/tmp/cluster-serving-jobs.yaml"
   val ARROW_INT = new ArrowType.Int(32, true)
   val ARROW_FLOAT = new ArrowType.FloatingPoint(FloatingPointPrecision.SINGLE)
   val ARROW_BINARY = new ArrowType.Binary()

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/utils/SerParams.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/utils/SerParams.scala
@@ -24,6 +24,7 @@ class SerParams(helper: ClusterServingHelper) extends Serializable {
   var redisHost = helper.redisHost
   var redisPort = helper.redisPort.toInt
   val coreNum = helper.coreNum
+  val jobName = helper.jobName
   val filter = helper.filter
   val chwFlag = helper.chwFlag
   val inferenceMode = helper.inferenceMode

--- a/zoo/src/test/scala/com/intel/analytics/zoo/serving/InferenceSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/serving/InferenceSpec.scala
@@ -43,5 +43,4 @@ class InferenceSpec extends FlatSpec with Matchers {
     assert(res.toTensor[Float].valueAt(1) == 123)
     assert(res.toTensor[Float].valueAt(2) == 456)
   }
-
 }


### PR DESCRIPTION
The most want-to in this PR is to remove the `running` flag, often when the error is raised, the flag is not removed, and next time we have to manually remove the flag, otherwise serving could not start. This is bad.

could use `cluster-serving-cli list` to list jobs

use `cluster-serving-stop jobname` to stop specific job

use `cluster-serving-stop` to stop all jobs

add shutdown hook and `running` flag is not used anymore