### PR TITLE
Orca Pytorch cifar10 example bigdl backend

### DIFF
--- a/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/README.md
+++ b/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/README.md
@@ -6,9 +6,9 @@ We demostrate how to easily run synchronous distributed Pytorch training using P
 We recommend you to use Anaconda to prepare the environments, especially if you want to run on a yarn cluster
 
 ```
-conda create -n zoo python=3.7 #zoo is conda environment name, you can set another name you like.
+conda create -n zoo python=3.7 # zoo is conda environment name, you can set another name you like.
 conda activate zoo
-pip install analytics-zoo==0.9.0.dev0 # or above
+pip install analytics-zoo # Need to install 0.9.0.dev0 or above
 pip install torch
 pip install torchvision
 ```

--- a/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/README.md
+++ b/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/README.md
@@ -35,5 +35,5 @@ You can find the logs for training.
 
 Final test results will be seen at the end.
 ```
-Test results: Map(Top1Accuracy -> Accuracy(correct: 5521, count: 10000, accuracy: 0.5521)) 
+Accuracy of the network on the 10000 test images: 0.541100025177002 
 ```

--- a/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/README.md
+++ b/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/README.md
@@ -1,0 +1,39 @@
+# Pytorch Cifar10 example
+We demostrate how to easily run synchronous distributed Pytorch training using Pytorch Estimator of Project Orca in Analytics Zoo. We use a simple convolutional nueral network model to train on Cifar10 dataset, which is a dataset for image classification. See [here](https://pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html) for the original single-node version of this example provided by Pytorch.
+
+## Prepare environments
+
+We recommend you to use Anaconda to prepare the environments, especially if you want to run on a yarn cluster
+
+```
+conda create -n zoo python=3.7 #zoo is conda environment name, you can set another name you like.
+conda activate zoo
+pip install analytics-zoo==0.9.0.dev0 # or above
+pip install torch
+pip install torchvision
+```
+
+# Run on local after pip install
+
+```
+python cifar10.py
+```
+
+# Run on yarn cluster for yarn-client mode after pip install
+
+```
+export HADOOP_CONF_DIR=path to your hadoop conf directory
+python cifar10.py --cluster_mode yarn-client
+```
+
+# Results
+
+You can find the logs for training.
+```
+2020-12-03 15:25:30 INFO  DistriOptimizer$:426 - [Epoch 2 47680/50000][Iteration 24420][Wall Clock 497.634203315s] Trained 4 records in 0.022554577 seconds. Throughput is 177.3476 records/second. Loss is 0.82751834.
+```
+
+Final test results will be seen at the end.
+```
+Test results: Map(Top1Accuracy -> Accuracy(correct: 5521, count: 10000, accuracy: 0.5521)) 
+```

--- a/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/__init__.py
+++ b/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/__init__.py
@@ -1,0 +1,15 @@
+#
+# Copyright 2018 Analytics Zoo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/cifar10.py
+++ b/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/cifar10.py
@@ -36,7 +36,7 @@ from zoo.orca.learn.metrics import Accuracy
 from zoo.orca.learn.trigger import EveryEpoch
 
 
-os.environ['KMP_DUPLICATE_LIB_OK']='True'
+os.environ['KMP_DUPLICATE_LIB_OK'] = 'True'
 parser = argparse.ArgumentParser(description='PyTorch Cifar10 Example')
 parser.add_argument('--cluster_mode', type=str, default="local",
                     help='The cluster mode, such as local, yarn or k8s.')

--- a/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/cifar10.py
+++ b/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/cifar10.py
@@ -119,7 +119,9 @@ images, labels = dataiter.next()
 imshow(torchvision.utils.make_grid(images))
 print('GroundTruth: ', ' '.join('%5s' % classes[labels[j]] for j in range(4)))
 
-result = orca_estimator.evaluate(data=testloader, validation_methods=[Accuracy()])
-print("Test results: {}".format(result[0]))
+res = orca_estimator.evaluate(data=testloader, validation_methods=[Accuracy()])[0]
+total_num = res.total_num
+result = res.result
+print("Accuracy of the network on the %s test images: %s" % (total_num, result))
 orca_estimator.shutdown()
 stop_orca_context()

--- a/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/cifar10.py
+++ b/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/cifar10.py
@@ -36,12 +36,52 @@ from zoo.orca.learn.metrics import Accuracy
 from zoo.orca.learn.trigger import EveryEpoch
 
 
+parser = argparse.ArgumentParser(description='PyTorch Cifar10 Example')
+parser.add_argument('--cluster_mode', type=str, default="local",
+                    help='The mode for the Spark cluster. local or yarn.')
+args = parser.parse_args()
+    
+transform = transforms.Compose(
+    [transforms.ToTensor(),
+     transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
+
+trainset = torchvision.datasets.CIFAR10(root='./data', train=True,
+                                        download=True, transform=transform)
+trainloader = torch.utils.data.DataLoader(trainset, batch_size=4,
+                                          shuffle=True, num_workers=2)
+
+testset = torchvision.datasets.CIFAR10(root='./data', train=False,
+                                       download=True, transform=transform)
+testloader = torch.utils.data.DataLoader(testset, batch_size=4,
+                                         shuffle=False, num_workers=2)
+
+classes = ('plane', 'car', 'bird', 'cat',
+           'deer', 'dog', 'frog', 'horse', 'ship', 'truck')
+
 def imshow(img):
     img = img / 2 + 0.5     # unnormalize
     npimg = img.numpy()
     plt.imshow(np.transpose(npimg, (1, 2, 0)))
     plt.show()
-         
+               
+dataiter = iter(trainloader)
+images, labels = dataiter.next()
+
+# show images
+imshow(torchvision.utils.make_grid(images))
+# print labels
+print(' '.join('%5s' % classes[labels[j]] for j in range(4)))
+               
+if args.cluster_mode == "local":
+    init_orca_context(cores=1, memory="20g")
+elif args.cluster_mode == "yarn":
+    init_orca_context(
+        cluster_mode="yarn-client", cores=4, num_nodes=2, memory="2g",
+        driver_memory="10g", driver_cores=1,
+        conf={"spark.rpc.message.maxSize": "1024",
+            "spark.task.maxFailures": "1",
+            "spark.driver.extraJavaOptions": "-Dbigdl.failure.retryTimes=1"})
+
 class Net(nn.Module):
     def __init__(self):
         super(Net, self).__init__()
@@ -60,82 +100,25 @@ class Net(nn.Module):
         x = F.relu(self.fc2(x))
         x = self.fc3(x)
         return x
+   
+net = Net()
+criterion = nn.CrossEntropyLoss()
+optimizer = optim.SGD(net.parameters(), lr=0.001, momentum=0.9)
 
-def main():
-    parser = argparse.ArgumentParser(description='PyTorch Cifar10 Example')
-    parser.add_argument('--dir', default='./data', metavar='N',
-                        help='the folder store mnist data')
-    parser.add_argument('--batch-size', type=int, default=4, metavar='N',
-                        help='input batch size for training per executor(default: 256)')
-    parser.add_argument('--test-batch-size', type=int, default=4, metavar='N',
-                        help='input batch size for testing per executor(default: 1000)')
-    parser.add_argument('--epochs', type=int, default=2, metavar='N',
-                        help='number of epochs to train (default: 2)')
-    parser.add_argument('--lr', type=float, default=0.001, metavar='LR',
-                        help='learning rate (default: 0.001)')
-    parser.add_argument('--seed', type=int, default=1, metavar='S',
-                        help='random seed (default: 1)')
-    parser.add_argument('--cluster_mode', type=str, default="local",
-                        help='The mode for the Spark cluster. local or yarn.')
-    args = parser.parse_args()
+net.train()  
+zoo_estimator = Estimator.from_torch(model=net, optimizer=optimizer, loss=criterion,
+                                     backend="bigdl")
+zoo_estimator.fit(data=trainloader, epochs=2, validation_data=testloader,
+                  validation_methods=[Accuracy()], checkpoint_trigger=EveryEpoch())
+print('Finished Training')
     
-    print(args)
+dataiter = iter(testloader)
+images, labels = dataiter.next()
 
-    torch.manual_seed(args.seed)
-    
-    transform = transforms.Compose(
-        [transforms.ToTensor(),
-         transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
+# print images
+imshow(torchvision.utils.make_grid(images))
+print('GroundTruth: ', ' '.join('%5s' % classes[labels[j]] for j in range(4)))
 
-    trainset = torchvision.datasets.CIFAR10(root=args.dir, train=True,
-                                            download=True, transform=transform)
-    trainloader = torch.utils.data.DataLoader(trainset, batch_size=args.batch_size,
-                                              shuffle=True, num_workers=2)
-
-    testset = torchvision.datasets.CIFAR10(root=args.dir, train=False,
-                                           download=True, transform=transform)
-    testloader = torch.utils.data.DataLoader(testset, batch_size=args.test_batch_size,
-                                             shuffle=False, num_workers=2)
-
-    classes = ('plane', 'car', 'bird', 'cat',
-               'deer', 'dog', 'frog', 'horse', 'ship', 'truck')
-               
-    dataiter = iter(trainloader)
-    images, labels = dataiter.next()
-
-    # show images
-    imshow(torchvision.utils.make_grid(images))
-    # print labels
-    print(' '.join('%5s' % classes[labels[j]] for j in range(4)))
-               
-    if args.cluster_mode == "local":
-        init_orca_context(cores=1, memory="20g")
-    elif args.cluster_mode == "yarn":
-        init_orca_context(
-            cluster_mode="yarn-client", cores=4, num_nodes=2, memory="2g",
-            driver_memory="10g", driver_cores=1,
-            conf={"spark.rpc.message.maxSize": "1024",
-                  "spark.task.maxFailures": "1",
-                  "spark.driver.extraJavaOptions": "-Dbigdl.failure.retryTimes=1"})
-    
-    model = Net()
-    model.train()
-    criterion = nn.CrossEntropyLoss()
-    optimizer = optim.SGD(model.parameters(), lr=args.lr, momentum=0.9)
-    zoo_estimator = Estimator.from_torch(model=model, optimizer=optimizer, loss=criterion,
-                                         backend="bigdl")
-    zoo_estimator.fit(data=trainloader, epochs=args.epochs, validation_data=testloader,
-                      validation_methods=[Accuracy()], checkpoint_trigger=EveryEpoch())
-    
-    dataiter = iter(testloader)
-    images, labels = dataiter.next()
-
-    # print images
-    imshow(torchvision.utils.make_grid(images))
-    print('GroundTruth: ', ' '.join('%5s' % classes[labels[j]] for j in range(4)))
-    zoo_estimator.evaluate(data=testloader, validation_methods=[Accuracy()])
-    stop_orca_context()
-
-
-if __name__ == '__main__':
-    main()
+zoo_estimator.evaluate(data=testloader, validation_methods=[Accuracy()])
+zoo_estimator.shutdown()
+stop_orca_context()

--- a/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/cifar10.py
+++ b/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/cifar10.py
@@ -1,0 +1,140 @@
+#
+# Copyright 2018 Analytics Zoo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# Most of the pytorch code is adapted from Pytorch's tutorial for 
+# neural networks training on Cifar10
+# https://pytorch.org/tutorials/beginner/blitz/cifar10_tutorial.html
+#
+from __future__ import print_function
+import os
+import argparse
+import matplotlib.pyplot as plt
+import numpy as np
+
+import torch
+import torchvision
+import torchvision.transforms as transforms
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+
+from zoo.orca import init_orca_context, stop_orca_context
+from zoo.orca.learn.pytorch import Estimator
+from zoo.orca.learn.metrics import Accuracy
+from zoo.orca.learn.trigger import EveryEpoch
+
+def imshow(img):
+    img = img / 2 + 0.5     # unnormalize
+    npimg = img.numpy()
+    plt.imshow(np.transpose(npimg, (1, 2, 0)))
+    plt.show()
+         
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.conv1 = nn.Conv2d(3, 6, 5)
+        self.pool = nn.MaxPool2d(2, 2)
+        self.conv2 = nn.Conv2d(6, 16, 5)
+        self.fc1 = nn.Linear(16 * 5 * 5, 120)
+        self.fc2 = nn.Linear(120, 84)
+        self.fc3 = nn.Linear(84, 10)
+
+    def forward(self, x):
+        x = self.pool(F.relu(self.conv1(x)))
+        x = self.pool(F.relu(self.conv2(x)))
+        x = x.view(-1, 16 * 5 * 5)
+        x = F.relu(self.fc1(x))
+        x = F.relu(self.fc2(x))
+        x = self.fc3(x)
+        return x
+
+def main():
+    parser = argparse.ArgumentParser(description='PyTorch Cifar10 Example')
+    parser.add_argument('--dir', default='./data', metavar='N',
+                        help='the folder store mnist data')
+    parser.add_argument('--batch-size', type=int, default=256, metavar='N',
+                        help='input batch size for training per executor(default: 256)')
+    parser.add_argument('--test-batch-size', type=int, default=1000, metavar='N',
+                        help='input batch size for testing per executor(default: 1000)')
+    parser.add_argument('--epochs', type=int, default=2, metavar='N',
+                        help='number of epochs to train (default: 2)')
+    parser.add_argument('--lr', type=float, default=0.001, metavar='LR',
+                        help='learning rate (default: 0.001)')
+    parser.add_argument('--seed', type=int, default=1, metavar='S',
+                        help='random seed (default: 1)')
+    parser.add_argument('--save-model', action='store_true', default=False,
+                        help='For Saving the current Model')
+    parser.add_argument('--cluster_mode', type=str, default="local",
+                        help='The mode for the Spark cluster. local or yarn.')
+    args = parser.parse_args()
+
+    torch.manual_seed(args.seed)
+    
+    transform = transforms.Compose(
+        [transforms.ToTensor(),
+         transforms.Normalize((0.5, 0.5, 0.5), (0.5, 0.5, 0.5))])
+
+    trainset = torchvision.datasets.CIFAR10(root='./data', train=True,
+                                            download=True, transform=transform)
+    trainloader = torch.utils.data.DataLoader(trainset, batch_size=4,
+                                              shuffle=True, num_workers=2)
+
+    testset = torchvision.datasets.CIFAR10(root='./data', train=False,
+                                           download=True, transform=transform)
+    testloader = torch.utils.data.DataLoader(testset, batch_size=4,
+                                             shuffle=False, num_workers=2)
+
+    classes = ('plane', 'car', 'bird', 'cat',
+               'deer', 'dog', 'frog', 'horse', 'ship', 'truck')
+               
+    dataiter = iter(trainloader)
+    images, labels = dataiter.next()
+
+    # show images
+    imshow(torchvision.utils.make_grid(images))
+    # print labels
+    print(' '.join('%5s' % classes[labels[j]] for j in range(4)))
+               
+    if args.cluster_mode == "local":
+        init_orca_context(cores=1, memory="20g")
+    elif args.cluster_mode == "yarn":
+        init_orca_context(
+            cluster_mode="yarn-client", cores=4, num_nodes=2, memory="2g",
+            driver_memory="10g", driver_cores=1,
+            conf={"spark.rpc.message.maxSize": "1024",
+                  "spark.task.maxFailures": "1",
+                  "spark.driver.extraJavaOptions": "-Dbigdl.failure.retryTimes=1"})
+    
+    model = Net()
+    model.train()
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.SGD(model.parameters(), lr=0.001, momentum=0.9)
+    zoo_estimator = Estimator.from_torch(model=model, optimizer=optimizer, loss=criterion,
+                                         backend="bigdl")
+    zoo_estimator.fit(data=trainloader, epochs=args.epochs, validation_data=testloader,
+                      validation_methods=[Accuracy()], checkpoint_trigger=EveryEpoch())
+    
+    dataiter = iter(testloader)
+    images, labels = dataiter.next()
+
+    # print images
+    imshow(torchvision.utils.make_grid(images))
+    print('GroundTruth: ', ' '.join('%5s' % classes[labels[j]] for j in range(4)))
+    estimator.evaluate(data=testloader, validation_methods=[Accuracy()])
+    stop_orca_context()
+
+
+if __name__ == '__main__':
+    main()

--- a/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/cifar10.py
+++ b/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/cifar10.py
@@ -36,7 +36,6 @@ from zoo.orca.learn.metrics import Accuracy
 from zoo.orca.learn.trigger import EveryEpoch
 
 
-os.environ['KMP_DUPLICATE_LIB_OK'] = 'True'
 parser = argparse.ArgumentParser(description='PyTorch Cifar10 Example')
 parser.add_argument('--cluster_mode', type=str, default="local",
                     help='The cluster mode, such as local, yarn or k8s.')
@@ -121,5 +120,6 @@ imshow(torchvision.utils.make_grid(images))
 print('GroundTruth: ', ' '.join('%5s' % classes[labels[j]] for j in range(4)))
 
 result = orca_estimator.evaluate(data=testloader, validation_methods=[Accuracy()])
+print("Test results: {}".format(result[0]))
 orca_estimator.shutdown()
 stop_orca_context()

--- a/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/cifar10.py
+++ b/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/cifar10.py
@@ -36,6 +36,7 @@ from zoo.orca.learn.metrics import Accuracy
 from zoo.orca.learn.trigger import EveryEpoch
 
 
+os.environ['KMP_DUPLICATE_LIB_OK']='True'
 parser = argparse.ArgumentParser(description='PyTorch Cifar10 Example')
 parser.add_argument('--cluster_mode', type=str, default="local",
                     help='The cluster mode, such as local, yarn or k8s.')

--- a/pyzoo/zoo/examples/run-example-tests-jep.sh
+++ b/pyzoo/zoo/examples/run-example-tests-jep.sh
@@ -53,6 +53,6 @@ python ${ANALYTICS_ZOO_ROOT}/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/cifar
 now=${data "+%s")
 time3=$((now-start))
 
-echo "#1 mnist example time used:$time1 seconds"
-echo "#2 orca MNIST example time used:#time2 seconds"
+echo "#1 MNIST example time used:$time1 seconds"
+echo "#2 orca MNIST example time used:$time2 seconds"
 echo "#3 orca Cifar10 example time used:$time3 seconds"

--- a/pyzoo/zoo/examples/run-example-tests-jep.sh
+++ b/pyzoo/zoo/examples/run-example-tests-jep.sh
@@ -32,6 +32,10 @@ fi
 
 python ${ANALYTICS_ZOO_ROOT}/pyzoo/zoo/examples/orca/learn/pytorch/mnist/lenet_mnist.py --dir analytics-zoo-data/data
 
+now=${data "+%s")
+time1=$((now-start))
+echo "#1 mnist example time used:$time1 seconds"
+
 echo "start example for Cifar10"
 #timer
 start=$(date "+%s")
@@ -43,3 +47,7 @@ else
     unzip ${ANALYTICS_ZOO_ROOT}/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/cifar10.zip
 fi
 python ${ANALYTICS_ZOO_ROOT}/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/cifar10.py
+
+now=${data "+%s")
+time2=$((now-start))
+echo "#2 cifar10 example time used:$time2 seconds"

--- a/pyzoo/zoo/examples/run-example-tests-jep.sh
+++ b/pyzoo/zoo/examples/run-example-tests-jep.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo "start example for MNIST"
+echo "#1 start example for MNIST"
 #timer
 start=$(date "+%s")
 if [ -f analytics-zoo-data/data/MNIST ]
@@ -17,7 +17,10 @@ fi
 
 python ${ANALYTICS_ZOO_ROOT}/pyzoo/zoo/examples/pytorch/train/mnist/main.py --dir analytics-zoo-data/data
 
-echo "start example for orca MNIST"
+now=${data "+%s")
+time1=$((now-start))
+
+echo "#2 start example for orca MNIST"
 #timer
 start=$(date "+%s")
 if [ -f analytics-zoo-data/data/MNIST ]
@@ -33,10 +36,10 @@ fi
 python ${ANALYTICS_ZOO_ROOT}/pyzoo/zoo/examples/orca/learn/pytorch/mnist/lenet_mnist.py --dir analytics-zoo-data/data
 
 now=${data "+%s")
-time1=$((now-start))
-echo "#1 mnist example time used:$time1 seconds"
+time2=$((now-start))
 
-echo "start example for Cifar10"
+
+echo "#3 start example for orca Cifar10"
 #timer
 start=$(date "+%s")
 if [ -d ${ANALYTICS_ZOO_ROOT}/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/data ]
@@ -49,5 +52,8 @@ fi
 python ${ANALYTICS_ZOO_ROOT}/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/cifar10.py
 
 now=${data "+%s")
-time2=$((now-start))
-echo "#2 cifar10 example time used:$time2 seconds"
+time3=$((now-start))
+
+echo "#1 mnist example time used:$time1 seconds"
+echo "#2 orca MNIST example time used:#time2 seconds"
+echo "#2 orca Cifar10 example time used:$time3 seconds"

--- a/pyzoo/zoo/examples/run-example-tests-jep.sh
+++ b/pyzoo/zoo/examples/run-example-tests-jep.sh
@@ -17,7 +17,7 @@ fi
 
 python ${ANALYTICS_ZOO_ROOT}/pyzoo/zoo/examples/pytorch/train/mnist/main.py --dir analytics-zoo-data/data
 
-now=${data "+%s")
+now=$(date "+%s")
 time1=$((now-start))
 
 echo "#2 start example for orca MNIST"
@@ -35,7 +35,7 @@ fi
 
 python ${ANALYTICS_ZOO_ROOT}/pyzoo/zoo/examples/orca/learn/pytorch/mnist/lenet_mnist.py --dir analytics-zoo-data/data
 
-now=${data "+%s")
+now=$(date "+%s")
 time2=$((now-start))
 
 echo "#3 start example for orca Cifar10"
@@ -50,7 +50,7 @@ else
 fi
 python ${ANALYTICS_ZOO_ROOT}/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/cifar10.py
 
-now=${data "+%s")
+now=$(date "+%s")
 time3=$((now-start))
 
 echo "#1 MNIST example time used:$time1 seconds"

--- a/pyzoo/zoo/examples/run-example-tests-jep.sh
+++ b/pyzoo/zoo/examples/run-example-tests-jep.sh
@@ -55,4 +55,4 @@ time3=$((now-start))
 
 echo "#1 mnist example time used:$time1 seconds"
 echo "#2 orca MNIST example time used:#time2 seconds"
-echo "#2 orca Cifar10 example time used:$time3 seconds"
+echo "#3 orca Cifar10 example time used:$time3 seconds"

--- a/pyzoo/zoo/examples/run-example-tests-jep.sh
+++ b/pyzoo/zoo/examples/run-example-tests-jep.sh
@@ -38,7 +38,6 @@ python ${ANALYTICS_ZOO_ROOT}/pyzoo/zoo/examples/orca/learn/pytorch/mnist/lenet_m
 now=${data "+%s")
 time2=$((now-start))
 
-
 echo "#3 start example for orca Cifar10"
 #timer
 start=$(date "+%s")

--- a/pyzoo/zoo/examples/run-example-tests-jep.sh
+++ b/pyzoo/zoo/examples/run-example-tests-jep.sh
@@ -31,3 +31,15 @@ else
 fi
 
 python ${ANALYTICS_ZOO_ROOT}/pyzoo/zoo/examples/orca/learn/pytorch/mnist/lenet_mnist.py --dir analytics-zoo-data/data
+
+echo "start example for Cifar10"
+#timer
+start=$(date "+%s")
+if [ -d ${ANALYTICS_ZOO_ROOT}/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/data ]
+then
+    echo "Cifar10 already exists"
+else
+    wget -nv $FTP_URI/analytics-zoo-data/cifar10.zip -P ${ANALYTICS_ZOO_ROOT}/pyzoo/zoo/examples/orca/learn/pytorch/cifar10
+    unzip ${ANALYTICS_ZOO_ROOT}/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/cifar10.zip
+fi
+python ${ANALYTICS_ZOO_ROOT}/pyzoo/zoo/examples/orca/learn/pytorch/cifar10/cifar10.py


### PR DESCRIPTION
This is the example of Pytorch Cifar10 tutorial. Follow the original logic, there are sampled graphs showing training data and testing data, trainning on Orca bigdl backend and calculating test accuracy on test data. The part for test accuracy on every class is currently unsupported. The evaluation function in estimator only returns a total accuracy and the predict function in estimator is not implement yet