### PR TITLE
add ld_library_path to init spark on yarn

### DIFF
--- a/pyzoo/zoo/util/spark.py
+++ b/pyzoo/zoo/util/spark.py
@@ -102,8 +102,8 @@ class SparkRunner:
                                          extra_executor_memory_for_ray)
             py_version = ".".join(platform.python_version().split(".")[0:2])
             preload_so = executor_python_env + "/lib/libpython" + py_version + "m.so"
-            ld_path = executor_python_env + "/lib:" + executor_python_env + "/lib/python" + \
-                      py_version + "/lib-dynload"
+            ld_path = executor_python_env + "/lib:" + executor_python_env + "/lib/python" +\
+                py_version + "/lib-dynload"
             if "spark.executorEnv.LD_LIBRARY_PATH" in conf:
                 ld_path = "{}:{}".format(ld_path, conf["spark.executorEnv.LD_LIBRARY_PATH"])
             conf.update({"spark.scheduler.minRegisteredResourcesRatio": "1.0",

--- a/pyzoo/zoo/util/spark.py
+++ b/pyzoo/zoo/util/spark.py
@@ -102,8 +102,13 @@ class SparkRunner:
                                          extra_executor_memory_for_ray)
             py_version = ".".join(platform.python_version().split(".")[0:2])
             preload_so = executor_python_env + "/lib/libpython" + py_version + "m.so"
+            ld_path = executor_python_env + "/lib:" + executor_python_env + "/lib/python" + \
+                      py_version + "/lib-dynload"
+            if "spark.executorEnv.LD_LIBRARY_PATH" in conf:
+                ld_path = "{}:{}".format(ld_path, conf["spark.executorEnv.LD_LIBRARY_PATH"])
             conf.update({"spark.scheduler.minRegisteredResourcesRatio": "1.0",
                          "spark.executorEnv.PYTHONHOME": executor_python_env,
+                         "spark.executorEnv.LD_LIBRARY_PATH": ld_path,
                          "spark.executorEnv.LD_PRELOAD": preload_so})
             if spark_yarn_archive:
                 conf["spark.yarn.archive"] = spark_yarn_archive

--- a/pyzoo/zoo/util/spark.py
+++ b/pyzoo/zoo/util/spark.py
@@ -104,11 +104,11 @@ class SparkRunner:
             preload_so = executor_python_env + "/lib/libpython" + py_version + "m.so"
             ld_path = executor_python_env + "/lib:" + executor_python_env + "/lib/python" +\
                 py_version + "/lib-dynload"
-            if "spark.executorEnv.LD_LIBRARY_PATH" in conf:
-                ld_path = "{}:{}".format(ld_path, conf["spark.executorEnv.LD_LIBRARY_PATH"])
+            if "spark.executor.extraLibraryPath" in conf:
+                ld_path = "{}:{}".format(ld_path, conf["spark.executor.extraLibraryPath"])
             conf.update({"spark.scheduler.minRegisteredResourcesRatio": "1.0",
                          "spark.executorEnv.PYTHONHOME": executor_python_env,
-                         "spark.executorEnv.LD_LIBRARY_PATH": ld_path,
+                         "spark.executor.extraLibraryPath": ld_path,
                          "spark.executorEnv.LD_PRELOAD": preload_so})
             if spark_yarn_archive:
                 conf["spark.yarn.archive"] = spark_yarn_archive


### PR DESCRIPTION
Fix 
```
jep.JepExecption:ImportError: /lib64/libstdc++.so.6: version 'GLIBCXX_3.4.21' not found(required by libtorch_python.so)
```

Add executor env LD_LIBRARY_PATH to use libstdc++.so in conda.