### PR TITLE
automl feature transform sklearn >=0.23 support

### DIFF
--- a/pyzoo/zoo/automl/feature/time_sequence.py
+++ b/pyzoo/zoo/automl/feature/time_sequence.py
@@ -17,6 +17,7 @@
 from zoo.automl.common.util import save_config
 from zoo.automl.feature.abstract import BaseFeatureTransformer
 
+import sklearn
 from sklearn.preprocessing import MinMaxScaler, StandardScaler
 import pandas as pd
 import numpy as np
@@ -295,10 +296,8 @@ class TimeSequenceFeatureTransformer(BaseFeatureTransformer):
         :return:
         """
         # for StandardScaler()
-        # num_features_input for 0.23 sklearn support, sklearn version >=0.24 will not check this
         data_to_save = {"mean": self.scaler.mean_.tolist(),
                         "scale": self.scaler.scale_.tolist(),
-                        "num_features_input": self.scaler.n_features_in_,
                         "future_seq_len": self.future_seq_len,
                         "dt_col": self.dt_col,
                         "target_col": self.target_col,
@@ -319,7 +318,6 @@ class TimeSequenceFeatureTransformer(BaseFeatureTransformer):
         self.scaler = StandardScaler()
         self.scaler.mean_ = np.asarray(config["mean"])
         self.scaler.scale_ = np.asarray(config["scale"])
-        self.scaler.n_features_in_ = config["num_features_input"]
 
         self.config = self._get_feat_config(**config)
 
@@ -511,6 +509,9 @@ class TimeSequenceFeatureTransformer(BaseFeatureTransformer):
         :param data:
         :return:
         """
+        # n_features_in_ only for 0.23 sklearn support, sklearn version >=0.24 will not check this
+        if sklearn.__version__[:4] == "0.23":
+            self.scaler.n_features_in_ = self.scaler.mean_.shape[0]
         np_scaled = self.scaler.transform(data)
         data_s = pd.DataFrame(np_scaled)
         return data_s

--- a/pyzoo/zoo/automl/feature/time_sequence.py
+++ b/pyzoo/zoo/automl/feature/time_sequence.py
@@ -295,9 +295,9 @@ class TimeSequenceFeatureTransformer(BaseFeatureTransformer):
         :return:
         """
         # for StandardScaler()
+        # num_features_input for 0.23 sklearn support, sklearn version >=0.24 will not check this
         data_to_save = {"mean": self.scaler.mean_.tolist(),
                         "scale": self.scaler.scale_.tolist(),
-                        # num_features_input for 0.23 sklearn support, sklearn version >=0.24 will not check this
                         "num_features_input": self.scaler.n_features_in_,
                         "future_seq_len": self.future_seq_len,
                         "dt_col": self.dt_col,

--- a/pyzoo/zoo/automl/feature/time_sequence.py
+++ b/pyzoo/zoo/automl/feature/time_sequence.py
@@ -297,6 +297,8 @@ class TimeSequenceFeatureTransformer(BaseFeatureTransformer):
         # for StandardScaler()
         data_to_save = {"mean": self.scaler.mean_.tolist(),
                         "scale": self.scaler.scale_.tolist(),
+                        # num_features_input for 0.23 sklearn support, sklearn version >=0.24 will not check this
+                        "num_features_input": self.scaler.n_features_in_,
                         "future_seq_len": self.future_seq_len,
                         "dt_col": self.dt_col,
                         "target_col": self.target_col,
@@ -317,6 +319,7 @@ class TimeSequenceFeatureTransformer(BaseFeatureTransformer):
         self.scaler = StandardScaler()
         self.scaler.mean_ = np.asarray(config["mean"])
         self.scaler.scale_ = np.asarray(config["scale"])
+        self.scaler.n_features_in_ = config["num_features_input"]
 
         self.config = self._get_feat_config(**config)
 


### PR DESCRIPTION
**Goal**:

Fix issue #2623.

**Change log**:

I add the conditional attribute `n_features_in_` setting in `_scale` function.

**Reason**:

This might be faster and better for future support.

**Reference**:

In sklearn version 0.23.X, it set a strict check on the attribute `n_features_in_`, while we only save `mean_` and `scale_` for the `StandardScaler`. This is the main reason for issue #2623.   
In sklearn version 0.24.X, this strict check is eliminated for stateless estimator(e.g. `StandardScaler`), still it might be added back later. see discussions sklearn pr 18011 and [here](https://scikit-learn-enhancement-proposals.readthedocs.io/en/latest/slep010/proposal.html)