### PR TITLE
Update orca pytorch quick start

### DIFF
--- a/readthedocs/source/doc/Orca/QuickStart/orca-pytorch-quickstart.md
+++ b/readthedocs/source/doc/Orca/QuickStart/orca-pytorch-quickstart.md
@@ -110,20 +110,21 @@ First, Create an Estimator
 
 ```python
 from zoo.orca.learn.pytorch import Estimator 
+from zoo.orca.learn.metrics import Accuracy
 
-est = Estimator.from_torch(model=model, optimizer=adam, loss=criterion)
+est = Estimator.from_torch(model=model, optimizer=adam, loss=criterion, metrics=[Accuracy()])
 ```
 
 Next, fit and evaluate using the Estimator
 
 ```python
-from zoo.orca.learn.metrics import Accuracy
+
 from zoo.orca.learn.trigger import EveryEpoch 
 
 est.fit(data=train_loader, epochs=10, validation_data=test_loader,
-        validation_metrics=[Accuracy()], checkpoint_trigger=EveryEpoch())
+        checkpoint_trigger=EveryEpoch())
 
-result = est.evaluate(data=test_loader, validation_metrics=[Accuracy()])
+result = est.evaluate(data=test_loader)
 for r in result:
     print(str(r))
 ```

--- a/readthedocs/source/doc/Orca/QuickStart/orca-pytorch-quickstart.md
+++ b/readthedocs/source/doc/Orca/QuickStart/orca-pytorch-quickstart.md
@@ -118,7 +118,6 @@ est = Estimator.from_torch(model=model, optimizer=adam, loss=criterion, metrics=
 Next, fit and evaluate using the Estimator
 
 ```python
-
 from zoo.orca.learn.trigger import EveryEpoch 
 
 est.fit(data=train_loader, epochs=10, validation_data=test_loader,


### PR DESCRIPTION
According to previous changes of orca pytorch,  validation metrics should be specified in the `Estimator.from_torch` function instead of the `fit` or `evaluate` function. The quick start document is updated in this PR to align with the [notebook](https://github.com/intel-analytics/analytics-zoo/blob/master/docs/docs/colab-notebook/orca/quickstart/pytorch_lenet_mnist.ipynb).