### PR TITLE
Implement metrics for pytorch ray estimator

### DIFF
--- a/pyzoo/test/zoo/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
+++ b/pyzoo/test/zoo/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
@@ -20,6 +20,7 @@ import pytest
 
 import torch
 import torch.nn as nn
+from zoo.orca.learn.metrics import Accuracy
 
 from zoo import init_nncontext
 from zoo.orca.learn.pytorch import Estimator
@@ -125,6 +126,7 @@ def get_estimator(workers_per_node=1, model_fn=get_model):
     estimator = Estimator.from_torch(model=model_fn,
                                      optimizer=get_optimizer,
                                      loss=nn.BCELoss(),
+                                     metrics=Accuracy(),
                                      config={"lr": 1e-2},
                                      workers_per_node=workers_per_node,
                                      backend="torch_distributed")
@@ -138,7 +140,7 @@ class TestPyTorchEstimator(TestCase):
         print(train_stats)
         val_stats = estimator.evaluate(val_data_loader, batch_size=64)
         print(val_stats)
-        assert 0 < val_stats["val_accuracy"] < 1
+        assert 0 < val_stats["Accuracy"] < 1
         assert estimator.get_model()
 
         # Verify syncing weights, i.e. the two workers have the same weights after training

--- a/pyzoo/zoo/orca/learn/bigdl/estimator.py
+++ b/pyzoo/zoo/orca/learn/bigdl/estimator.py
@@ -71,7 +71,7 @@ class BigDLEstimator(OrcaSparkEstimator):
                  feature_preprocessing=None, label_preprocessing=None, model_dir=None):
         self.loss = loss
         self.optimizer = optimizer
-        self.metrics = Metrics.convert_metrics_list(metrics)
+        self.metrics = Metric.convert_metrics_list(metrics)
         self.feature_preprocessing = feature_preprocessing
         self.label_preprocessing = label_preprocessing
         self.model_dir = model_dir

--- a/pyzoo/zoo/orca/learn/bigdl/estimator.py
+++ b/pyzoo/zoo/orca/learn/bigdl/estimator.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from zoo.orca.learn.metrics import Metrics
+from zoo.orca.learn.metrics import Metric
 from zoo.orca.learn.utils import bigdl_metric_results_to_dict
 from zoo.pipeline.nnframes import NNEstimator, NNModel
 from zoo.pipeline.estimator import Estimator as SparkEstimator
@@ -193,8 +193,6 @@ class BigDLEstimator(OrcaSparkEstimator):
             raise NotImplementedError
         elif isinstance(data, SparkXShards):
             from zoo.orca.data.utils import xshard_to_sample
-            from zoo.orca.learn.metrics import Metrics
-
             val_feature_set = FeatureSet.sample_rdd(data.rdd.flatMap(xshard_to_sample))
             result = self.estimator.evaluate(val_feature_set, self.metrics, batch_size)
         else:

--- a/pyzoo/zoo/orca/learn/metrics.py
+++ b/pyzoo/zoo/orca/learn/metrics.py
@@ -142,8 +142,6 @@ class Accuracy(Metric):
         self.zero_based_label = zero_based_label
 
     def get_bigdl_metric(self):
-        if self.threshold != 0.5:
-            raise ValueError("bigdl Accuracy does not support threshold argument other than 0.5")
         from zoo.pipeline.api.keras.metrics import Accuracy as KerasAccuracy
         return KerasAccuracy(zero_based_label=self.zero_based_label)
 

--- a/pyzoo/zoo/orca/learn/metrics.py
+++ b/pyzoo/zoo/orca/learn/metrics.py
@@ -14,35 +14,84 @@
 # limitations under the License.
 #
 from abc import ABC, abstractmethod
+from builtins import ModuleNotFoundError
 
 
-class Metrics(ABC):
+class Metric(ABC):
+
+    def get_metric(self, backend="bigdl"):
+
+        if backend == "bigdl":
+            metric_impl = self.get_bigdl_metric()
+        elif backend == "pytorch":
+            metric_impl = self.get_pytorch_metric()
+        elif backend == "tf":
+            metric_impl = self.get_tf_metric()
+        elif backend == "mxnet":
+            metric_impl = self.get_mxnet_metric()
+        else:
+            valid_backends = {
+                "bigdl",
+                "pytorch",
+                "tf",
+                "mxnet"
+            }
+            raise ValueError(f"backend should be one of {valid_backends}, but got {backend}")
+        return metric_impl
+
+    def get_bigdl_metric(self):
+        raise NotImplementedError()
+
+    def get_tf_metric(self):
+        raise NotImplementedError()
+
+    def get_pytorch_metric(self):
+        raise NotImplementedError()
+
+    def get_mxnet_metric(self):
+        raise NotImplementedError()
+
     @abstractmethod
-    def get_metrics(self):
+    def get_name(self):
         pass
 
     @staticmethod
-    def convert_metrics_list(metrics):
+    def convert_metrics_list(metrics, backend="bigdl"):
         if metrics is None:
             return None
         if isinstance(metrics, list):
-            keras_metrics = []
+            metric_impls = []
             for m in metrics:
-                if isinstance(m, Metrics):
-                    keras_metrics.append(m.get_metrics())
+                if isinstance(m, Metric):
+                    metric_impls.append(m.get_metric(backend))
                 else:
-                    raise ValueError("Only orca metrics are supported, but get " +
-                                     m.__class__.__name__)
-            return keras_metrics
+                    metric_impls.append(m)
+            return metric_impls
         else:
-            if isinstance(metrics, Metrics):
-                return [metrics.get_metrics()]
+            if isinstance(metrics, Metric):
+                return metrics.get_metric(backend)
+            else:
+                raise ValueError("Only orca metrics are supported, but get " +
+                                 metrics.__class__.__name__)
+
+    @staticmethod
+    def convert_metrics_dict(metrics, backend="bigdl"):
+        if metrics is None:
+            return {}
+        if isinstance(metrics, list):
+            metric_impls = {}
+            for m in metrics:
+                metric_impls[m.get_name()] = m.get_metric(backend)
+            return metric_impls
+        else:
+            if isinstance(metrics, Metric):
+                return {metrics.get_name(): metrics.get_metric(backend)}
             else:
                 raise ValueError("Only orca metrics are supported, but get " +
                                  metrics.__class__.__name__)
 
 
-class AUC(Metrics):
+class AUC(Metric):
     """
     Metric for binary(0/1) classification, support single label and multiple labels.
 
@@ -53,29 +102,33 @@ class AUC(Metrics):
     >>> meter = AUC(20)
     """
     def __init__(self, threshold_num=200):
+        self.threshold_num = threshold_num
+
+    def get_bigdl_metric(self):
         from zoo.pipeline.api.keras.metrics import AUC as KerasAUC
-        self.metrics = KerasAUC(threshold_num=threshold_num)
+        return KerasAUC(threshold_num=self.threshold_num)
 
-    def get_metrics(self):
-        return self.metrics
+    def get_name(self):
+        return "AUC"
 
 
-class MAE(Metrics):
+class MAE(Metric):
     """
     Metric for mean absoluate error, similar from MAE criterion
 
     >>> mae = MAE()
 
     """
-    def __init__(self):
+
+    def get_bigdl_metric(self):
         from zoo.pipeline.api.keras.metrics import MAE as KerasMAE
-        self.metrics = KerasMAE()
+        return KerasMAE()
 
-    def get_metrics(self):
-        return self.metrics
+    def get_name(self):
+        return "MAE"
 
 
-class Accuracy(Metrics):
+class Accuracy(Metric):
     """
     Measures top1 accuracy for multi-class classification
     or accuracy for binary classification.
@@ -88,58 +141,80 @@ class Accuracy(Metrics):
 
     >>> acc = Accuracy()
     """
-    def __init__(self, zero_based_label=True):
+    def __init__(self, threshold=0.5, zero_based_label=True):
+        self.zero_based_label = zero_based_label
+        self.threshold = threshold
+
+    def get_bigdl_metric(self):
+        if self.threshold != 0.5:
+            raise ValueError("bigdl Accuracy does not support threshold")
         from zoo.pipeline.api.keras.metrics import Accuracy as KerasAccuracy
-        self.metrics = KerasAccuracy(zero_based_label=zero_based_label)
+        return KerasAccuracy(zero_based_label=self.zero_based_label)
 
-    def get_metrics(self):
-        return self.metrics
+    def get_pytorch_metric(self):
+        try:
+            from pytorch_lightning import metrics
+        except ModuleNotFoundError as e:
+            raise RuntimeError("Could not find pytorch lightning, "
+                               "please install pytorch lightning when "
+                               "using orca metrics for pytorch")
+
+        if not self.zero_based_label:
+            raise ValueError("pytorch Accuracy does not support one based accuracy, "
+                             "please set zero_based_label to True")
+        return metrics.Accuracy(threshold=self.threshold)
+
+    def get_name(self):
+        return "Accuracy"
 
 
-class SparseCategoricalAccuracy(Metrics):
+class SparseCategoricalAccuracy(Metric):
     """
     Measures top1 accuracy for multi-class classification with sparse target.
 
     >>> acc = SparseCategoricalAccuracy()
     """
-    def __init__(self):
+
+    def get_bigdl_metric(self):
         from zoo.pipeline.api.keras.metrics import \
             SparseCategoricalAccuracy as KerasSparseCategoricalAccuracy
-        self.metrics = KerasSparseCategoricalAccuracy()
+        return KerasSparseCategoricalAccuracy()
 
-    def get_metrics(self):
-        return self.metrics
+    def get_name(self):
+        return "SparseCategoricalAccuracy"
 
 
-class CategoricalAccuracy(Metrics):
+class CategoricalAccuracy(Metric):
     """
     Measures top1 accuracy for multi-class classification when target is one-hot encoded.
 
     >>> acc = CategoricalAccuracy()
     """
-    def __init__(self):
+
+    def get_bigdl_metric(self):
         from zoo.pipeline.api.keras.metrics import CategoricalAccuracy as KerasCategoricalAccuracy
-        self.metrics = KerasCategoricalAccuracy()
+        return KerasCategoricalAccuracy()
 
-    def get_metrics(self):
-        return self.metrics
+    def get_name(self):
+        return "CategoricalAccuracy"
 
 
-class BinaryAccuracy(Metrics):
+class BinaryAccuracy(Metric):
     """
     Measures top1 accuracy for binary classification with zero-based index.
 
     >>> acc = BinaryAccuracy()
     """
-    def __init__(self):
+
+    def get_bigdl_metric(self):
         from zoo.pipeline.api.keras.metrics import BinaryAccuracy as KerasBinaryAccuracy
-        self.metrics = KerasBinaryAccuracy()
+        return KerasBinaryAccuracy()
 
-    def get_metrics(self):
-        return self.metrics
+    def get_name(self):
+        return "BinaryAccuracy"
 
 
-class Top5Accuracy(Metrics):
+class Top5Accuracy(Metric):
     """
     Measures top5 accuracy for multi-class classification.
 
@@ -149,9 +224,10 @@ class Top5Accuracy(Metrics):
 
     >>> acc = Top5Accuracy()
     """
-    def __init__(self):
-        from zoo.pipeline.api.keras.metrics import Top5Accuracy as KerasTop5Accuracy
-        self.metrics = KerasTop5Accuracy()
 
-    def get_metrics(self):
-        return self.metrics
+    def get_bigdl_metric(self):
+        from zoo.pipeline.api.keras.metrics import Top5Accuracy as KerasTop5Accuracy
+        return KerasTop5Accuracy()
+
+    def get_name(self):
+        return "Top5Accuracy"

--- a/pyzoo/zoo/orca/learn/metrics.py
+++ b/pyzoo/zoo/orca/learn/metrics.py
@@ -14,8 +14,7 @@
 # limitations under the License.
 #
 from abc import ABC, abstractmethod
-from builtins import ModuleNotFoundError
-import logging
+
 
 class Metric(ABC):
 

--- a/pyzoo/zoo/orca/learn/metrics.py
+++ b/pyzoo/zoo/orca/learn/metrics.py
@@ -75,14 +75,12 @@ class Metric(ABC):
                 if isinstance(m, Metric):
                     metric_impls.append(m.get_metric(backend))
                 else:
-                    metric_impls.append(m)
+                    raise ValueError("Only orca metrics are supported, but get " +
+                                     m.__class__.__name__)
             return metric_impls
         else:
             if isinstance(metrics, Metric):
-                return metrics.get_metric(backend)
-            else:
-                raise ValueError("Only orca metrics are supported, but get " +
-                                 metrics.__class__.__name__)
+                return [metrics.get_metric(backend)]
 
     @staticmethod
     def convert_metrics_dict(metrics, backend="bigdl"):

--- a/pyzoo/zoo/orca/learn/pytorch/estimator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/estimator.py
@@ -47,12 +47,10 @@ class Estimator(object):
                    model_dir=None,
                    backend="bigdl"):
         if backend in {"horovod", "torch_distributed"}:
-            if metrics is not None:
-                warnings.warn(f"The metrics argument is not support in {backend} backend, "
-                              f"this takes no effect")
             return PyTorchRayEstimator(model_creator=model,
                                        optimizer_creator=optimizer,
                                        loss_creator=loss,
+                                       metrics=metrics,
                                        scheduler_creator=scheduler_creator,
                                        training_operator_cls=training_operator_cls,
                                        initialization_hook=initialization_hook,
@@ -79,6 +77,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                  model_creator,
                  optimizer_creator,
                  loss_creator=None,
+                 metrics=None,
                  scheduler_creator=None,
                  training_operator_cls=TrainingOperator,
                  initialization_hook=None,
@@ -96,6 +95,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
         self.estimator = PyTorchRayEstimator(model_creator=model_creator,
                                              optimizer_creator=optimizer_creator,
                                              loss_creator=loss_creator,
+                                             metrics=metrics,
                                              scheduler_creator=scheduler_creator,
                                              training_operator_cls=training_operator_cls,
                                              initialization_hook=initialization_hook,
@@ -229,8 +229,8 @@ class PyTorchSparkEstimator(OrcaSparkEstimator):
             optimizer = optimizer.get_optimizer()
         else:
             raise ValueError("Only PyTorch optimizer and orca optimizer are supported")
-        from zoo.orca.learn.metrics import Metrics
-        self.metrics = Metrics.convert_metrics_list(metrics)
+        from zoo.orca.learn.metrics import Metric
+        self.metrics = Metric.convert_metrics_list(metrics)
         self.log_dir = None
         self.app_name = None
         self.model_dir = model_dir

--- a/pyzoo/zoo/orca/learn/pytorch/pytorch_metrics.py
+++ b/pyzoo/zoo/orca/learn/pytorch/pytorch_metrics.py
@@ -44,4 +44,3 @@ class Accuracy:
 
     def compute(self):
         return self.correct.float() / self.total
-

--- a/pyzoo/zoo/orca/learn/pytorch/pytorch_metrics.py
+++ b/pyzoo/zoo/orca/learn/pytorch/pytorch_metrics.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import pytorch_lightning
-import logging
 import torch
 
 

--- a/pyzoo/zoo/orca/learn/pytorch/pytorch_metrics.py
+++ b/pyzoo/zoo/orca/learn/pytorch/pytorch_metrics.py
@@ -1,0 +1,47 @@
+#
+# Copyright 2018 Analytics Zoo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import pytorch_lightning
+import logging
+import torch
+
+
+def _unify_input_formats(preds, target):
+    if not (preds.ndim == target.ndim or preds.ndim == target.ndim + 1):
+        raise ValueError("preds the same or one more dimensions than targets")
+
+    if preds.ndim == target.ndim + 1:
+        preds = torch.argmax(preds, dim=1)
+
+    if preds.ndim == target.ndim and preds.is_floating_point():
+        preds = (preds >= 0.5).long()
+    return preds, target
+
+
+class Accuracy:
+
+    def __init__(self):
+
+        self.correct = torch.tensor(0)
+        self.total = torch.tensor(0)
+
+    def __call__(self, preds, targets):
+        preds, target = _unify_input_formats(preds, targets)
+        self.correct += torch.sum(preds == target)
+        self.total += target.numel()
+
+    def compute(self):
+        return self.correct.float() / self.total
+

--- a/pyzoo/zoo/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -93,6 +93,7 @@ class PyTorchRayEstimator:
             model_creator,
             optimizer_creator,
             loss_creator=None,
+            metrics=None,
             scheduler_creator=None,
             training_operator_cls=TrainingOperator,
             initialization_hook=None,
@@ -132,7 +133,9 @@ class PyTorchRayEstimator:
             training_operator_cls=self.training_operator_cls,
             scheduler_step_freq=self.scheduler_step_freq,
             use_tqdm=self.use_tqdm,
-            config=worker_config)
+            config=worker_config,
+            metrics=metrics
+        )
 
         if backend == "torch_distributed":
             cores_per_node = ray_ctx.ray_node_cpu_cores // workers_per_node

--- a/pyzoo/zoo/orca/learn/pytorch/torch_runner.py
+++ b/pyzoo/zoo/orca/learn/pytorch/torch_runner.py
@@ -318,7 +318,9 @@ class TorchRunner:
         if num_steps:
             loader = itertools.islice(loader, num_steps)
         with self.timers.record("validation"):
-            validation_stats = self.training_operator.validate(loader, info=info, metrics=self.metrics)
+            validation_stats = self.training_operator.validate(loader,
+                                                               info=info,
+                                                               metrics=self.metrics)
         if profile:
             validation_stats.update(profile=self.timers.stats())
         return validation_stats

--- a/pyzoo/zoo/orca/learn/pytorch/torch_runner.py
+++ b/pyzoo/zoo/orca/learn/pytorch/torch_runner.py
@@ -63,6 +63,7 @@ class TorchRunner:
                  model_creator,
                  optimizer_creator,
                  loss_creator=None,
+                 metrics=None,
                  scheduler_creator=None,
                  training_operator_cls=None,
                  config=None,
@@ -79,6 +80,7 @@ class TorchRunner:
         self.epochs = 0
         self.models = None
         self.optimizers = None
+        self.metrics = metrics
         self.criterion = None
         self.schedulers = None
         self.train_loader = None
@@ -316,7 +318,7 @@ class TorchRunner:
         if num_steps:
             loader = itertools.islice(loader, num_steps)
         with self.timers.record("validation"):
-            validation_stats = self.training_operator.validate(loader, info=info)
+            validation_stats = self.training_operator.validate(loader, info=info, metrics=self.metrics)
         if profile:
             validation_stats.update(profile=self.timers.stats())
         return validation_stats

--- a/pyzoo/zoo/orca/learn/pytorch/training_operator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/training_operator.py
@@ -322,7 +322,7 @@ class TrainingOperator:
 
         result = {name: metric.compute() for name, metric in metrics.items()}
 
-        result["loss"] = sum(losses) / total_samples
+        result["val_loss"] = sum(losses) / total_samples
 
         result["num_samples"] = total_samples
 

--- a/pyzoo/zoo/orca/learn/pytorch/training_operator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/training_operator.py
@@ -35,6 +35,7 @@ import collections
 import torch
 import numpy as np
 
+from zoo.orca.learn.metrics import Metric
 from zoo.orca.learn.pytorch.utils import (TimerCollection, AverageMeterCollection,
                                           NUM_SAMPLES)
 from zoo.orca.learn.pytorch.constants import (SCHEDULER_STEP_EPOCH, NUM_STEPS,
@@ -280,7 +281,7 @@ class TrainingOperator:
 
         return {"train_loss": loss.item(), NUM_SAMPLES: features[0].size(0)}
 
-    def validate(self, val_iterator, info):
+    def validate(self, val_iterator, info, metrics):
         """Runs one standard validation pass over the val_iterator.
 
         This will call ``model.eval()`` and ``torch.no_grad`` when iterating
@@ -303,18 +304,29 @@ class TrainingOperator:
                 from ``validate_batch`` and dividing it by the sum of
                 ``num_samples`` from all calls to ``self.validate_batch``.
         """
-        metric_meters = AverageMeterCollection()
-
         # switch to evaluate mode
         self.model.eval()
+        metrics = Metric.convert_metrics_dict(metrics, backend="pytorch")
+        losses = []
+        total_samples = 0
         with torch.no_grad():
             for batch_idx, batch in enumerate(val_iterator):
                 batch_info = {"batch_idx": batch_idx}
                 batch_info.update(info)
-                metrics = self.validate_batch(batch, batch_info)
-                metric_meters.update(metrics, n=metrics.pop(NUM_SAMPLES, 1))
+                output, target, loss = self.forward_batch(batch, batch_info)
+                num_samples = target.size(0)
+                total_samples += num_samples
+                losses.append(loss.item() * num_samples)
+                for metric in metrics.values():
+                    metric(output, target)
 
-        return metric_meters.summary()
+        result = {name: metric.compute() for name, metric in metrics.items()}
+
+        result["loss"] = sum(losses) / total_samples
+
+        result["num_samples"] = total_samples
+
+        return result
 
     def predict(self, pred_iterator):
         # switch to evaluate mode
@@ -344,7 +356,7 @@ class TrainingOperator:
         np_output = output.detach().numpy()
         return np_output
 
-    def validate_batch(self, batch, batch_info):
+    def forward_batch(self, batch, batch_info):
         """Calculates the loss and accuracy over a given batch.
 
         You can override this method to provide arbitrary metrics.
@@ -377,40 +389,8 @@ class TrainingOperator:
         with self.timers.record("eval_fwd"):
             output = self.model(*features)
             loss = self.criterion(output, target)
-            if len(target.size()) > 1:
-                # Can't directly call torch.squeeze() in case batch size is 1.
-                for i in reversed(range(1, len(target.size()))):
-                    target = torch.squeeze(target, i)
-            if len(output.size()) > 1:
-                # In case there is extra trailing dimensions.
-                for i in reversed(range(1, len(output.size()))):
-                    output = torch.squeeze(output, i)
 
-        np_output = output.detach().numpy()
-        np_target = target.detach().numpy()
-        # validate will be called by TCMF to get val_loss for regression tasks.
-        # In this case, accuracy is calculated but not used and the result is wrong.
-        # So do not directly raise an Exception here to avoid errors in TCMF.
-        # TODO: Support other validation metrics.
-        if len(np_target.shape) != 1 or len(np_output.shape) > 2:
-            import warnings
-            warnings.warn("Currently in validate, only accuracy for classification with "
-                          "zero-based label is supported by default. You can override "
-                          "validate_batch in TrainingOperator for other validation metrics")
-        import numpy as np
-        if len(np_output.shape) == 1:  # Binary classification
-            np_output = np.round(np_output, 0)
-        else:  # Multi-class classification
-            np_output = np.argmax(np_output, axis=1)
-
-        num_correct = np.sum(np_output == np_target)
-        num_samples = target.size(0)
-
-        return {
-            "val_loss": loss.item(),
-            "val_accuracy": num_correct / num_samples,
-            NUM_SAMPLES: num_samples
-        }
+        return output, target, loss
 
     def state_dict(self):
         """Override this to return a representation of the operator state.


### PR DESCRIPTION
For pytorch and bigdl estimators, they both use a unified orca metrics interface specified at estimator construction. Inside estimator, each estimator will get the implementation metrics class according to their backend ("pytorch" or "bigdl" currently).

For pytorch ray estimators, currently we use the pytorch lightning implementation. **Users need to install pytorch lightning package to use this feature.**

```python
from zoo.orca.learn.metrics import Accuracy
estimator = Estimator.from_torch(model=model_fn,
                                 optimizer=get_optimizer,
                                 loss=nn.BCELoss(),
                                 metrics=Accuracy(),
                                 config={"lr": 1e-2},
                                 workers_per_node=workers_per_node,
                                 backend="torch_distributed")
```
- [ ] making pytorch lightning a plugin ?