### PR TITLE
Fix validate in Orca PyTorch Estimator

### DIFF
--- a/pyzoo/dev/run-pytests-horovod-pytorch
+++ b/pyzoo/dev/run-pytests-horovod-pytorch
@@ -24,7 +24,7 @@ export PYSPARK_PYTHON=python
 export PYSPARK_DRIVER_PYTHON=python
 
 echo "Running RayOnSpark tests"
-python -m pytest -v ../test/zoo/orca/learn/ray/pytorch/test_pytorch_estimator.py
+python -m pytest -v ../test/zoo/orca/learn/ray/pytorch/test_estimator_horovod_backend.py
 exit_status_1=$?
 if [ $exit_status_1 -ne 0 ];
 then

--- a/pyzoo/dev/run-pytests-ray
+++ b/pyzoo/dev/run-pytests-ray
@@ -35,7 +35,7 @@ fi
 
 echo "Running orca learn ray tests"
 python -m pytest -v ../test/zoo/orca/learn/ray \
-       --ignore=../test/zoo/orca/learn/ray/pytorch/test_pytorch_estimator.py \
+       --ignore=../test/zoo/orca/learn/ray/pytorch/test_estimator_horovod_backend.py \
        --ignore=../test/zoo/orca/learn/ray/tf/ 
 exit_status_2=$?
 if [ $exit_status_2 -ne 0 ];

--- a/pyzoo/test/zoo/orca/learn/ray/pytorch/test_estimator_horovod_backend.py
+++ b/pyzoo/test/zoo/orca/learn/ray/pytorch/test_estimator_horovod_backend.py
@@ -27,7 +27,7 @@ import os
 from tempfile import TemporaryDirectory
 
 
-class TestPyTorchTrainer(TestCase):
+class TestPyTorchEstimator(TestCase):
     def test_train(self):
         estimator = Estimator.from_torch(
             model=model_creator,

--- a/pyzoo/test/zoo/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
+++ b/pyzoo/test/zoo/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
@@ -90,7 +90,7 @@ def get_optimizer(model, config):
     return torch.optim.SGD(model.parameters(), lr=config.get("lr", 1e-2))
 
 
-class TestPyTorchTrainer(TestCase):
+class TestPyTorchEstimator(TestCase):
     def test_linear(self):
         estimator = Estimator.from_torch(model=get_model,
                                          optimizer=get_optimizer,

--- a/pyzoo/test/zoo/orca/learn/ray/pytorch/test_pytorch_trainer.py
+++ b/pyzoo/test/zoo/orca/learn/ray/pytorch/test_pytorch_trainer.py
@@ -28,10 +28,13 @@ np.random.seed(1337)  # for reproducibility
 class LinearDataset(torch.utils.data.Dataset):
     """y = a * x + b"""
 
-    def __init__(self, a, b, size=1000):
-        x = np.arange(0, 10, 10 / size, dtype=np.float32)
-        self.x = torch.from_numpy(x)
-        self.y = torch.from_numpy(a * x + b)
+    def __init__(self, size=1000):
+        X1 = torch.randn(size // 2, 50)
+        X2 = torch.randn(size // 2, 50) + 1.5
+        self.x = torch.cat([X1, X2], dim=0)
+        Y1 = torch.zeros(size // 2, 1)
+        Y2 = torch.ones(size // 2, 1)
+        self.y = torch.cat([Y1, Y2], dim=0)
 
     def __getitem__(self, index):
         return self.x[index, None], self.y[index, None]
@@ -40,8 +43,30 @@ class LinearDataset(torch.utils.data.Dataset):
         return len(self.x)
 
 
+class Net(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(50, 50)
+        self.relu1 = nn.ReLU()
+        self.dout = nn.Dropout(0.2)
+        self.fc2 = nn.Linear(50, 100)
+        self.prelu = nn.PReLU(1)
+        self.out = nn.Linear(100, 1)
+        self.out_act = nn.Sigmoid()
+
+    def forward(self, input_):
+        a1 = self.fc1(input_)
+        h1 = self.relu1(a1)
+        dout = self.dout(h1)
+        a2 = self.fc2(dout)
+        h2 = self.prelu(a2)
+        a3 = self.out(h2)
+        y = self.out_act(a3)
+        return y
+
+
 def train_data_loader(config):
-    train_dataset = LinearDataset(2, 5, size=config.get("data_size", 1000))
+    train_dataset = LinearDataset(size=config.get("data_size", 1000))
     train_loader = torch.utils.data.DataLoader(
         train_dataset,
         batch_size=config.get("batch_size", 32),
@@ -50,7 +75,7 @@ def train_data_loader(config):
 
 
 def val_data_loader(config):
-    val_dataset = LinearDataset(2, 5, size=config.get("val_size", 400))
+    val_dataset = LinearDataset(size=config.get("val_size", 400))
     validation_loader = torch.utils.data.DataLoader(
         val_dataset,
         batch_size=config.get("batch_size", 32))
@@ -58,7 +83,7 @@ def val_data_loader(config):
 
 
 def get_model(config):
-    return nn.Linear(1, config.get("hidden_size", 1))
+    return Net()
 
 
 def get_optimizer(model, config):
@@ -69,15 +94,15 @@ class TestPyTorchTrainer(TestCase):
     def test_linear(self):
         estimator = Estimator.from_torch(model=get_model,
                                          optimizer=get_optimizer,
-                                         loss=nn.MSELoss(),
-                                         config={"lr": 1e-2, "hidden_size": 1,
+                                         loss=nn.BCELoss(),
+                                         config={"lr": 1e-2,
                                                  "batch_size": 128},
                                          backend="pytorch")
         train_stats = estimator.fit(train_data_loader, epochs=2)
         print(train_stats)
-        # it seems validate on regression model is not supported
-        # val_stats = estimator.evaluate(val_data_loader)
-        # print(val_stats)
+        val_stats = estimator.evaluate(val_data_loader)
+        print(val_stats)
+        assert 0 < val_stats["val_accuracy"] < 1
         assert estimator.get_model()
         estimator.shutdown()
 

--- a/pyzoo/zoo/orca/learn/pytorch/training_operator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/training_operator.py
@@ -386,7 +386,7 @@ class TrainingOperator:
         else:  # Multi-class classification
             np_output = np.argmax(np_output, axis=1)
 
-        num_correct = np.sum((np_output == np_target).astype(np.uint8))
+        num_correct = np.sum(np_output == np_target)
         num_samples = target.size(0)
         return {
             "val_loss": loss.item(),

--- a/pyzoo/zoo/orca/learn/pytorch/training_operator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/training_operator.py
@@ -364,7 +364,7 @@ class TrainingOperator:
         with self.timers.record("eval_fwd"):
             output = self.model(*features)
             loss = self.criterion(output, target)
-            if len(output.size()) > 2:
+            if len(output.size()) > 1:
                 # In case there is extra trailing dimensions.
                 for i in reversed(range(1, len(output.size()))):
                     output = torch.squeeze(output, i)

--- a/pyzoo/zoo/orca/learn/pytorch/training_operator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/training_operator.py
@@ -349,11 +349,10 @@ class TrainingOperator:
         """
         # unpack features into list to support multiple inputs model
         *features, target = batch
-        _target = target
-        if len(_target.size()) > 1:
+        if len(target.size()) > 1:
             # Can't directly call torch.squeeze() in case batch size is 1.
-            for i in reversed(range(1, len(_target.size()))):
-                _target = torch.squeeze(_target, i)
+            for i in reversed(range(1, len(target.size()))):
+                target = torch.squeeze(target, i)
 
         if self.use_gpu:
             features = [
@@ -365,14 +364,13 @@ class TrainingOperator:
         with self.timers.record("eval_fwd"):
             output = self.model(*features)
             loss = self.criterion(output, target)
-            _output = output
-            if len(_output.size()) > 2:
+            if len(output.size()) > 2:
                 # In case there is extra trailing dimensions.
-                for i in reversed(range(1, len(_output.size()))):
-                    _output = torch.squeeze(_output, i)
+                for i in reversed(range(1, len(output.size()))):
+                    output = torch.squeeze(output, i)
 
-        np_output = _output.detach().numpy()
-        np_target = _target.detach().numpy()
+        np_output = output.detach().numpy()
+        np_target = target.detach().numpy()
         # validate will be called by TCMF to get val_loss for regression tasks.
         # In this case, accuracy is calculated but not used and the result is wrong.
         # So do not directly raise an Exception here to avoid errors in TCMF.


### PR DESCRIPTION
- If target is of size (batch, 1) and predicted of size (batch, ), the accuracy calculation `target == predicted` would result in a tensor of size (batch, batch), which is wrong.
- Also accuracy for binary classification is not supported previously.
- Handle cases where output or target has extra singleton dimensions.
- Add unit tests to cover this. 