### PR TITLE
image-similarity notebook dimension match error when core_num equals to batch_size

### DIFF
--- a/apps/image-similarity/image-similarity.ipynb
+++ b/apps/image-similarity/image-similarity.ipynb
@@ -247,7 +247,7 @@
     "from bigdl.nn.criterion import CrossEntropyCriterion\n",
     "\n",
     "# add a new linear layer with numClass outputs, in our example, it's 6.\n",
-    "scene_network = Sequential().add(part_model).add(View([1024])).add(Linear(1024, 6)).add(LogSoftMax())\n",
+    "scene_network = Sequential().add(part_model).add(View([1024], num_input_dims=3)).add(Linear(1024, 6)).add(LogSoftMax())\n",
     "\n",
     "transformer = ChainedPreprocessing(\n",
     "    [RowToImageFeature(), ImageResize(256, 256), ImageCenterCrop(224, 224),\n",
@@ -429,7 +429,7 @@
     "# create a new model by removing layers after pool5\n",
     "model = full_model.new_graph([\"pool5\"])\n",
     "# generates a vector of dimension 25088 for each image\n",
-    "vggModel = Sequential().add(model).add(View([25088])).add(Normalize(2.0))\n",
+    "vggModel = Sequential().add(model).add(View([25088], num_input_dims=3)).add(Normalize(2.0))\n",
     "\n",
     "embeddingModel = NNModel(vggModel, transformer).setFeaturesCol(\"image\")\n",
     "embeddingModel.transform(imageDF.limit(10)).show()"


### PR DESCRIPTION
To fix https://github.com/intel-analytics/analytics-zoo/issues/2563