### PR TITLE
Support modulepickle for Ray

### DIFF
--- a/pyzoo/zoo/orca/learn/mxnet/mxnet_runner.py
+++ b/pyzoo/zoo/orca/learn/mxnet/mxnet_runner.py
@@ -47,8 +47,11 @@ class MXNetRunner(object):
             # Set seed so that the model on each worker is initialized with the same weights.
             if "seed" in self.config:
                 mx.random.seed(self.config["seed"])
-
-            self.model = self.model_creator(self.config)
+            import types
+            if isinstance(self.model_creator, types.FunctionType):
+                self.models = self.model_creator(self.config)
+            else:
+                self.model = self.model_creator
             self.loss = self.loss_creator(self.config) if self.loss_creator else None
             self.eval_metrics = self.eval_metrics_creator(self.config) \
                 if self.eval_metrics_creator else None

--- a/pyzoo/zoo/orca/learn/mxnet/mxnet_runner.py
+++ b/pyzoo/zoo/orca/learn/mxnet/mxnet_runner.py
@@ -49,7 +49,7 @@ class MXNetRunner(object):
                 mx.random.seed(self.config["seed"])
             import types
             if isinstance(self.model_creator, types.FunctionType):
-                self.models = self.model_creator(self.config)
+                self.model = self.model_creator(self.config)
             else:
                 self.model = self.model_creator
             self.loss = self.loss_creator(self.config) if self.loss_creator else None

--- a/pyzoo/zoo/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -102,10 +102,8 @@ class PyTorchRayEstimator:
 
         # todo remove ray_ctx to run on workers
         ray_ctx = RayContext.get()
-        if not (isinstance(model_creator, types.FunctionType) and
-                isinstance(optimizer_creator, types.FunctionType)):  # Torch model is also callable.
-            raise ValueError(
-                "Must provide a function for both model_creator and optimizer_creator")
+        assert isinstance(optimizer_creator, types.FunctionType), \
+            "Must provide a function for both model_creator and optimizer_creator"
 
         self.model_creator = model_creator
         self.optimizer_creator = optimizer_creator
@@ -283,7 +281,11 @@ class PyTorchRayEstimator:
     def get_model(self):
         """Returns the learned model(s)."""
         state = self.get_state_dict()
-        model = self.model_creator(self.config)
+        import types
+        if isinstance(self.model_creator, types.FunctionType):
+            model = self.model_creator(self.config)
+        else:
+            model = self.model_creator
         model_state = state["models"][0]
         model.load_state_dict(model_state)
         return model.module if hasattr(model, "module") else model

--- a/pyzoo/zoo/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -103,7 +103,7 @@ class PyTorchRayEstimator:
         # todo remove ray_ctx to run on workers
         ray_ctx = RayContext.get()
         assert isinstance(optimizer_creator, types.FunctionType), \
-            "Must provide a function for both model_creator and optimizer_creator"
+            "Must provide a function for optimizer_creator"
 
         self.model_creator = model_creator
         self.optimizer_creator = optimizer_creator

--- a/pyzoo/zoo/orca/learn/pytorch/torch_runner.py
+++ b/pyzoo/zoo/orca/learn/pytorch/torch_runner.py
@@ -149,7 +149,12 @@ class TorchRunner:
         """Runs the creator functions without any distributed coordination."""
 
         logger.debug("Creating model")
-        self.models = self.model_creator(self.config)
+        # Torch model is also callable, so can't use callable to check.
+        import types
+        if isinstance(self.model_creator, types.FunctionType):
+            self.models = self.model_creator(self.config)
+        else:
+            self.models = self.model_creator
         if not isinstance(self.models, Iterable):
             self.models = [self.models]
         assert all(isinstance(model, nn.Module) for model in self.models), (

--- a/pyzoo/zoo/orca/learn/pytorch/torch_runner.py
+++ b/pyzoo/zoo/orca/learn/pytorch/torch_runner.py
@@ -149,7 +149,7 @@ class TorchRunner:
         """Runs the creator functions without any distributed coordination."""
 
         logger.debug("Creating model")
-        # Torch model is also callable, so can't use callable to check.
+        # Torch model is also callable, so can't use callable to check a function.
         import types
         if isinstance(self.model_creator, types.FunctionType):
             self.models = self.model_creator(self.config)
@@ -173,7 +173,12 @@ class TorchRunner:
         import horovod.torch as hvd
 
         logger.debug("Creating model")
-        self.models = self.model_creator(self.config)
+        # Torch model is also callable, so can't use callable to check a function.
+        import types
+        if isinstance(self.model_creator, types.FunctionType):
+            self.models = self.model_creator(self.config)
+        else:
+            self.models = self.model_creator
         if not isinstance(self.models, Iterable):
             self.models = [self.models]
         else:

--- a/pyzoo/zoo/ray/__init__.py
+++ b/pyzoo/zoo/ray/__init__.py
@@ -15,3 +15,6 @@
 #
 
 from .raycontext import RayContext
+
+from zoo.util import modulepickle
+modulepickle.extend_ray()

--- a/pyzoo/zoo/util/modulepickle.py
+++ b/pyzoo/zoo/util/modulepickle.py
@@ -1,0 +1,180 @@
+import os
+from io import BytesIO
+from tarfile import TarFile
+import tempfile
+import importlib
+import importlib.machinery
+import hashlib
+import sys
+from logging import getLogger
+
+__all__ = ('extend', 'extend_ray', 'extend_cloudpickle')
+
+log = getLogger(__name__)
+
+TEMPDIR_ID = 'MODULEPICKLE'
+
+
+def md5(compressed):
+    md5 = hashlib.md5()
+    md5.update(compressed)
+    return md5.hexdigest()[:16]  # 32 bytes ought to be enough for everyone
+
+
+class Package:
+    def __init__(self, name, compressed):
+        self.name = name
+        self.compressed = compressed
+        self.md5 = md5(compressed)
+
+    def invalidate_caches(self):
+        # Chuck out any modules that come from one of our temp dirs, so that when they get importer next time it's imported from
+        # the shiny new temp dir
+        modules = list(sys.modules)
+        for k in modules:
+            v = sys.modules[k]
+            filepath = getattr(v, '__file__', '') or ''
+            if f'{TEMPDIR_ID}-{self.name}-' in filepath:
+                del sys.modules[k]
+
+        # And then invalidate the cache of everyone on the meta_path, just to be safe.
+        importlib.invalidate_caches()
+
+    def uninstall(self):
+        sys.path = [p for p in sys.path if f'{TEMPDIR_ID}-{self.name}-' not in p]
+
+    def extract(self):
+        # Salt the temp directory with the hashcode of the compressed dir, so that when the next copy of it comes down the line,
+        #  we can either reuse the existing dir if it's the same, or point ourselves at a new one if it isn't.
+        dirpath = tempfile.mkdtemp(prefix=f'{TEMPDIR_ID}-{self.name}-{self.md5}-')
+        bs = BytesIO(self.compressed)
+        with TarFile(fileobj=bs) as tf:
+            tf.extractall(os.path.join(dirpath))
+        return dirpath
+
+    def install(self):
+        """'Installing' this package means extracting it to a hash-salted temp dir and then appending the dir to the path"""
+        # Only need to install it if the hash of the dir has changed since we last added it to the path
+        if not any(self.md5 in p for p in sys.path):
+            self.uninstall()
+            self.invalidate_caches()
+            sys.path.append(self.extract())
+
+    def load(self, name):
+        self.install()
+        return importlib.import_module(name)
+
+
+def compress(packagename, path):
+    tar = BytesIO()
+    with TarFile(fileobj=tar, mode='w') as tf:
+        tf.add(path, packagename)
+    # TODO: This was originally gzipped, but the gzipped value seems to change on repeated compressions, breaking hashing.
+    # Looks like the issue is a timestamp that can be overriden with a parameter, but let's leave it uncompressed for now.
+    return tar.getvalue()
+
+
+def import_compressed(name, package, class_name):
+    res = package.load(name)
+    if getattr(res, class_name, None):
+        class_type = getattr(res, class_name)
+        return class_type.__new__(class_type)
+    else:
+        return res
+
+
+def packagename(module):
+    # The package we want to zip up is the first part of the module name
+    # TODO: Check this holds on relative imports
+    return module.__name__.split('.')[0]
+
+
+def is_local(module):
+    # If the module is in the current working directory,
+    # and it doesn't have `site-packages` in it's path (which probably means it's part of a local virtualenv)
+    # assume it's local and that it's cool to pickle it.
+    path = getattr(module, '__file__', None)
+
+    # sys.executable = $python_lib_path/bin/python
+    python_lib_path = sys.executable[:-len("/bin/python")]
+
+    if path is None:
+        return False
+
+    if path.startswith(python_lib_path):
+        return False
+
+    return True
+
+
+def get_path(module):
+    path = getattr(module, '__file__', '')
+    package_name = module.__name__
+    # Single file
+    if "." not in package_name and path.endswith(package_name + ".py"):
+        return path
+    package_path_part = package_name.replace(".", "/")
+    package_first_part = package_path_part.split("/")[0]
+    idx = path.index(package_path_part)
+    import os
+    package_path = os.path.join(path[:idx], package_first_part)
+    return package_path
+
+
+def extend(base):
+    """Create a Pickler that can pickle packages by inheriting from `base`
+
+    We're dynamically inheriting from `base` here because my principal use case is extending ray's pickler, and ray's
+    installation dependencies are vast. Don't want to truck that around for a one-module package which works just as
+    well with cloudpickle.
+    """
+
+    class ModulePickler(base):
+
+        dispatch = base.dispatch.copy()
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.packages = {}
+
+        def compress_package(self, name, path):
+            # The same package might contain many of the modules a function references, so it makes sense to cache them
+            # as we go.
+            packagename = name
+            if name not in self.packages:
+                if path.endswith(".py"):
+                    packagename = name + ".py"
+                compressed = compress(packagename, path)
+                self.packages[name] = Package(name, compressed)
+            return self.packages[name]
+
+        def reducer_override(self, obj):
+            if getattr(obj, "__module__", None):
+                module = sys.modules[obj.__module__]
+                if module.__name__ != "__main__" and is_local(module):
+                    if packagename(module) in self.packages:
+                        package = self.packages[packagename(module)]
+                    else:
+                        print("get local {} in save_module, path is {}".format(module.__name__, module.__file__))
+                        package = self.compress_package(packagename(module), get_path(module))
+                    args = (module.__name__, package, obj.__class__.__name__)
+                    return import_compressed, args, obj.__dict__
+            return super().reducer_override(obj)
+
+    return ModulePickler
+
+
+def extend_ray():
+    """Extends Ray's CloudPickler with a ModulePickler"""
+    import ray.cloudpickle
+    ray.cloudpickle.CloudPickler = extend(ray.cloudpickle.CloudPickler)
+    ray.cloudpickle.dump.__globals__['CloudPickler'] = ray.cloudpickle.CloudPickler
+    ray.cloudpickle.dumps.__globals__['CloudPickler'] = ray.cloudpickle.CloudPickler
+
+
+def extend_cloudpickle():
+    """Extends cloudpickle's CloudPickler with a ModulePickler"""
+    import cloudpickle
+    cloudpickle.CloudPickler = extend(cloudpickle.CloudPickler)
+    cloudpickle.dump.__globals__['CloudPickler'] = cloudpickle.CloudPickler
+    cloudpickle.dumps.__globals__['CloudPickler'] = cloudpickle.CloudPickler


### PR DESCRIPTION
I tested on yarn it works for two cases:
- https://github.com/intel-analytics/analytics-zoo/blob/master/pyzoo/zoo/examples/orca/learn/horovod/pytorch_estimator.py I put the model definition in a separate python file not available on other nodes.
- Ali tianchi baseline code where the model is defined in a directory of python files not available on other nodes.

The loaded model have the same weights as the original model.
Since I'm still not familiar and confident with pickling, probably need someone to help to confirm this feature. Talk to you next week @jason-dai 

- [ ] Rename model_creator to model.