### PR TITLE
add pytorch ray_sgd trainer support to Orca Pytorch Estimator

### DIFF
--- a/pyzoo/test/zoo/orca/learn/ray/pytorch/test_pytorch_estimator.py
+++ b/pyzoo/test/zoo/orca/learn/ray/pytorch/test_pytorch_estimator.py
@@ -28,72 +28,72 @@ from tempfile import TemporaryDirectory
 
 
 class TestPyTorchEstimator(TestCase):
-    # def test_train(self):
-    #     estimator = Estimator.from_torch(
-    #         model=model_creator,
-    #         optimizer=optimizer_creator,
-    #         loss=nn.MSELoss,
-    #         scheduler_creator=scheduler_creator,
-    #         config={
-    #             "lr": 1e-2,  # used in optimizer_creator
-    #             "hidden_size": 1,  # used in model_creator
-    #             "batch_size": 4,  # used in data_creator
-    #         })
-    #     stats1 = estimator.fit(train_data_creator, epochs=5)
-    #     train_loss1 = stats1[-1]["train_loss"]
-    #     validation_loss1 = estimator.evaluate(validation_data_creator)["val_loss"]
-    #
-    #     stats2 = estimator.fit(train_data_creator, epochs=3)
-    #     train_loss2 = stats2[-1]["train_loss"]
-    #     validation_loss2 = estimator.evaluate(validation_data_creator)["val_loss"]
-    #
-    #     assert train_loss2 <= train_loss1, (train_loss2, train_loss1)
-    #     assert validation_loss2 <= validation_loss1, (validation_loss2,
-    #                                                   validation_loss1)
-    #     estimator.shutdown()
-    #
-    # def test_save_and_restore(self):
-    #     estimator1 = Estimator.from_torch(
-    #         model=model_creator,
-    #         optimizer=optimizer_creator,
-    #         loss=nn.MSELoss,
-    #         scheduler_creator=scheduler_creator,
-    #         config={
-    #             "lr": 1e-2,  # used in optimizer_creator
-    #             "hidden_size": 1,  # used in model_creator
-    #             "batch_size": 4,  # used in data_creator
-    #         })
-    #     with TemporaryDirectory() as tmp_path:
-    #         estimator1.fit(train_data_creator, epochs=1)
-    #         checkpoint_path = os.path.join(tmp_path, "checkpoint")
-    #         estimator1.save(checkpoint_path)
-    #
-    #         model1 = estimator1.get_model()
-    #
-    #         estimator1.shutdown()
-    #
-    #         estimator2 = Estimator.from_torch(
-    #             model=model_creator,
-    #             optimizer=optimizer_creator,
-    #             loss=nn.MSELoss,
-    #             scheduler_creator=scheduler_creator,
-    #             config={
-    #                 "lr": 1e-2,  # used in optimizer_creator
-    #                 "hidden_size": 1,  # used in model_creator
-    #                 "batch_size": 4,  # used in data_creator
-    #             })
-    #         estimator2.load(checkpoint_path)
-    #
-    #         model2 = estimator2.get_model()
-    #
-    #     model1_state_dict = model1.state_dict()
-    #     model2_state_dict = model2.state_dict()
-    #
-    #     assert set(model1_state_dict.keys()) == set(model2_state_dict.keys())
-    #
-    #     for k in model1_state_dict:
-    #         assert torch.equal(model1_state_dict[k], model2_state_dict[k])
-    #     estimator2.shutdown()
+    def test_train(self):
+        estimator = Estimator.from_torch(
+            model=model_creator,
+            optimizer=optimizer_creator,
+            loss=nn.MSELoss,
+            scheduler_creator=scheduler_creator,
+            config={
+                "lr": 1e-2,  # used in optimizer_creator
+                "hidden_size": 1,  # used in model_creator
+                "batch_size": 4,  # used in data_creator
+            })
+        stats1 = estimator.fit(train_data_creator, epochs=5)
+        train_loss1 = stats1[-1]["train_loss"]
+        validation_loss1 = estimator.evaluate(validation_data_creator)["val_loss"]
+
+        stats2 = estimator.fit(train_data_creator, epochs=3)
+        train_loss2 = stats2[-1]["train_loss"]
+        validation_loss2 = estimator.evaluate(validation_data_creator)["val_loss"]
+
+        assert train_loss2 <= train_loss1, (train_loss2, train_loss1)
+        assert validation_loss2 <= validation_loss1, (validation_loss2,
+                                                      validation_loss1)
+        estimator.shutdown()
+
+    def test_save_and_restore(self):
+        estimator1 = Estimator.from_torch(
+            model=model_creator,
+            optimizer=optimizer_creator,
+            loss=nn.MSELoss,
+            scheduler_creator=scheduler_creator,
+            config={
+                "lr": 1e-2,  # used in optimizer_creator
+                "hidden_size": 1,  # used in model_creator
+                "batch_size": 4,  # used in data_creator
+            })
+        with TemporaryDirectory() as tmp_path:
+            estimator1.fit(train_data_creator, epochs=1)
+            checkpoint_path = os.path.join(tmp_path, "checkpoint")
+            estimator1.save(checkpoint_path)
+
+            model1 = estimator1.get_model()
+
+            estimator1.shutdown()
+
+            estimator2 = Estimator.from_torch(
+                model=model_creator,
+                optimizer=optimizer_creator,
+                loss=nn.MSELoss,
+                scheduler_creator=scheduler_creator,
+                config={
+                    "lr": 1e-2,  # used in optimizer_creator
+                    "hidden_size": 1,  # used in model_creator
+                    "batch_size": 4,  # used in data_creator
+                })
+            estimator2.load(checkpoint_path)
+
+            model2 = estimator2.get_model()
+
+        model1_state_dict = model1.state_dict()
+        model2_state_dict = model2.state_dict()
+
+        assert set(model1_state_dict.keys()) == set(model2_state_dict.keys())
+
+        for k in model1_state_dict:
+            assert torch.equal(model1_state_dict[k], model2_state_dict[k])
+        estimator2.shutdown()
 
     def test_train_ray_sgd(self):
         def data_creator(config):

--- a/pyzoo/test/zoo/orca/learn/ray/pytorch/test_pytorch_estimator.py
+++ b/pyzoo/test/zoo/orca/learn/ray/pytorch/test_pytorch_estimator.py
@@ -27,44 +27,122 @@ import os
 from tempfile import TemporaryDirectory
 
 
-class TestPyTorchTrainer(TestCase):
-    def test_train(self):
+class TestPyTorchEstimator(TestCase):
+    # def test_train(self):
+    #     estimator = Estimator.from_torch(
+    #         model=model_creator,
+    #         optimizer=optimizer_creator,
+    #         loss=nn.MSELoss,
+    #         scheduler_creator=scheduler_creator,
+    #         config={
+    #             "lr": 1e-2,  # used in optimizer_creator
+    #             "hidden_size": 1,  # used in model_creator
+    #             "batch_size": 4,  # used in data_creator
+    #         })
+    #     stats1 = estimator.fit(train_data_creator, epochs=5)
+    #     train_loss1 = stats1[-1]["train_loss"]
+    #     validation_loss1 = estimator.evaluate(validation_data_creator)["val_loss"]
+    #
+    #     stats2 = estimator.fit(train_data_creator, epochs=3)
+    #     train_loss2 = stats2[-1]["train_loss"]
+    #     validation_loss2 = estimator.evaluate(validation_data_creator)["val_loss"]
+    #
+    #     assert train_loss2 <= train_loss1, (train_loss2, train_loss1)
+    #     assert validation_loss2 <= validation_loss1, (validation_loss2,
+    #                                                   validation_loss1)
+    #     estimator.shutdown()
+    #
+    # def test_save_and_restore(self):
+    #     estimator1 = Estimator.from_torch(
+    #         model=model_creator,
+    #         optimizer=optimizer_creator,
+    #         loss=nn.MSELoss,
+    #         scheduler_creator=scheduler_creator,
+    #         config={
+    #             "lr": 1e-2,  # used in optimizer_creator
+    #             "hidden_size": 1,  # used in model_creator
+    #             "batch_size": 4,  # used in data_creator
+    #         })
+    #     with TemporaryDirectory() as tmp_path:
+    #         estimator1.fit(train_data_creator, epochs=1)
+    #         checkpoint_path = os.path.join(tmp_path, "checkpoint")
+    #         estimator1.save(checkpoint_path)
+    #
+    #         model1 = estimator1.get_model()
+    #
+    #         estimator1.shutdown()
+    #
+    #         estimator2 = Estimator.from_torch(
+    #             model=model_creator,
+    #             optimizer=optimizer_creator,
+    #             loss=nn.MSELoss,
+    #             scheduler_creator=scheduler_creator,
+    #             config={
+    #                 "lr": 1e-2,  # used in optimizer_creator
+    #                 "hidden_size": 1,  # used in model_creator
+    #                 "batch_size": 4,  # used in data_creator
+    #             })
+    #         estimator2.load(checkpoint_path)
+    #
+    #         model2 = estimator2.get_model()
+    #
+    #     model1_state_dict = model1.state_dict()
+    #     model2_state_dict = model2.state_dict()
+    #
+    #     assert set(model1_state_dict.keys()) == set(model2_state_dict.keys())
+    #
+    #     for k in model1_state_dict:
+    #         assert torch.equal(model1_state_dict[k], model2_state_dict[k])
+    #     estimator2.shutdown()
+
+    def test_train_ray_sgd(self):
+        def data_creator(config):
+            return train_data_creator(config), validation_data_creator(config)
+
         estimator = Estimator.from_torch(
             model=model_creator,
             optimizer=optimizer_creator,
+            data_creator=data_creator,
             loss=nn.MSELoss,
-            scheduler_creator=scheduler_creator,
             config={
                 "lr": 1e-2,  # used in optimizer_creator
                 "hidden_size": 1,  # used in model_creator
                 "batch_size": 4,  # used in data_creator
-            })
-        stats1 = estimator.fit(train_data_creator, epochs=5)
+            },
+            backend='ray_sgd'
+        )
+        stats1 = estimator.fit(epochs=5)
         train_loss1 = stats1[-1]["train_loss"]
-        validation_loss1 = estimator.evaluate(validation_data_creator)["val_loss"]
+        validation_loss1 = estimator.evaluate()["val_loss"]
 
-        stats2 = estimator.fit(train_data_creator, epochs=3)
+        stats2 = estimator.fit(epochs=3)
         train_loss2 = stats2[-1]["train_loss"]
-        validation_loss2 = estimator.evaluate(validation_data_creator)["val_loss"]
+        validation_loss2 = estimator.evaluate()["val_loss"]
 
         assert train_loss2 <= train_loss1, (train_loss2, train_loss1)
         assert validation_loss2 <= validation_loss1, (validation_loss2,
                                                       validation_loss1)
         estimator.shutdown()
 
-    def test_save_and_restore(self):
+    def test_estimator_ray_sgd_save_and_restore(self):
+        def data_creator(config):
+            return train_data_creator(config), validation_data_creator(config)
+
         estimator1 = Estimator.from_torch(
             model=model_creator,
             optimizer=optimizer_creator,
+            data_creator=data_creator,
             loss=nn.MSELoss,
             scheduler_creator=scheduler_creator,
             config={
                 "lr": 1e-2,  # used in optimizer_creator
                 "hidden_size": 1,  # used in model_creator
                 "batch_size": 4,  # used in data_creator
-            })
+            },
+            backend='ray_sgd'
+        )
         with TemporaryDirectory() as tmp_path:
-            estimator1.fit(train_data_creator, epochs=1)
+            estimator1.fit(epochs=1)
             checkpoint_path = os.path.join(tmp_path, "checkpoint")
             estimator1.save(checkpoint_path)
 
@@ -75,13 +153,16 @@ class TestPyTorchTrainer(TestCase):
             estimator2 = Estimator.from_torch(
                 model=model_creator,
                 optimizer=optimizer_creator,
+                data_creator=data_creator,
                 loss=nn.MSELoss,
                 scheduler_creator=scheduler_creator,
                 config={
                     "lr": 1e-2,  # used in optimizer_creator
                     "hidden_size": 1,  # used in model_creator
                     "batch_size": 4,  # used in data_creator
-                })
+                },
+                backend='ray_sgd'
+            )
             estimator2.load(checkpoint_path)
 
             model2 = estimator2.get_model()


### PR DESCRIPTION
Add pytorch ray_sgd trainer support to Orca Pytorch Estimator.

Because pytorch ray sgd trainer need data_creator in constructor, add data_creator=None to Estimator.from_torch(). No need to give data option to fit and evaluate when use ray sgd trainner.

Add some APIs to PytorchTrainer.