### PR TITLE
Fix locale environment variables when launching Ray

### DIFF
--- a/docs/docs/ProgrammingGuide/rayonspark.md
+++ b/docs/docs/ProgrammingGuide/rayonspark.md
@@ -91,3 +91,17 @@ print(ray.get([c.increment.remote() for c in counters]))
 ray_ctx.stop()
 sc.stop()
 ```
+
+---
+### **FAQ**
+- If you encounter the following error when initiating RayOnSpark, especially when you are using Spark standalone cluster:
+```
+This system supports the C.UTF-8 locale which is recommended. You might be able to resolve your issue by exporting the following environment variables:
+
+    export LC_ALL=C.UTF-8
+    export LANG=C.UTF-8
+```
+Add the environment variables when initiating RayContext would resolve the issue:
+```python
+ray_ctx = RayContext(sc=sc, object_store_memory="5g", env={"LANG": "C.UTF-8", "LC_ALL": "C.UTF-8"})
+```

--- a/pyzoo/zoo/ray/raycontext.py
+++ b/pyzoo/zoo/ray/raycontext.py
@@ -102,8 +102,6 @@ class RayServiceFuncGenerator(object):
             modified_env["PATH"] = "{}:{}".format(executor_python_path, os.environ["PATH"])
         else:
             modified_env["PATH"] = executor_python_path
-        modified_env["LC_ALL"] = "C.UTF-8"
-        modified_env["LANG"] = "C.UTF-8"
         modified_env.pop("MALLOC_ARENA_MAX", None)
         modified_env.pop("RAY_BACKEND_LOG_LEVEL", None)
         # Unset all MKL setting as Analytics Zoo would give default values when init env.


### PR DESCRIPTION
Fix #3148 

Previously in #2685 added LC_ALL and LANG as environment variables for launching ray because an error occurred for Spark standalone single node. But now I can't reproduce this... Don't know why.
Anyway, it would be better to remove them by default. And I add in FAQ that if users encounter the issue, they can set these two environment variables.