### PR TITLE
Support SparkXShards for PyTorch Ray Estimator

### DIFF
--- a/pyzoo/test/zoo/orca/learn/ray/pytorch/test_estimator_horovod_backend.py
+++ b/pyzoo/test/zoo/orca/learn/ray/pytorch/test_estimator_horovod_backend.py
@@ -36,14 +36,13 @@ class TestPyTorchEstimator(TestCase):
             scheduler_creator=scheduler_creator,
             config={
                 "lr": 1e-2,  # used in optimizer_creator
-                "hidden_size": 1,  # used in model_creator
-                "batch_size": 4,  # used in data_creator
+                "hidden_size": 1  # used in model_creator
             }, backend="horovod")
-        stats1 = estimator.fit(train_data_creator, epochs=5)
+        stats1 = estimator.fit(train_data_creator, batch_size=4, epochs=5)
         train_loss1 = stats1[-1]["train_loss"]
         validation_loss1 = estimator.evaluate(validation_data_creator)["val_loss"]
 
-        stats2 = estimator.fit(train_data_creator, epochs=3)
+        stats2 = estimator.fit(train_data_creator, batch_size=4, epochs=3)
         train_loss2 = stats2[-1]["train_loss"]
         validation_loss2 = estimator.evaluate(validation_data_creator)["val_loss"]
 
@@ -60,11 +59,10 @@ class TestPyTorchEstimator(TestCase):
             scheduler_creator=scheduler_creator,
             config={
                 "lr": 1e-2,  # used in optimizer_creator
-                "hidden_size": 1,  # used in model_creator
-                "batch_size": 4,  # used in data_creator
+                "hidden_size": 1  # used in model_creator
             }, backend="horovod")
         with TemporaryDirectory() as tmp_path:
-            estimator1.fit(train_data_creator, epochs=1)
+            estimator1.fit(train_data_creator, batch_size=4, epochs=1)
             checkpoint_path = os.path.join(tmp_path, "checkpoint")
             estimator1.save(checkpoint_path)
 
@@ -79,8 +77,7 @@ class TestPyTorchEstimator(TestCase):
                 scheduler_creator=scheduler_creator,
                 config={
                     "lr": 1e-2,  # used in optimizer_creator
-                    "hidden_size": 1,  # used in model_creator
-                    "batch_size": 4,  # used in data_creator
+                    "hidden_size": 1  # used in model_creator
                 }, backend="horovod")
             estimator2.load(checkpoint_path)
 

--- a/pyzoo/test/zoo/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
+++ b/pyzoo/test/zoo/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
@@ -106,14 +106,13 @@ class TestPyTorchEstimator(TestCase):
         estimator.shutdown()
 
     def test_linear_spark_xshards(self):
+        from zoo import init_nncontext
+        from zoo.orca.data import SparkXShards
         estimator = Estimator.from_torch(model=get_model,
                                          optimizer=get_optimizer,
                                          loss=nn.BCELoss(),
-                                         config={"lr": 1e-2,
-                                                 "batch_size": 128},
+                                         config={"lr": 1e-1},
                                          backend="pytorch")
-        from zoo import init_nncontext
-        from zoo.orca.data import SparkXShards
         sc = init_nncontext()
         x_rdd = sc.parallelize(np.random.rand(4000, 1, 50).astype(np.float32))
         y_rdd = sc.parallelize(np.random.randint(0, 2, size=(4000, 1)).astype(np.float32))
@@ -121,9 +120,9 @@ class TestPyTorchEstimator(TestCase):
         train_rdd, val_rdd = rdd.randomSplit([0.9, 0.1])
         train_xshards = SparkXShards(train_rdd)
         val_xshards = SparkXShards(val_rdd)
-        train_stats = estimator.fit(train_xshards, batch_size=128, epochs=2)
+        train_stats = estimator.fit(train_xshards, batch_size=256, epochs=2)
         print(train_stats)
-        val_stats = estimator.evaluate(val_xshards, batch_size=32)
+        val_stats = estimator.evaluate(val_xshards, batch_size=128)
         print(val_stats)
         estimator.shutdown()
 

--- a/pyzoo/test/zoo/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
+++ b/pyzoo/test/zoo/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
@@ -95,15 +95,36 @@ class TestPyTorchEstimator(TestCase):
         estimator = Estimator.from_torch(model=get_model,
                                          optimizer=get_optimizer,
                                          loss=nn.BCELoss(),
-                                         config={"lr": 1e-2,
-                                                 "batch_size": 128},
+                                         config={"lr": 1e-2},
                                          backend="pytorch")
-        train_stats = estimator.fit(train_data_loader, epochs=2)
+        train_stats = estimator.fit(train_data_loader, epochs=2, batch_size=128)
         print(train_stats)
-        val_stats = estimator.evaluate(val_data_loader)
+        val_stats = estimator.evaluate(val_data_loader, batch_size=64)
         print(val_stats)
         assert 0 < val_stats["val_accuracy"] < 1
         assert estimator.get_model()
+        estimator.shutdown()
+
+    def test_linear_spark_xshards(self):
+        estimator = Estimator.from_torch(model=get_model,
+                                         optimizer=get_optimizer,
+                                         loss=nn.BCELoss(),
+                                         config={"lr": 1e-2,
+                                                 "batch_size": 128},
+                                         backend="pytorch")
+        from zoo import init_nncontext
+        from zoo.orca.data import SparkXShards
+        sc = init_nncontext()
+        x_rdd = sc.parallelize(np.random.rand(4000, 1, 50).astype(np.float32))
+        y_rdd = sc.parallelize(np.random.randint(0, 2, size=(4000, 1)).astype(np.float32))
+        rdd = x_rdd.zip(y_rdd).map(lambda x_y: {'x': x_y[0], 'y': x_y[1]})
+        train_rdd, val_rdd = rdd.randomSplit([0.9, 0.1])
+        train_xshards = SparkXShards(train_rdd)
+        val_xshards = SparkXShards(val_rdd)
+        train_stats = estimator.fit(train_xshards, batch_size=128, epochs=2)
+        print(train_stats)
+        val_stats = estimator.evaluate(val_xshards, batch_size=32)
+        print(val_stats)
         estimator.shutdown()
 
 

--- a/pyzoo/zoo/examples/orca/learn/horovod/pytorch_estimator.py
+++ b/pyzoo/zoo/examples/orca/learn/horovod/pytorch_estimator.py
@@ -85,12 +85,11 @@ def train_example(workers_per_node):
         workers_per_node=workers_per_node,
         config={
             "lr": 1e-2,  # used in optimizer_creator
-            "hidden_size": 1,  # used in model_creator
-            "batch_size": 4,  # used in data_creator
+            "hidden_size": 1  # used in model_creator
         }, backend="horovod")
 
     # train 5 epochs
-    stats = estimator.fit(train_data_creator, epochs=5)
+    stats = estimator.fit(train_data_creator, batch_size=4, epochs=5)
     print("train stats: {}".format(stats))
     val_stats = estimator.evaluate(validation_data_creator)
     print("validation stats: {}".format(val_stats))

--- a/pyzoo/zoo/orca/data/ray_rdd.py
+++ b/pyzoo/zoo/orca/data/ray_rdd.py
@@ -112,10 +112,14 @@ class RayRdd:
         return ray.get(self.meta_store.num_partitions.remote())
 
     def collect(self):
-        partition_refs = ray.get(self.meta_store.get_all_partition_refs.remote())
-        partitions = ray.get(partition_refs)
+        partitions = self.collect_partitions()
         data = [item for part in partitions for item in part]
         return data
+
+    def collect_partitions(self):
+        partition_refs = ray.get(self.meta_store.get_all_partition_refs.remote())
+        partitions = ray.get(partition_refs)
+        return partitions
 
     def to_spark_rdd(self):
         ray_ctx = RayContext.get()

--- a/pyzoo/zoo/orca/data/shard.py
+++ b/pyzoo/zoo/orca/data/shard.py
@@ -151,6 +151,10 @@ class RayXShards(XShards):
     def collect(self):
         return self.ray_rdd.collect()
 
+    # Collect without flattening the results.
+    def collect_partitions(self):
+        return self.ray_rdd.collect_partitions()
+
     def num_partitions(self):
         return self.ray_rdd.num_partitions()
 

--- a/pyzoo/zoo/orca/data/utils.py
+++ b/pyzoo/zoo/orca/data/utils.py
@@ -143,55 +143,46 @@ def flatten_xy(allow_tuple=True, allow_list=True):
     return _flatten_xy
 
 
+def combine(data_list):
+    item = data_list[0]
+    if isinstance(item, dict):
+        res = {}
+        for k, v in item.items():
+            res[k] = np.concatenate([data[k] for data in data_list], axis=0)
+    elif isinstance(item, list) or isinstance(item, tuple):
+        res = []
+        for i in range(len(data_list[0])):
+            res.append(np.concatenate([data[i] for data in data_list], axis=0))
+        if isinstance(item, tuple):
+            res = tuple(res)
+    elif isinstance(data_list[0], np.ndarray):
+        res = np.concatenate(data_list, axis=0)
+    else:
+        raise ValueError(
+            "value of x and y should be an ndarray, a dict of ndarrays, a tuple of ndarrays"
+            " or a list of ndarrays, please check your input")
+    return res
+
+
 def ray_partition_get_data_label(partition_data,
                                  allow_tuple=True,
                                  allow_list=True,
-                                 get_label=True):
+                                 has_label=True):
     """
-    :param partition_data:
-    :param allow_tuple: boolean, if the model accepts a tuple as input. Default: True
-    :param allow_list: boolean, if the model accepts a list as input. Default: True
-    :return:
+    :param partition_data: The data partition from Spark RDD, which should be a list of records.
+    :param allow_tuple: Boolean. Whether the model accepts a tuple as input. Default is True.
+    :param allow_list: Boolean. Whether the model accepts a list as input. Default is True.
+    :param has_label: Boolean. Whether the data partition contains labels.
+    :return: Concatenated data for the data partition.
     """
-    from functools import reduce
-
-    def combine_dict(dict1, dict2):
-        return {key: np.concatenate((value, dict2[key]), axis=0)
-                for (key, value) in dict1.items()}
-
-    def combine_list(list1, list2):
-        return [np.concatenate((list1[index], list2[index]), axis=0)
-                for index in range(0, len(list1))]
-
-    def combine_tuple(tuple1, tuple2):
-        return tuple(np.concatenate((tuple1[index], tuple2[index]), axis=0)
-                     for index in range(0, len(tuple1)))
-
-    def check_type_and_combine(data_list):
-        if isinstance(data_list[0], dict):
-            return reduce(lambda dict1, dict2: combine_dict(dict1, dict2), data_list)
-        elif isinstance(data_list[0], np.ndarray):
-            return reduce(lambda array1, array2: np.concatenate((array1, array2), axis=0),
-                          data_list)
-        elif isinstance(data_list[0], list):
-            data = reduce(lambda list1, list2: combine_list(list1, list2), data_list)
-            data = _convert_list_tuple(data, allow_tuple=allow_tuple, allow_list=allow_list)
-            return data
-        elif isinstance(data_list[0], tuple):
-            data = reduce(lambda tuple1, tuple2: combine_tuple(tuple1, tuple2), data_list)
-            data = _convert_list_tuple(data, allow_tuple=allow_tuple, allow_list=allow_list)
-            return data
-        else:
-            raise ValueError(
-                "value of x and y should be an ndarray, a dict of ndarrays, a tuple of ndarrays"
-                " or a list of ndarrays, please check your input")
-
     data_list = [data['x'] for data in partition_data]
     label_list = [data['y'] for data in partition_data]
 
-    data = check_type_and_combine(data_list)
-    if get_label:
-        label = check_type_and_combine(label_list)
+    data = _convert_list_tuple(combine(data_list),
+                               allow_tuple=allow_tuple, allow_list=allow_list)
+    if has_label:
+        label = _convert_list_tuple(combine(label_list),
+                                    allow_tuple=allow_tuple, allow_list=allow_list)
     else:
         label = None
 
@@ -267,9 +258,6 @@ def get_class_name(obj):
 
 
 def _convert_list_tuple(data, allow_tuple, allow_list):
-    if not allow_list and not allow_tuple:
-        raise ValueError("value of x and y should be a ndarray, but get a " +
-                         data.__class__.__name__ + " instead")
     if isinstance(data, list):
         if not allow_list and allow_tuple:
             return tuple(data)

--- a/pyzoo/zoo/orca/learn/mxnet/mxnet_runner.py
+++ b/pyzoo/zoo/orca/learn/mxnet/mxnet_runner.py
@@ -31,9 +31,6 @@ class MXNetRunner(object):
                           validation_metrics_creator=None, eval_metrics_creator=None):
         logging.basicConfig(level=logging.INFO)  # This can print log messages to console.
         self.logger = logging.getLogger()
-        assert isinstance(config, dict), "config must be a dict"
-        for param in ["optimizer", "optimizer_params", "log_interval"]:
-            assert param in config, param + " must be specified in config"
         self.config = config
         self.model_creator = model_creator
         self.loss_creator = loss_creator
@@ -84,7 +81,7 @@ class MXNetRunner(object):
         """Train the model and update the model parameters."""
         stats = dict()
         if self.is_worker:
-            config = self.config
+            config = self.config.copy()
             if "batch_size" not in config:
                 config["batch_size"] = batch_size
 

--- a/pyzoo/zoo/orca/learn/mxnet/mxnet_trainer.py
+++ b/pyzoo/zoo/orca/learn/mxnet/mxnet_trainer.py
@@ -91,7 +91,10 @@ class Estimator(object):
         ray_ctx = RayContext.get()
         if not num_workers:
             num_workers = ray_ctx.num_ray_nodes
-        self.config = config
+        self.config = {} if config is None else config
+        assert isinstance(config, dict), "config must be a dict"
+        for param in ["optimizer", "optimizer_params", "log_interval"]:
+            assert param in config, param + " must be specified in config"
         self.model_creator = model_creator
         self.loss_creator = loss_creator
         self.validation_metrics_creator = validation_metrics_creator

--- a/pyzoo/zoo/orca/learn/mxnet/mxnet_trainer.py
+++ b/pyzoo/zoo/orca/learn/mxnet/mxnet_trainer.py
@@ -13,25 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import itertools
+
 import os
+import types
+import itertools
 import subprocess
 import ray
 from dmlc_tracker.tracker import get_host_ip
 
-from zoo.orca.data.shard import RayXShards
-from zoo.orca.data.utils import ray_partition_get_data_label
+from zoo.orca.data.utils import ray_partition_get_data_label, process_spark_xshards
 from zoo.ray import RayContext
 from zoo.orca.learn.mxnet.mxnet_runner import MXNetRunner
 from zoo.orca.learn.mxnet.utils import find_free_port
-
-
-def process_spark_xshards(spark_xshards, num_workers):
-    data = spark_xshards
-    if data.num_partitions() != num_workers:
-        data = data.repartition(num_workers)
-    ray_xshards = RayXShards.from_spark_xshards(data)
-    return ray_xshards
 
 
 def shards_ref_to_creator(shards_ref, shuffle=False):
@@ -232,11 +225,11 @@ class Estimator(object):
             stats = worker_stats + server_stats
 
         else:  # data_creator functions; should return Iter or DataLoader
-            assert callable(data),\
+            assert isinstance(data, types.FunctionType),\
                 "train_data should be either an instance of SparkXShards or a callable function"
             train_data_list = [data] * self.num_workers
             if validation_data:
-                assert callable(validation_data),\
+                assert isinstance(validation_data, types.FunctionType),\
                     "val_data should be either an instance of SparkXShards or a callable function"
             val_data_list = [validation_data] * self.num_workers
             self.runners = self.workers + self.servers

--- a/pyzoo/zoo/orca/learn/pytorch/estimator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/estimator.py
@@ -129,7 +129,7 @@ class PyTorchRayEstimatorWrapper(Estimator):
                     this will return a list of metric dictionaries whose
                     length will be equal to ``num_workers``.
         """
-        return self.estimator.train(data_creator=data, epochs=epochs,
+        return self.estimator.train(data=data, epochs=epochs,
                                     profile=profile, reduce_results=reduce_results, info=info)
 
     def predict(self, data, **kwargs):

--- a/pyzoo/zoo/orca/learn/pytorch/estimator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/estimator.py
@@ -132,11 +132,11 @@ class PyTorchRayEstimatorWrapper(Estimator):
         :param info: An optional dictionary that can be passed to the training operator
         for train_epoch and train_batch.
 
-        :return A list of dictionary of metrics for every training epoch. If reduce_results is False,
-        this will return a nested list of metric dictionaries whose length will be equal to the total
-        number of workers.
-        You can also provide custom metrics by passing in a custom training_operator_cls when creating
-        the Estimator.
+        :return A list of dictionary of metrics for every training epoch. If reduce_results is
+        False, this will return a nested list of metric dictionaries whose length will be equal
+        to the total number of workers.
+        You can also provide custom metrics by passing in a custom training_operator_cls when
+        creating the Estimator.
         """
         return self.estimator.train(data=data, epochs=epochs, batch_size=batch_size,
                                     profile=profile, reduce_results=reduce_results, info=info)

--- a/pyzoo/zoo/orca/learn/pytorch/estimator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/estimator.py
@@ -114,7 +114,7 @@ class PyTorchRayEstimatorWrapper(Estimator):
         """
         Trains a PyTorch model given training data for several epochs.
 
-        Calls `operator.train_epoch()` on N parallel workers simultaneously
+        Calls `TrainingOperator.train_epoch()` on N parallel workers simultaneously
         underneath the hood.
         :param data: An instance of SparkXShards or a function that takes config as
         argument and returns a PyTorch DataLoader for training.
@@ -129,8 +129,8 @@ class PyTorchRayEstimatorWrapper(Estimator):
         one dict. If a metric is a non-numerical value (or nested dictionaries), one value will
         be randomly selected among the workers. If False, returns a list of dicts for all workers.
         Default is True.
-        :param info: An optional dictionary that can be passed to the training operator
-        for train_epoch and train_batch.
+        :param info: An optional dictionary that can be passed to the TrainingOperator for
+        train_epoch and train_batch.
 
         :return A list of dictionary of metrics for every training epoch. If reduce_results is
         False, this will return a nested list of metric dictionaries whose length will be equal
@@ -144,22 +144,33 @@ class PyTorchRayEstimatorWrapper(Estimator):
     def predict(self, data, **kwargs):
         pass
 
-    def evaluate(self, data, num_steps=None, profile=False, info=None):
+    def evaluate(self, data, batch_size=32, num_steps=None, profile=False, info=None):
         """
+        Evaluates a PyTorch model given validation data.
+        Note that only accuracy for classification with zero-based label is supported by
+        default. You can override validate_batch in TrainingOperator for other metrics.
 
-        :param data: (callable) a funtion that takes a config dict as input and return
-            a data loader containing the validation data.
-        :param num_steps: (int) Number of batches to compute update steps on.
-               This corresponds also to the number of times ``TrainingOperator.validate_batch``
-               is called.
-        :param profile: (bool) Returns time stats for the evaluation procedure.
-        :param info: (dict) Optional dictionary passed to the training operator for `validate`
-            and `validate_batch`.
-        :return: A dictionary of metrics for validation.
-            You can provide custom metrics by passing in a custom ``training_operator_cls``.
+        Calls `TrainingOperator.validate()` on N parallel workers simultaneously
+        underneath the hood.
+        :param data: An instance of SparkXShards or a function that takes config as
+        argument and returns a PyTorch DataLoader for validation.
+        :param batch_size: The number of samples per batch for each worker. Default is 32.
+        The total batch size would be workers_per_node*num_nodes.
+        If you validation data is a function, you can set batch_size to be config["batch_size"]
+        for the PyTorch DataLoader.
+        :param num_steps: The number of batches to compute the validation results on. This
+        corresponds to the number of times `TrainingOperator.validate_batch` is called.
+        :param profile: Boolean. Whether to return time stats for the training procedure.
+        Default is False.
+        :param info: An optional dictionary that can be passed to the TrainingOperator
+        for validate.
+
+        :return A dictionary of metrics for the given data, including validation accuracy and loss.
+        You can also provide custom metrics by passing in a custom training_operator_cls when
+        creating the Estimator.
         """
-        return self.estimator.validate(data_creator=data, num_steps=num_steps, profile=profile,
-                                       info=info)
+        return self.estimator.validate(data=data, batch_size=batch_size, num_steps=num_steps,
+                                       profile=profile, info=info)
 
     def get_model(self):
         """Returns the learned model(s)."""

--- a/pyzoo/zoo/orca/learn/pytorch/estimator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/estimator.py
@@ -110,26 +110,35 @@ class PyTorchRayEstimatorWrapper(Estimator):
                                              backend=backend,
                                              workers_per_node=workers_per_node)
 
-    def fit(self, data, epochs=1, profile=False, reduce_results=True, info=None):
+    def fit(self, data, epochs=1, batch_size=32, profile=False, reduce_results=True, info=None):
         """
+        Trains a PyTorch model given training data for several epochs.
 
-        :param data: (callable) a funtion that takes a config dict as input and return a data
-            loader containing the training data.
-        :param epochs: (int) Number of epochs to train the model
-        :param profile: (bool) Returns time stats for the training procedure.
-        :param reduce_results: (bool) Whether to average all metrics across all workers into one
-            dict. If a metric is a non-numerical value (or nested dictionaries), one value will be
-            randomly selected among the workers. If False, returns a list of dicts.
-        :param info: (dict) Optional dictionary passed to the training operator for ``train_epoch``
-            and ``train_batch``.
-        :return: (list) A list of stats whose length will be equal to ``epochs``.
-                stats is a dictionary of metrics for training.
-                    You can provide custom metrics by passing in a custom
-                    ``training_operator_cls``. If ``reduce_results=False``,
-                    this will return a list of metric dictionaries whose
-                    length will be equal to ``num_workers``.
+        Calls `operator.train_epoch()` on N parallel workers simultaneously
+        underneath the hood.
+        :param data: An instance of SparkXShards or a function that takes config as
+        argument and returns a PyTorch DataLoader for training.
+        :param epochs: The number of epochs to train the model. Default is 1.
+        :param batch_size: The number of samples per batch for each worker. Default is 32.
+        The total batch size would be workers_per_node*num_nodes.
+        If you training data is a function, you can set batch_size to be config["batch_size"]
+        for the PyTorch DataLoader.
+        :param profile: Boolean. Whether to return time stats for the training procedure.
+        Default is False.
+        :param reduce_results: Boolean. Whether to average all metrics across all workers into
+        one dict. If a metric is a non-numerical value (or nested dictionaries), one value will
+        be randomly selected among the workers. If False, returns a list of dicts for all workers.
+        Default is True.
+        :param info: An optional dictionary that can be passed to the training operator
+        for train_epoch and train_batch.
+
+        :return A list of dictionary of metrics for every training epoch. If reduce_results is False,
+        this will return a nested list of metric dictionaries whose length will be equal to the total
+        number of workers.
+        You can also provide custom metrics by passing in a custom training_operator_cls when creating
+        the Estimator.
         """
-        return self.estimator.train(data=data, epochs=epochs,
+        return self.estimator.train(data=data, epochs=epochs, batch_size=batch_size,
                                     profile=profile, reduce_results=reduce_results, info=info)
 
     def predict(self, data, **kwargs):

--- a/pyzoo/zoo/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -219,10 +219,7 @@ class PyTorchRayEstimator:
                                                                     transform_func,
                                                                     gang_scheduling=True)
             # TODO: verify this
-            stats = stats_shards.collect()
-            worker_stats = []
-            for i in range(self.num_workers):
-                worker_stats.append(stats[i])
+            worker_stats = stats_shards.collect_partitions()
         else:
             assert isinstance(data, types.FunctionType), \
                 "data should be either an instance of SparkXShards or a callable function"

--- a/pyzoo/zoo/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -66,7 +66,6 @@ def shards_ref_to_creator(shards_ref):
             def __getitem__(self, i):
                 return index_data(self.x, i), index_data(self.y, i)
 
-        # TODO: refactor batch_size in fit
         assert "batch_size" in config, "batch_size must be set in config"
         params = {"batch_size": config["batch_size"], "shuffle": True}
         for arg in ["shuffle", "sampler", "batch_sampler", "num_workers", "collate_fn",

--- a/pyzoo/zoo/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -212,13 +212,12 @@ class PyTorchRayEstimator:
 
             def transform_func(worker, shards_ref):
                 data_creator = shards_ref_to_creator(shards_ref)
-                # Wrap DistributedSampler on DataLoader should be False for SparkXShards.
+                # Should not wrap DistributedSampler on DataLoader for SparkXShards input.
                 return worker.train_epochs.remote(data_creator, epochs, profile, info, False)
 
             stats_shards = ray_xshards.transform_shards_with_actors(self.remote_workers,
                                                                     transform_func,
                                                                     gang_scheduling=True)
-            # TODO: verify this
             worker_stats = stats_shards.collect_partitions()
         else:
             assert isinstance(data, types.FunctionType), \

--- a/pyzoo/zoo/orca/learn/pytorch/torch_runner.py
+++ b/pyzoo/zoo/orca/learn/pytorch/torch_runner.py
@@ -242,13 +242,17 @@ class TorchRunner:
         return (isinstance(loader, DataLoader)
                 and not_iterable)
 
-    def train_epochs(self, data_creator, epochs=1, profile=False, info=None, wrap_dataloader=None):
+    def train_epochs(self, data_creator, epochs=1, batch_size=32, profile=False,
+                     info=None, wrap_dataloader=None):
+        config = self.config.copy()
+        if "batch_size" not in config:
+            config["batch_size"] = batch_size
         if OrcaContext.serialize_data_creation:
             with FileLock(
                     os.path.join(tempfile.gettempdir(), ".orcadata.lock")):
-                loader = data_creator(self.config)
+                loader = data_creator(config)
         else:
-            loader = data_creator(self.config)
+            loader = data_creator(config)
 
         if wrap_dataloader is None:
             if TorchRunner.should_wrap_dataloader(loader):


### PR DESCRIPTION
Similar to MXNet, support SparkXShards of RDD[dict of numpy] where each records contains 'x'  for features and 'y' for labels. Features and labels can be ndarray, list/dict/tuple of ndarrays.

This PR first focuses on training fit. If the implementation is OK, then I will modify validate as well.

Also fixes #3048 Add documentation that batch size should be batch size per worker.

- [x] Add unit tests.

- [x] Update validate.

- [x] Remove print/debug messages.