### PR TITLE
[WIP] Cluster Serving performance - inference block all others

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/serving/ClusterServingInferenceBlockOthersExample.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/serving/ClusterServingInferenceBlockOthersExample.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 Analytics Zoo Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.zoo.examples.serving
+
+import org.apache.flink.api.common.functions.RichMapFunction
+import org.apache.flink.configuration.Configuration
+import org.apache.flink.streaming.api.functions.sink.{RichSinkFunction, SinkFunction}
+import org.apache.flink.streaming.api.functions.source.{RichParallelSourceFunction, SourceFunction}
+import org.apache.flink.streaming.api.scala.{StreamExecutionEnvironment, _}
+import org.apache.log4j.{Level, Logger}
+
+object ClusterServingInferenceBlockOthersExample {
+  class MySource extends RichParallelSourceFunction[String] {
+    var cnt = 0
+    @volatile var isRunning = true
+
+    override def open(parameters: Configuration): Unit = {
+      println("Source opened")
+    }
+    override def run(ctx: SourceFunction.SourceContext[String]): Unit =
+      while (isRunning) {
+        cnt += 1
+        ctx.collect(cnt.toString)
+      }
+
+    override def cancel(): Unit = {
+    }
+  }
+  class MyMap extends RichMapFunction[String, String] {
+    override def map(value: String): String = {
+      println(s"preprocessing")
+      Model.synchronized {
+        while (Model.queueing != 0) {
+          println("waiting during preprocessing")
+          Model.wait()
+        }
+      }
+      Thread.sleep(50)
+      println(s"predicting")
+      var res = ""
+      var holder: String = null
+      Model.synchronized {
+        Model.queueing += 1
+        while (Model.model == null) {
+          println("waiting during predict")
+          Model.wait()
+        }
+        holder = Model.model
+        Model.model = null
+      }
+      println(s"Model taken, name is: $holder")
+      res = holder + ": " + value
+      Thread.sleep(200)
+      Model.synchronized {
+        Model.model = "MyModel"
+        Model.queueing -= 1
+        Model.notifyAll()
+      }
+      res
+    }
+  }
+  class MySink extends RichSinkFunction[String] {
+    override def invoke(value: String, context: SinkFunction.Context[_]): Unit = {
+      println(s"value $value written to sink.")
+    }
+  }
+  Logger.getLogger("org").setLevel(Level.ERROR)
+  def main(args: Array[String]): Unit = {
+    val serving = StreamExecutionEnvironment.getExecutionEnvironment
+    serving.addSource(new MySource())
+      .map(new MyMap())
+      .addSink(new MySink())
+    serving.execute()
+  }
+}
+
+object Model {
+  var queueing: Int = 0
+  var model: String = "MyModel"
+}

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/inference/InferenceModel.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/inference/InferenceModel.scala
@@ -511,12 +511,15 @@ class InferenceModel(private var autoScalingEnabled: Boolean = true,
 
   private def predict(inputActivity: Activity): Activity = {
     val model = ModelHolder.synchronized {
+//      println(s"${System.currentTimeMillis()} Thread ${Thread.currentThread().getId} get lock")
       ModelHolder.modelQueueing += 1
-      while (modelQueue.peek() == null) ModelHolder.wait()
+      while (ModelHolder.nonOMP != 0 || modelQueue.peek() == null) ModelHolder.wait()
+//      println(s"${System.currentTimeMillis()} Thread ${Thread.currentThread().getId} try to get model")
       retrieveModel()
     }
     try {
       val begin = System.nanoTime()
+      InferenceSupportive.logger.info(s"Thread ${Thread.currentThread().getId} Inference start.")
       val result = model.predict(inputActivity)
       val end = System.nanoTime()
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/arrow/ArrowDeserializer.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/arrow/ArrowDeserializer.scala
@@ -68,6 +68,8 @@ class ArrowDeserializer {
       val vectorSchemaRoot = reader.getVectorSchemaRoot
       result = result :+ getFromSchemaRoot(vectorSchemaRoot)
     }
+//    readAllocator.close()
+    reader.close()
     result
   }
   def getString(arr: Array[(Array[Float], Array[Int])]): String = {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/baseline/InferenceBaseline.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/baseline/InferenceBaseline.scala
@@ -85,8 +85,9 @@ object InferenceBaseline extends Supportive {
 
     val model = helper.loadInferenceModel()
     val warmT = makeTensorFromShape(param.inputShape)
-    ClusterServingInference.typeCheck(warmT)
-    ClusterServingInference.dimCheck(warmT, "add", sParam.modelType)
+    val clusterServingInference = new ClusterServingInference(null, "openvino")
+    clusterServingInference.typeCheck(warmT)
+    clusterServingInference.dimCheck(warmT, "add", sParam.modelType)
     (0 until 10).foreach(_ => {
       val result = model.doPredict(warmT)
     })
@@ -107,14 +108,14 @@ object InferenceBaseline extends Supportive {
       )
       (0 until param.testNum).grouped(sParam.coreNum).flatMap(batch => {
           val t = timer.timing("Batch input", batch.size) {
-            ClusterServingInference.batchInput(a, sParam.coreNum, true, sParam.resize)
+            clusterServingInference.batchInput(a, sParam.coreNum, true, sParam.resize)
           }
-          ClusterServingInference.dimCheck(t, "add", sParam.modelType)
+          clusterServingInference.dimCheck(t, "add", sParam.modelType)
           val result = timer.timing("Inference", batch.size) {
             model.doPredict(t)
           }
-          ClusterServingInference.dimCheck(t, "remove", sParam.modelType)
-          ClusterServingInference.dimCheck(result, "remove", sParam.modelType)
+          clusterServingInference.dimCheck(t, "remove", sParam.modelType)
+          clusterServingInference.dimCheck(result, "remove", sParam.modelType)
 
           Seq()
       }).toArray

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/baseline/OpenVINOBaseline.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/baseline/OpenVINOBaseline.scala
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2018 Analytics Zoo Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.zoo.serving.baseline
+
+import java.util.Base64
+
+import com.intel.analytics.bigdl.nn.abstractnn.Activity
+import com.intel.analytics.bigdl.tensor.Tensor
+import com.intel.analytics.bigdl.utils.T
+import com.intel.analytics.zoo.pipeline.api.net.TFNet
+import com.intel.analytics.zoo.pipeline.inference.{DeviceType, InferenceModelFactory, OpenVINOModel, OpenVinoInferenceSupportive}
+import com.intel.analytics.zoo.serving.PreProcessing
+import com.intel.analytics.zoo.serving.arrow.{ArrowDeserializer, ArrowSerializer}
+import com.intel.analytics.zoo.serving.engine.{ClusterServingInference, ModelHolder, Timer}
+import com.intel.analytics.zoo.serving.utils.{ClusterServingHelper, SerParams, Supportive}
+import scopt.OptionParser
+
+object OpenVINOBaseline extends Supportive {
+  case class Params(configPath: String = "config.yaml",
+                    testNum: Int = 1000,
+                    parNum: Int = 1,
+                    inputShape: String = "3, 224, 224")
+  val parser = new OptionParser[Params]("Text Classification Example") {
+    opt[String]('c', "configPath")
+      .text("Config Path of Cluster Serving")
+      .action((x, params) => params.copy(configPath = x))
+    opt[Int]('n', "testNum")
+      .text("Number of test input")
+      .action((x, params) => params.copy(testNum = x))
+    opt[Int]('p', "parallelism")
+      .text("Parallelism number, align to Flink -p")
+      .action((x, params) => params.copy(parNum = x))
+    opt[String]('s', "inputShape")
+      .text("Input Shape, split by coma")
+      .action((x, params) => params.copy(inputShape = x))
+  }
+  def parseShape(shape: String): Array[Array[Int]] = {
+    val shapeListStr = shape.
+      split("""\[\[|\]\]|\],\s*\[""").filter(x => x != "")
+    var shapeList = new Array[Array[Int]](shapeListStr.length)
+    (0 until shapeListStr.length).foreach(idx => {
+      val arr = shapeListStr(idx).stripPrefix("[").stripSuffix("]").split(",")
+      val thisShape = new Array[Int](arr.length)
+      (0 until arr.length).foreach(i => {
+        thisShape(i) = arr(i).trim.toInt
+      })
+      shapeList(idx) = thisShape
+    })
+    shapeList
+  }
+  def makeTensorFromShape(shapeStr: String): Activity = {
+    val shapeArr = parseShape(shape = shapeStr)
+    if (shapeArr.length == 1) {
+      Tensor[Float](shapeArr(0)).rand()
+    }
+    else {
+      throw new Error("multiple dim not supported yet")
+    }
+  }
+  def getBase64StringOfTensor(activity: Activity): String = {
+    val byteArr = ArrowSerializer.activityBatchToByte(activity, 1)
+    Base64.getEncoder.encodeToString(byteArr)
+  }
+  def main(args: Array[String]): Unit = {
+    val param = parser.parse(args, Params()).head
+    val helper = new ClusterServingHelper()
+    helper.initArgs()
+    val sParam = new SerParams(helper)
+
+
+    val warmT = makeTensorFromShape(param.inputShape)
+    ClusterServingInference.typeCheck(warmT)
+    ClusterServingInference.dimCheck(warmT, "add", sParam.modelType)
+
+    println("Warming up finished, begin baseline test...generating Base64 string")
+
+
+
+    Thread.sleep(3000)
+
+
+    timing(s"Baseline for parallel pipeline ${param.parNum} " +
+      s"with input ${param.testNum.toString}") {
+
+      (0 until param.parNum).indices.toParArray.foreach(_ => {
+        val model = OpenVinoInferenceSupportive.loadOpenVinoIR(
+          helper.defPath, helper.weightPath, DeviceType.CPU, helper.coreNum)
+        val t = warmT
+        model.predict(t)
+//        val model = TFNet(helper.weightPath)
+//        val t = warmT.toTensor[Float].transpose(2, 4).contiguous()
+//        model.forward(t)
+        val b64string = getBase64StringOfTensor(t)
+        println(s"Previewing base64 string, prefix is ${b64string.substring(0, 20)}")
+
+
+        val timer = new Timer()
+        var a = Seq[(String, String)]()
+        val pre = new PreProcessing(true)
+        (0 until sParam.coreNum).foreach( i =>
+          a = a :+ (i.toString(), b64string)
+        )
+        (0 until param.testNum).grouped(sParam.coreNum).flatMap(i => {
+          val preprocessed = timer.timing(s"Thread ${Thread.currentThread().getId} Preprocess", sParam.coreNum) {
+            a.map(item => {
+              val deserializer = new ArrowDeserializer()
+              val arr = deserializer.create(b64string)
+              val tensor = Tensor(arr(0)._1, arr(0)._2)
+              println(s"${System.currentTimeMillis()} Thread ${Thread.currentThread().getId} preprocess finished")
+              (item._1, T(tensor))
+            })
+          }
+          val t = timer.timing(s"Thread ${Thread.currentThread().getId} Batch input", sParam.coreNum) {
+            ClusterServingInference.batchInput(preprocessed, sParam.coreNum, false, sParam.resize)
+          }
+          ClusterServingInference.dimCheck(t, "add", sParam.modelType)
+          val result = timer.timing(s"Thread ${Thread.currentThread().getId} Inference", sParam.coreNum) {
+            model.predict(t)
+//              model.forward(t)
+          }
+          ClusterServingInference.dimCheck(t, "remove", sParam.modelType)
+          ClusterServingInference.dimCheck(result, "remove", sParam.modelType)
+          val postprocessed = timer.timing(s"Thread ${Thread.currentThread().getId} Postprocess", sParam.coreNum) {
+            (0 until sParam.coreNum).map(i => {
+              ArrowSerializer.activityBatchToByte(result, i + 1)
+            })
+          }
+
+          Seq(postprocessed)
+        }).toArray
+        timer.print()
+      })
+
+    }
+
+
+
+
+  }
+}

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/baseline/PreprocessingBaseline.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/baseline/PreprocessingBaseline.scala
@@ -23,11 +23,11 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.T
 import com.intel.analytics.zoo.serving.PreProcessing
 import com.intel.analytics.zoo.serving.arrow.{ArrowDeserializer, ArrowSerializer}
-import com.intel.analytics.zoo.serving.engine.{ClusterServingInference, Timer}
+import com.intel.analytics.zoo.serving.engine.{ClusterServingInference, ModelHolder, Timer}
 import com.intel.analytics.zoo.serving.utils.{ClusterServingHelper, SerParams, Supportive}
 import scopt.OptionParser
 
-object MockSinglePipelineBaseline extends Supportive {
+object PreprocessingBaseline extends Supportive {
   case class Params(configPath: String = "config.yaml",
                     testNum: Int = 1000,
                     parNum: Int = 1,
@@ -79,60 +79,53 @@ object MockSinglePipelineBaseline extends Supportive {
     helper.initArgs()
     val sParam = new SerParams(helper)
 
-    val model = helper.loadInferenceModel()
     val warmT = makeTensorFromShape(param.inputShape)
-    val clusterServingInference = new ClusterServingInference(null, "openvino")
-    clusterServingInference.typeCheck(warmT)
-    clusterServingInference.dimCheck(warmT, "add", sParam.modelType)
-    (0 until 10).foreach(_ => {
-      val result = model.doPredict(warmT)
-    })
-    println("Warming up finished, begin baseline test...generating Base64 string")
-
     val b64string = getBase64StringOfTensor(warmT)
     println(s"Previewing base64 string, prefix is ${b64string.substring(0, 20)}")
-    Thread.sleep(3000)
-
-    val timer = new Timer()
-    timing(s"Base line for single pipeline " +
+    timing(s"Baseline for parallel pipeline ${param.parNum} " +
       s"with input ${param.testNum.toString}") {
-      var a = Seq[(String, String)]()
-      val pre = new PreProcessing(true)
-      (0 until sParam.coreNum).foreach( i =>
-        a = a :+ (i.toString(), b64string)
-      )
-      (0 until param.testNum).grouped(sParam.coreNum).flatMap(batch => {
-        val preprocessed = timer.timing("Preprocess", batch.size) {
-          (0 until batch.size).toParArray.map(i => {
-            val tensor = timer.timing(s"Thread ${Thread.currentThread().getId} Preprocess one record", sParam.coreNum) {
-              val deserializer = new ArrowDeserializer()
-              val arr = deserializer.create(b64string)
-              Tensor(arr(0)._1, arr(0)._2)
-            }
 
-            (a(i)._1, T(tensor))
-          }).toIterator
-        }
-        preprocessed.grouped(batch.size).flatMap(b => {
-          val t = timer.timing("Batch input", batch.size) {
-            clusterServingInference.batchInput(b, sParam.coreNum, true, sParam.resize)
-          }
-          clusterServingInference.dimCheck(t, "add", sParam.modelType)
-          val result = timer.timing("Inference", batch.size) {
-            model.doPredict(t)
-          }
-          clusterServingInference.dimCheck(t, "remove", sParam.modelType)
-          clusterServingInference.dimCheck(result, "remove", sParam.modelType)
-          val postprocessed = timer.timing("Postprocess", batch.size) {
-            (0 until sParam.coreNum).map(i => {
-              ArrowSerializer.activityBatchToByte(result, i + 1)
+      (0 until param.parNum).indices.toParArray.foreach(_ => {
+        val timer = new Timer()
+        var a = Seq[(String, String)]()
+        val pre = new PreProcessing(true)
+        (0 until sParam.coreNum).foreach( i =>
+          a = a :+ (i.toString(), b64string)
+        )
+        (0 until param.testNum).grouped(sParam.coreNum).flatMap(i => {
+          val preprocessed = timer.timing(s"Thread ${Thread.currentThread().getId} Preprocess", sParam.coreNum) {
+            a.map(item => {
+              ModelHolder.synchronized{
+                while (ModelHolder.modelQueueing != 0) {
+                  ModelHolder.wait()
+                }
+                ModelHolder.nonOMP += 1
+              }
+              val tensor = timer.timing(s"Thread ${Thread.currentThread().getId} Preprocess one record", sParam.coreNum) {
+                val deserializer = new ArrowDeserializer()
+                val arr = deserializer.create(b64string)
+                Tensor(arr(0)._1, arr(0)._2)
+              }
+              ModelHolder.synchronized {
+                ModelHolder.modelQueueing += 1
+              }
+              Thread.sleep(50)
+              ModelHolder.synchronized {
+                ModelHolder.modelQueueing -= 1
+              }
+              ModelHolder.synchronized{
+                ModelHolder.nonOMP -= 1
+                ModelHolder.notifyAll()
+              }
+              (item._1, T(tensor))
+
             })
           }
-          Seq(postprocessed)
-        })
+          Seq(preprocessed)
+        }).toArray
+        timer.print()
+      })
 
-      }).toArray
-      timer.print()
     }
 
 
@@ -140,4 +133,3 @@ object MockSinglePipelineBaseline extends Supportive {
 
   }
 }
-

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/Timer.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/Timer.scala
@@ -66,11 +66,11 @@ class Timer() {
   var timerMap = Map[String, TimerUnit]()
 
   def timing[T](name: String, num: Int)(f: => T): T = {
-    val begin = System.currentTimeMillis
+    val begin = System.nanoTime()
     val result = f
-    val end = System.currentTimeMillis
+    val end = System.nanoTime()
     val cost = (end - begin)
-    Logger.getLogger(getClass).info(s"$name time elapsed [${cost / 1000} s, ${cost % 1000} ms].")
+    Logger.getLogger(getClass).info(s"$name time elapsed [${(cost / 1e9).toInt} s, ${cost / 1e6} ms].")
     if (!timerMap.contains(name)) {
       timerMap += (name -> new TimerUnit())
     }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/operator/ClusterServingInferenceOperator.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/operator/ClusterServingInferenceOperator.scala
@@ -28,7 +28,7 @@ import org.apache.log4j.Logger
 class ClusterServingInferenceOperator(var params: ClusterServingParams = null)
   extends RichMapFunction[List[(String, Activity)], List[(String, String)]] {
   var logger: Logger = null
-  var pre: PreProcessing = null
+  var inference = new ClusterServingInference(null, params._modelType)
 
   override def open(parameters: Configuration): Unit = {
     logger = Logger.getLogger(getClass)
@@ -71,7 +71,7 @@ class ClusterServingInferenceOperator(var params: ClusterServingParams = null)
   override def map(in: List[(String, Activity)]): List[(String, String)] = {
     val t1 = System.nanoTime()
     val postProcessed =
-      ClusterServingInference.singleThreadInference(in.toIterator, params._modelType, "").toList
+      inference.singleThreadInference(in).toList
     val t2 = System.nanoTime()
     logger.info(s"${postProcessed.size} records backend time ${(t2 - t1) / 1e9} s. " +
       s"Throughput ${postProcessed.size / ((t2 - t1) / 1e9)}")

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/preprocessing/PreProcessing.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/preprocessing/PreProcessing.scala
@@ -35,9 +35,6 @@ import org.opencv.imgproc.Imgproc
 class PreProcessing(chwFlag: Boolean = true) {
   val logger = Logger.getLogger(getClass)
 
-  var tensorBuffer: Array[Tensor[Float]] = null
-  var arrayBuffer: Array[Array[Float]] = null
-
   var byteBuffer: Array[Byte] = null
 
 

--- a/zoo/src/test/scala/com/intel/analytics/zoo/serving/CorrectnessSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/serving/CorrectnessSpec.scala
@@ -105,7 +105,7 @@ class CorrectnessSpec extends FlatSpec with Matchers {
     logger.info(s"${fileList.size} images about to enqueue...")
 
     val pre = new PreProcessing(param.chwFlag)
-    pre.arrayBuffer = Array(new Array[Float](3 * 224 * 224))
+    val clusterServingInference = new ClusterServingInference(pre, param.modelType)
     var predictMap = Map[String, String]()
 
     for (file <- fileList) {
@@ -123,7 +123,7 @@ class CorrectnessSpec extends FlatSpec with Matchers {
       val inputBase64 = new String(java.util.Base64.getEncoder
        .encode(instances.toArrow()))
       val input = pre.decodeArrowBase64(inputBase64)
-      val bInput = ClusterServingInference.batchInput(Seq(("", input)), 1, true, false)
+      val bInput = clusterServingInference.batchInput(Seq(("", input)), 1, true, false)
       val result = model.doPredict(bInput)
       val value = PostProcessing(result.toTensor[Float]
         .squeeze(1), "topN(1)", 1)


### PR DESCRIPTION
Example contains basic logic of blocking, `Model.queueing` is variable about how many threads are waiting for the model. 

Model inference should take the highest priority ideally. Because if one thread is waiting but no thread is doing inference, this thread is wasted. And inference should block other non-OMP threads in order to avoid conflict.

Please check if any potential bug or overhead if available.