### PR TITLE
Update index.rst

### DIFF
--- a/readthedocs/source/index.rst
+++ b/readthedocs/source/index.rst
@@ -56,9 +56,3 @@ Analytics Zoo includes the **Orca** library that seamlessly scale out your singl
    
    doc/Application/presentations.md
    doc/Application/powered-by.md  
-   
-.. toctree::
-   :maxdepth: 1
-   :caption: Release
-   
-   doc/release.md


### PR DESCRIPTION
 release.md is referenced by other pages and created, so remove its link from index.rst.  
 after remove,  release download page will not show in home page and left menu.

tets demo: https://testhelendoc.readthedocs.io/en/latest/
