### PR TITLE
Torchoptim, wrap pytorch optimizer to bigdl's optimmethod

### DIFF
--- a/pyzoo/dev/run-pytests-jep.sh
+++ b/pyzoo/dev/run-pytests-jep.sh
@@ -19,13 +19,10 @@
 cd "`dirname $0`"
 
 echo "Running Jep tests"
+set -ex
 python -m pytest -v ../test/zoo/orca/learn/jep/test_pytorch_estimator_for_spark.py
 python -m pytest -v ../test/zoo/orca/learn/jep/test_pytorch_estimator_for_dataloader.py
 python -m pytest -v ../test/zoo/orca/learn/jep/test_pytorch_estimator_for_spark_creator.py
 python -m pytest -v ../test/zoo/pipeline/api/torch/test_torch_estimator.py
 python -m pytest -v ../test/zoo/pipeline/api/torch/test_torch.py
-exit_status_1=$?
-if [ $exit_status_1 -ne 0 ];
-then
-    exit $exit_status_1
-fi
+python -m pytest -v ../test/zoo/pipeline/api/torch/test_torch_optim.py

--- a/pyzoo/test/zoo/pipeline/api/torch/test_torch.py
+++ b/pyzoo/test/zoo/pipeline/api/torch/test_torch.py
@@ -20,7 +20,7 @@ import torchvision
 import pytest
 
 from unittest import TestCase
-from zoo.pipeline.api.torch import TorchModel, TorchLoss, TorchOptim
+from zoo.pipeline.api.torch import TorchModel, TorchLoss
 from zoo.common.nncontext import *
 from torch.utils.data import TensorDataset, DataLoader
 from zoo.pipeline.estimator import *
@@ -179,45 +179,6 @@ class TestPytorch(TestCase):
                                   validation_method=[Accuracy()])
 
         trained_model = az_model.to_pytorch()
-
-    def test_torch_optim(self):
-        class SimpleTorchModel(nn.Module):
-            def __init__(self):
-                super(SimpleTorchModel, self).__init__()
-                self.dense1 = nn.Linear(2, 4)
-                self.bn1 = torch.nn.BatchNorm1d(4)
-                self.dense2 = nn.Linear(4, 1)
-
-            def forward(self, x):
-                x = self.dense1(x)
-                x = self.bn1(x)
-                x = torch.sigmoid(self.dense2(x))
-                return x
-
-        torch_model = SimpleTorchModel()
-        loss_fn = torch.nn.BCELoss()
-        torch_optim = torch.optim.Adam(torch_model.parameters())
-        az_model = TorchModel.from_pytorch(torch_model)
-        zoo_loss = TorchLoss.from_pytorch(loss_fn)
-
-        def train_dataloader():
-            inputs = torch.Tensor([[1, 2], [1, 3], [3, 2],
-                                   [5, 6], [8, 9], [1, 9]])
-            targets = torch.Tensor([[0], [0], [0],
-                                    [1], [1], [1]])
-            return DataLoader(TensorDataset(inputs, targets), batch_size=2)
-
-        train_featureset = FeatureSet.pytorch_dataloader(train_dataloader)
-        val_featureset = FeatureSet.pytorch_dataloader(train_dataloader)
-        zoo_optimizer = TorchOptim.from_pytorch(torch_optim)
-        estimator = Estimator(az_model, optim_methods=zoo_optimizer)
-        estimator.train_minibatch(train_featureset, zoo_loss, end_trigger=MaxEpoch(4),
-                                  checkpoint_trigger=EveryEpoch(),
-                                  validation_set=val_featureset,
-                                  validation_method=[Accuracy()])
-
-        trained_model = az_model.to_pytorch()
-
 
 
 if __name__ == "__main__":

--- a/pyzoo/test/zoo/pipeline/api/torch/test_torch.py
+++ b/pyzoo/test/zoo/pipeline/api/torch/test_torch.py
@@ -20,7 +20,7 @@ import torchvision
 import pytest
 
 from unittest import TestCase
-from zoo.pipeline.api.torch import TorchModel, TorchLoss
+from zoo.pipeline.api.torch import TorchModel, TorchLoss, TorchOptim
 from zoo.common.nncontext import *
 from torch.utils.data import TensorDataset, DataLoader
 from zoo.pipeline.estimator import *
@@ -179,6 +179,45 @@ class TestPytorch(TestCase):
                                   validation_method=[Accuracy()])
 
         trained_model = az_model.to_pytorch()
+
+    def test_torch_optim(self):
+        class SimpleTorchModel(nn.Module):
+            def __init__(self):
+                super(SimpleTorchModel, self).__init__()
+                self.dense1 = nn.Linear(2, 4)
+                self.bn1 = torch.nn.BatchNorm1d(4)
+                self.dense2 = nn.Linear(4, 1)
+
+            def forward(self, x):
+                x = self.dense1(x)
+                x = self.bn1(x)
+                x = torch.sigmoid(self.dense2(x))
+                return x
+
+        torch_model = SimpleTorchModel()
+        loss_fn = torch.nn.BCELoss()
+        torch_optim = torch.optim.Adam(torch_model.parameters())
+        az_model = TorchModel.from_pytorch(torch_model)
+        zoo_loss = TorchLoss.from_pytorch(loss_fn)
+
+        def train_dataloader():
+            inputs = torch.Tensor([[1, 2], [1, 3], [3, 2],
+                                   [5, 6], [8, 9], [1, 9]])
+            targets = torch.Tensor([[0], [0], [0],
+                                    [1], [1], [1]])
+            return DataLoader(TensorDataset(inputs, targets), batch_size=2)
+
+        train_featureset = FeatureSet.pytorch_dataloader(train_dataloader)
+        val_featureset = FeatureSet.pytorch_dataloader(train_dataloader)
+        zoo_optimizer = TorchOptim.from_pytorch(torch_optim)
+        estimator = Estimator(az_model, optim_methods=zoo_optimizer)
+        estimator.train_minibatch(train_featureset, zoo_loss, end_trigger=MaxEpoch(4),
+                                  checkpoint_trigger=EveryEpoch(),
+                                  validation_set=val_featureset,
+                                  validation_method=[Accuracy()])
+
+        trained_model = az_model.to_pytorch()
+
 
 
 if __name__ == "__main__":

--- a/pyzoo/test/zoo/pipeline/api/torch/test_torch_optim.py
+++ b/pyzoo/test/zoo/pipeline/api/torch/test_torch_optim.py
@@ -83,6 +83,5 @@ class TestPytorchOptim(TestCase):
         trained_model = az_model.to_pytorch()
 
 
-
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/pyzoo/test/zoo/pipeline/api/torch/test_torch_optim.py
+++ b/pyzoo/test/zoo/pipeline/api/torch/test_torch_optim.py
@@ -1,0 +1,88 @@
+#
+# Copyright 2018 Analytics Zoo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import torch
+from torch import nn
+import pytest
+
+from unittest import TestCase
+from zoo.pipeline.api.torch import TorchModel, TorchLoss, TorchOptim
+from zoo.common.nncontext import *
+from torch.utils.data import TensorDataset, DataLoader
+from zoo.pipeline.estimator import *
+from bigdl.optim.optimizer import MaxEpoch, EveryEpoch
+from zoo.pipeline.api.keras.metrics import Accuracy
+from zoo.feature.common import FeatureSet
+
+
+class TestPytorchOptim(TestCase):
+
+    def setUp(self):
+        """ setup any state tied to the execution of the given method in a
+        class.  setup_method is invoked for every test method of a class.
+        """
+        self.sc = init_spark_on_local(4)
+
+    def tearDown(self):
+        """ teardown any state that was previously setup with a setup_method
+        call.
+        """
+        self.sc.stop()
+
+    def test_torch_optim(self):
+        class SimpleTorchModel(nn.Module):
+            def __init__(self):
+                super(SimpleTorchModel, self).__init__()
+                self.dense1 = nn.Linear(2, 4)
+                self.bn1 = torch.nn.BatchNorm1d(4)
+                self.dense2 = nn.Linear(4, 1)
+
+            def forward(self, x):
+                x = self.dense1(x)
+                x = self.bn1(x)
+                x = torch.sigmoid(self.dense2(x))
+                return x
+
+        self.sc.stop()
+        self.sc = init_nncontext()
+        torch_model = SimpleTorchModel()
+        loss_fn = torch.nn.BCELoss()
+        torch_optim = torch.optim.Adam(torch_model.parameters())
+        az_model = TorchModel.from_pytorch(torch_model)
+        zoo_loss = TorchLoss.from_pytorch(loss_fn)
+
+        def train_dataloader():
+            inputs = torch.Tensor([[1, 2], [1, 3], [3, 2],
+                                   [5, 6], [8, 9], [1, 9]])
+            targets = torch.Tensor([[0], [0], [0],
+                                    [1], [1], [1]])
+            return DataLoader(TensorDataset(inputs, targets), batch_size=2)
+
+        train_featureset = FeatureSet.pytorch_dataloader(train_dataloader)
+        val_featureset = FeatureSet.pytorch_dataloader(train_dataloader)
+        zoo_optimizer = TorchOptim.from_pytorch(torch_optim)
+        estimator = Estimator(az_model, optim_methods=zoo_optimizer)
+        estimator.train_minibatch(train_featureset, zoo_loss, end_trigger=MaxEpoch(4),
+                                  checkpoint_trigger=EveryEpoch(),
+                                  validation_set=val_featureset,
+                                  validation_method=[Accuracy()])
+
+        trained_model = az_model.to_pytorch()
+
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/pyzoo/zoo/common/nncontext.py
+++ b/pyzoo/zoo/common/nncontext.py
@@ -19,6 +19,7 @@
 
 from bigdl.util.common import *
 from zoo.common.utils import callZooFunc
+from zoo.util.utils import set_python_home
 import warnings
 import multiprocessing
 import os
@@ -45,6 +46,7 @@ def init_spark_on_local(cores=2, conf=None, python_location=None, spark_log_leve
     from zoo.util.spark import SparkRunner
     runner = SparkRunner(spark_log_level=spark_log_level,
                          redirect_spark_log=redirect_spark_log)
+    set_python_home()
     return runner.init_spark_on_local(cores=cores, conf=conf,
                                       python_location=python_location)
 
@@ -118,6 +120,7 @@ def init_spark_on_yarn(hadoop_conf,
         spark_yarn_archive=spark_yarn_archive,
         jars=jars,
         conf=conf)
+    set_python_home()
     return sc
 
 
@@ -185,6 +188,7 @@ def init_spark_standalone(num_executors,
         jars=jars,
         python_location=python_location,
         enable_numa_binding=enable_numa_binding)
+    set_python_home()
     return sc
 
 
@@ -378,6 +382,7 @@ def init_nncontext(conf=None, spark_log_level="WARN", redirect_spark_log=True):
         redire_spark_logs()
         show_bigdl_info_logs()
     init_engine()
+    set_python_home()
     return sc
 
 

--- a/pyzoo/zoo/examples/pytorch/train/mnist/main.py
+++ b/pyzoo/zoo/examples/pytorch/train/mnist/main.py
@@ -90,7 +90,6 @@ def main():
         num_cores_per_executor = 4
         hadoop_conf_dir = os.environ.get('HADOOP_CONF_DIR')
         zoo_conda_name = os.environ.get('ZOO_CONDA_NAME')  # The name of the created conda-env
-        #del os.environ['PYTHONHOME']
         sc = init_spark_on_yarn(
             hadoop_conf=hadoop_conf_dir,
             conda_name=zoo_conda_name,

--- a/pyzoo/zoo/pipeline/api/torch/__init__.py
+++ b/pyzoo/zoo/pipeline/api/torch/__init__.py
@@ -16,3 +16,4 @@
 
 from .torch_loss import TorchLoss
 from .torch_model import TorchModel
+from .torch_optim import TorchOptim

--- a/pyzoo/zoo/pipeline/api/torch/torch_optim.py
+++ b/pyzoo/zoo/pipeline/api/torch/torch_optim.py
@@ -1,0 +1,43 @@
+#
+# Copyright 2018 Analytics Zoo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import sys
+import io
+import torch
+from importlib.util import find_spec
+from zoo.pipeline.api.torch import zoo_pickle_module
+from bigdl.optim.optimizer import OptimMethod
+
+if find_spec('jep') is None:
+    raise Exception("jep not found, please install jep first.")
+
+
+class TorchOptim(OptimMethod):
+    """
+    TorchOptim wraps a torch optimizer for distributed inference or training.
+    """
+
+    def __init__(self, optim_bytes, bigdl_type="float"):
+        """
+        :param bigdl_type:
+        """
+        super(TorchOptim, self).__init__(None, bigdl_type, optim_bytes)
+
+    @staticmethod
+    def from_pytorch(optim):
+        bys = io.BytesIO()
+        torch.save(optim, bys, pickle_module=zoo_pickle_module)
+        zoo_optim = TorchOptim(bys.getvalue())
+        return zoo_optim

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModel.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModel.scala
@@ -37,6 +37,7 @@ class TorchModel private(private val modelHolder: TorchModel2Holder, init_weight
   import TorchModel._
 
   protected var loaded = false
+  @transient
   protected lazy val load = {
     PythonInterpreter.set("model_bytes", modelHolder.torchBytes)
     val loadModelCode =
@@ -50,8 +51,6 @@ class TorchModel private(private val modelHolder: TorchModel2Holder, init_weight
          |from zoo.pipeline.api.torch.utils import trainable_param
          |from zoo.pipeline.api.torch import zoo_pickle_module
          |
-         |import pickle
-         |from pyspark.serializers import CloudPickleSerializer
          |by = bytes(b % 256 for b in model_bytes)
          |${getName()} = torch.load(io.BytesIO(by), pickle_module=zoo_pickle_module)
          |""".stripMargin

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchOptim.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchOptim.scala
@@ -95,7 +95,7 @@ object TorchOptim{
   case object LrSchedule extends OptimType
   case object Optim extends OptimType
 
-  def apply[T](optimBytes: Array[Byte])(implicit ev: TensorNumeric[T]): TorchOptim[T] = {
+  def apply[T: ClassTag](optimBytes: Array[Byte])(implicit ev: TensorNumeric[T]): TorchOptim[T] = {
     new TorchOptim[T](optimBytes)
   }
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchOptim.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchOptim.scala
@@ -79,12 +79,21 @@ class TorchOptim[@specialized(Float, Double) T: ClassTag](
 
   }
 
-  override def clearHistory(): Unit = ???
+  override def clearHistory(): Unit = {
 
-  override def getLearningRate(): Double = ???
+  }
+
+  override def getLearningRate(): Double = {
+    optimType match {
+      case Optim =>
+        PythonInterpreter.getValue[Double](s"${name}.defaults['lr']")
+      case _ =>
+        throw new IllegalArgumentException()
+    }
+  }
 
   override def loadFromTable(config: Table): TorchOptim.this.type = {
-    throw new UnsupportedOperationException()
+    this
   }
 
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchOptim.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchOptim.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 Analytics Zoo Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.intel.analytics.zoo.pipeline.api.net
 
 import com.intel.analytics.bigdl.optim.OptimMethod
@@ -45,7 +60,9 @@ class TorchOptim[@specialized(Float, Double) T: ClassTag](
   var name = ""
   var init = false
 
-  override def optimize(feval: Tensor[T] => (T, Tensor[T]), parameter: Tensor[T]): (Tensor[T], Array[T]) = {
+  override def optimize(
+        feval: Tensor[T] => (T, Tensor[T]),
+        parameter: Tensor[T]): (Tensor[T], Array[T]) = {
     optimType match {
       case Optim =>
         val (fx, dfdx) = feval(parameter)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchOptim.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchOptim.scala
@@ -24,6 +24,7 @@ class TorchOptim[@specialized(Float, Double) T: ClassTag](
     val loadModelCode =
       s"""
          |import torch
+         |import io
          |from torch.optim.optimizer import Optimizer
          |from torch.optim.lr_scheduler import _LRScheduler
          |from zoo.pipeline.api.torch import zoo_pickle_module

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchOptim.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/TorchOptim.scala
@@ -1,0 +1,96 @@
+package com.intel.analytics.zoo.pipeline.api.net
+
+import com.intel.analytics.bigdl.optim.OptimMethod
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
+import com.intel.analytics.bigdl.utils.{EngineType, Table}
+import com.intel.analytics.zoo.common.PythonInterpreter
+import com.intel.analytics.zoo.feature.PythonFeatureSet
+import jep.NDArray
+import org.apache.spark.TaskContext
+
+import scala.reflect.ClassTag
+
+class TorchOptim[@specialized(Float, Double) T: ClassTag](
+    torchOptim: Array[Byte])(implicit ev: TensorNumeric[T]) extends OptimMethod[T] {
+  import TorchOptim._
+
+  protected val postfix = Integer.toHexString(java.util.UUID.randomUUID().hashCode())
+  @transient
+  protected lazy val optimType: OptimType = {
+    val partId = TaskContext.getPartitionId()
+    name = s"optim_${postfix}_${partId}"
+    PythonInterpreter.set("optim_bytes", torchOptim)
+    val loadModelCode =
+      s"""
+         |import torch
+         |from torch.optim.optimizer import Optimizer
+         |from torch.optim.lr_scheduler import _LRScheduler
+         |
+         |from pyspark.serializers import CloudPickleSerializer
+         |optim_by = bytes(b % 256 for b in optim_bytes)
+         |$name = CloudPickleSerializer.loads(CloudPickleSerializer, optim_by)
+         |""".stripMargin
+    PythonInterpreter.exec(loadModelCode)
+    if (PythonInterpreter.getValue[Boolean](s"isinstance($name, Optimizer)")) {
+      Optim
+    } else if (PythonInterpreter.getValue[Boolean](s"isinstance($name, _LRScheduler)")) {
+      LrSchedule
+    } else {
+      throw new IllegalArgumentException("Unknown optimizer type")
+    }
+  }
+
+  var name = ""
+  var init = false
+
+  override def optimize(feval: Tensor[T] => (T, Tensor[T]), parameter: Tensor[T]): (Tensor[T], Array[T]) = {
+    optimType match {
+      case LrSchedule =>
+        val (fx, dfdx) = feval(parameter)
+        val weightName = "weight"
+        if (!init) {
+          PythonInterpreter.set(weightName, new NDArray[Array[Float]](
+            parameter.toTensor[Float].storage().array()))
+          val initCode =
+            s"""
+               |$weightName = torch.tensor($weightName, requires_grad=True)
+               |$weightName = torch.autograd.Variable($weightName)
+               |${name}.__init__([${weightName}], **${name}.defaults)
+               |""".stripMargin
+          PythonInterpreter.exec(initCode)
+        }
+        val gradientName = "gradient"
+        PythonInterpreter.set("gradient", new NDArray[Array[Float]](
+          dfdx.toTensor[Float].storage().array()))
+        val stepCode =
+          s"""
+             |${weightName}.grad = torch.tensor(${gradientName})
+             |${name}.step()
+             |""".stripMargin
+        PythonInterpreter.exec(stepCode)
+        val updatedParameter = PythonFeatureSet.ndArrayToTensor(
+          PythonInterpreter.getValue(s"${weightName}.data.numpy()").asInstanceOf[NDArray[_]])
+        parameter.copy(updatedParameter.toTensor[T])
+        (parameter, Array(fx))
+    }
+
+  }
+
+  override def clearHistory(): Unit = ???
+
+  override def getLearningRate(): Double = ???
+
+  override def loadFromTable(config: Table): TorchOptim.this.type = {
+    throw new UnsupportedOperationException()
+  }
+
+}
+
+object TorchOptim{
+  sealed trait OptimType
+
+  case object LrSchedule extends OptimType
+  case object Optim extends OptimType
+
+}

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/python/PythonZooNet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/python/PythonZooNet.scala
@@ -184,6 +184,10 @@ class PythonZooNet[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonZoo
     TorchLoss(criterion)
   }
 
+  def createTorchOptim(optim: Array[Byte]): TorchOptim[T] = {
+    TorchOptim(optim)
+  }
+
   def torchNetSavePytorch(torchnet: TorchNet, path: String): Unit = {
     torchnet.savePytorch(path)
   }

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/net/TorchOptimSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/net/TorchOptimSpec.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018 Analytics Zoo Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intel.analytics.zoo.pipeline.api.net
+
+import java.nio.file.{Files, Paths}
+
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.zoo.common.PythonInterpreter
+import com.intel.analytics.zoo.core.TFNetNative
+import com.intel.analytics.zoo.pipeline.api.keras.ZooSpecHelper
+import org.apache.log4j.{Level, Logger}
+
+class TorchOptimSpec extends ZooSpecHelper{
+
+  protected def ifskipTest(): Unit = {
+    // Skip unitest if environment is not ready, PYTHONHOME should be set in environment
+    if (System.getenv("PYTHONHOME") == null) {
+      cancel("Please export PYTHONHOME before this test.")
+    } else {
+      logger.info(s"use python home: ${System.getenv("PYTHONHOME")}")
+      Logger.getLogger(PythonInterpreter.getClass()).setLevel(Level.DEBUG)
+      // Load TFNet before create interpreter, or the TFNet will throw an OMP error #13
+      TFNetNative.isLoaded
+    }
+  }
+
+  val lenet =
+    s"""
+       |import torch
+       |import torch.nn as nn
+       |import torch.nn.functional as F
+       |from zoo.util.nest import ptensor_to_numpy
+       |from zoo.pipeline.api.torch import zoo_pickle_module
+       |import io
+       |
+       |class LeNet(nn.Module):
+       |    def __init__(self):
+       |        super(LeNet, self).__init__()
+       |        self.conv1 = nn.Conv2d(1, 20, 5, 1)
+       |        self.conv2 = nn.Conv2d(20, 50, 5, 1)
+       |        self.fc1 = nn.Linear(4*4*50, 500)
+       |        self.fc2 = nn.Linear(500, 10)
+       |    def forward(self, x):
+       |        x = F.relu(self.conv1(x))
+       |        x = F.max_pool2d(x, 2, 2)
+       |        x = F.relu(self.conv2(x))
+       |        x = F.max_pool2d(x, 2, 2)
+       |        x = x.view(-1, 4*4*50)
+       |        x = F.relu(self.fc1(x))
+       |        x = self.fc2(x)
+       |        return F.log_softmax(x, dim=1)
+       |""".stripMargin
+
+  "TorchOptim" should "load without error" in {
+    ifskipTest()
+    val tmpname = createTmpFile().getAbsolutePath()
+    val code = lenet +
+      s"""
+         |model = LeNet()
+         |adam = torch.optim.SGD(model.parameters(), lr=0.1)
+         |torch.save(adam, "$tmpname", pickle_module=zoo_pickle_module)
+         |""".stripMargin
+    PythonInterpreter.exec(code)
+    val bys = Files.readAllBytes(Paths.get(tmpname))
+    val torchOptim = TorchOptim[Float](bys)
+
+    val weight = Tensor[Float](4).fill(1)
+    val gradient = Tensor[Float](Array(0.1f, 0.2f, 0.3f, 0.4f), Array(4))
+    torchOptim.optimize(_ => (1f, gradient), weight)
+    weight should be (Tensor[Float](Array(0.99f, 0.98f, 0.97f, 0.96f), Array(4)))
+  }
+
+
+
+}

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/net/TorchOptimSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/net/TorchOptimSpec.scala
@@ -18,11 +18,12 @@ package com.intel.analytics.zoo.pipeline.api.net
 import java.nio.file.{Files, Paths}
 
 import com.intel.analytics.bigdl.tensor.Tensor
-import com.intel.analytics.zoo.common.PythonInterpreter
+import com.intel.analytics.zoo.common.{PythonInterpreter, PythonInterpreterTest}
 import com.intel.analytics.zoo.core.TFNetNative
 import com.intel.analytics.zoo.pipeline.api.keras.ZooSpecHelper
 import org.apache.log4j.{Level, Logger}
 
+@PythonInterpreterTest
 class TorchOptimSpec extends ZooSpecHelper{
 
   protected def ifskipTest(): Unit = {


### PR DESCRIPTION
1. Add TorchOptim who wraps pytorch optimizer to bigdl's optimmethod.
2. Change init_spark_on_yarn's conda-pack to  shell command `conda pack` , as we can unset PYTHONHOME in the subprocess.
3. set pythonhome in driver when `init_nncontext()`, `init_spark_on_yarn()`, `init_spark_on_standalone()` and `init_spark_on_k8s()`