### PR TITLE
del lang3 due to conflict.

### DIFF
--- a/zoo/pom.xml
+++ b/zoo/pom.xml
@@ -517,6 +517,7 @@
                             <artifactSet>
                                 <excludes>
                                     <exclude>org.scala-lang:scala-library</exclude>
+                                    <exclude>org.apache.commons:commons-lang3</exclude>
                                 </excludes>
                             </artifactSet>
                         </configuration>


### PR DESCRIPTION
del lang3 due to jar conflict in our customer's environment.
It commons-lang3 should be provided. But dependency tree shows it's compile.