### PR TITLE
Cluster Serving auto set flink parallelism

### DIFF
--- a/scripts/cluster-serving/cluster-serving-start
+++ b/scripts/cluster-serving/cluster-serving-start
@@ -22,10 +22,7 @@ while [ "$1" != "" ]; do
         -c | --config_path )    shift
                                 config_path=$1
                                 ;;
-        -p | --parallelism )    shift
-                                par_num=$1
-                                ;;
-        -t | --omp )            shift
+        -o | --omp )            shift
                                 export OMP_NUM_THREADS=$1
                                 ;;
         -h | --help )           usage
@@ -40,9 +37,7 @@ done
 if [ -z "${config_path// }" ]; then
   config_path=config.yaml
 fi
-if [ -z "${par_num// }" ]; then
-  par_num=1
-fi
+
 
 parse_yaml $config_path
 eval $(parse_yaml $config_path)
@@ -94,6 +89,6 @@ else
   rm -rf /tmp/cluster-serving-jobs.yaml
 fi
 
-${FLINK_HOME}/bin/flink run -c com.intel.analytics.zoo.serving.ClusterServing -p $par_num zoo.jar -c $config_path
+${FLINK_HOME}/bin/flink run -c com.intel.analytics.zoo.serving.ClusterServing zoo.jar -c $config_path
 
 

--- a/scripts/cluster-serving/config.yaml
+++ b/scripts/cluster-serving/config.yaml
@@ -11,9 +11,9 @@ data:
   # default, None
   filter:
 params:
-  # default, 4
+  # default, number of cores per model in serving
   core_number:
-  # default: model number will auto-adapt to core_number, do not set it if not sure about the behavior
+  # default: number of models in serving
   model_number:
   # default: OFF
   performance_mode:

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/baseline/InferenceBaseline.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/baseline/InferenceBaseline.scala
@@ -102,12 +102,12 @@ object InferenceBaseline extends Supportive {
       s"with input ${param.testNum.toString}") {
       var a = Seq[(String, Table)]()
       val pre = new PreProcessing(true)
-      (0 until helper.coreNum).foreach( i =>
+      (0 until helper.thrdPerModel).foreach(i =>
         a = a :+ (i.toString(), T(warmT))
       )
-      (0 until param.testNum).grouped(helper.coreNum).flatMap(batch => {
+      (0 until param.testNum).grouped(helper.thrdPerModel).flatMap(batch => {
           val t = timer.timing("Batch input", batch.size) {
-            clusterServingInference.batchInput(a, helper.coreNum, true, helper.resize)
+            clusterServingInference.batchInput(a, helper.thrdPerModel, true, helper.resize)
           }
           clusterServingInference.dimCheck(t, "add", helper.modelType)
           val result = timer.timing("Inference", batch.size) {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/FlinkInference.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/FlinkInference.scala
@@ -52,7 +52,7 @@ class FlinkInference(helper: ClusterServingHelper)
       }
       inference = new ClusterServingInference(new PreProcessing(
         helper.chwFlag, helper.redisHost, helper.redisPort),
-        helper.modelType, helper.filter, helper.coreNum, helper.resize)
+        helper.modelType, helper.filter, helper.thrdPerModel, helper.resize)
     }
 
     catch {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/FlinkRedisSource.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/FlinkRedisSource.scala
@@ -76,7 +76,7 @@ class FlinkRedisSource(params: ClusterServingHelper)
     .SourceContext[List[(String, String)]]): Unit = while (isRunning) {
     val groupName = "serving"
     val consumerName = "consumer-" + UUID.randomUUID().toString
-    val readNumPerTime = if (params.modelType == "openvino") params.coreNum else 4
+    val readNumPerTime = if (params.modelType == "openvino") params.thrdPerModel else 4
 
     val response = jedis.xreadGroup(
       groupName,

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/utils/ClusterServingHelper.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/utils/ClusterServingHelper.scala
@@ -57,8 +57,7 @@ class ClusterServingHelper(_configPath: String = "config.yaml", _modelDir: Strin
   var redisHost: String = null
   var redisPort: Int = _
   var redisTimeout: Int = 5000
-  var nodeNum: Int = 1
-  var coreNum: Int = 1
+  var thrdPerModel: Int = 1
   var modelPar: Int = 1
   var blasFlag: Boolean = false
   var chwFlag: Boolean = true
@@ -140,10 +139,9 @@ class ClusterServingHelper(_configPath: String = "config.yaml", _modelDir: Strin
     resize = getYaml(dataConfig, "resize", true).asInstanceOf[Boolean]
 
     val paramsConfig = configList.get("params").asInstanceOf[HM]
-    coreNum = getYaml(paramsConfig, "core_number", 4).asInstanceOf[Int]
+    thrdPerModel = getYaml(paramsConfig, "core_number", 4).asInstanceOf[Int]
 
-    val modelParDefault = if (modelType == "openvino") coreNum else coreNum
-    modelPar = getYaml(paramsConfig, "model_number", default = modelParDefault).asInstanceOf[Int]
+    modelPar = getYaml(paramsConfig, "model_number", default = 1).asInstanceOf[Int]
 
 
     if (modelType == "caffe" || modelType == "bigdl") {
@@ -325,8 +323,8 @@ class ClusterServingHelper(_configPath: String = "config.yaml", _modelDir: Strin
       case "keras" => logError("Keras currently not supported in Cluster Serving," +
         "consider transform it to Tensorflow")
       case "openvino" => modelEncrypted match {
-        case true => model.doLoadEncryptedOpenVINO(defPath, weightPath, secret, salt, coreNum)
-        case false => model.doLoadOpenVINO(defPath, weightPath, coreNum)
+        case true => model.doLoadEncryptedOpenVINO(defPath, weightPath, secret, salt, thrdPerModel)
+        case false => model.doLoadOpenVINO(defPath, weightPath, thrdPerModel)
       }
       case _ => logError("Invalid model type, please check your model directory")
     }

--- a/zoo/src/test/scala/com/intel/analytics/zoo/serving/models/OpenVINOModelSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/serving/models/OpenVINOModelSpec.scala
@@ -43,7 +43,7 @@ class OpenVINOModelSpec extends FlatSpec with Matchers {
     Seq("sh", "-c", "rm -rf /tmp/openvino_inception_v1*").!
 
     val inference = new ClusterServingInference(new PreProcessing(helper.chwFlag),
-      helper.modelType, "", helper.coreNum, helper.resize)
+      helper.modelType, "", helper.thrdPerModel, helper.resize)
     val in = List(("1", b64string), ("2", b64string), ("3", b64string))
     val postProcessed = inference.multiThreadPipeline(in)
 
@@ -72,7 +72,7 @@ class OpenVINOModelSpec extends FlatSpec with Matchers {
     Seq("sh", "-c", "rm -rf /tmp/openvino_mobilenet_v1*").!
 
     val inference = new ClusterServingInference(new PreProcessing(helper.chwFlag),
-      helper.modelType, "", helper.coreNum, helper.resize)
+      helper.modelType, "", helper.thrdPerModel, helper.resize)
     val in = List(("1", b64string), ("2", b64string), ("3", b64string))
     val postProcessed = inference.multiThreadPipeline(in)
 
@@ -102,7 +102,7 @@ class OpenVINOModelSpec extends FlatSpec with Matchers {
     Seq("sh", "-c", "rm -rf /tmp/openvino_mobilenet_v2*").!
 
     val inference = new ClusterServingInference(new PreProcessing(helper.chwFlag),
-      helper.modelType, "", helper.coreNum, helper.resize)
+      helper.modelType, "", helper.thrdPerModel, helper.resize)
     val in = List(("1", b64string), ("2", b64string), ("3", b64string))
     val postProcessed = inference.multiThreadPipeline(in)
 
@@ -132,7 +132,7 @@ class OpenVINOModelSpec extends FlatSpec with Matchers {
     Seq("sh", "-c", "rm -rf /tmp/openvino2020_resnet50*").!
 
     val inference = new ClusterServingInference(new PreProcessing(helper.chwFlag),
-      helper.modelType, "", helper.coreNum, helper.resize)
+      helper.modelType, "", helper.thrdPerModel, helper.resize)
     val in = List(("1", b64string), ("2", b64string), ("3", b64string))
     val postProcessed = inference.multiThreadPipeline(in)
 
@@ -162,7 +162,7 @@ class OpenVINOModelSpec extends FlatSpec with Matchers {
     Seq("sh", "-c", "rm -rf /tmp/openvino_resnet50*").!
 
     val inference = new ClusterServingInference(new PreProcessing(helper.chwFlag),
-      helper.modelType, "", helper.coreNum, helper.resize)
+      helper.modelType, "", helper.thrdPerModel, helper.resize)
     val in = List(("1", b64string), ("2", b64string), ("3", b64string))
     val postProcessed = inference.multiThreadPipeline(in)
 
@@ -193,7 +193,7 @@ class OpenVINOModelSpec extends FlatSpec with Matchers {
     Seq("sh", "-c", "rm -rf /tmp/openvino_vgg16*").!
 
     val inference = new ClusterServingInference(new PreProcessing(helper.chwFlag),
-      helper.modelType, "", helper.coreNum, helper.resize)
+      helper.modelType, "", helper.thrdPerModel, helper.resize)
     val in = List(("1", b64string), ("2", b64string), ("3", b64string))
     val postProcessed = inference.multiThreadPipeline(in)
 

--- a/zoo/src/test/scala/com/intel/analytics/zoo/serving/models/TensorflowModelSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/serving/models/TensorflowModelSpec.scala
@@ -44,7 +44,7 @@ class TensorflowModelSpec extends FlatSpec with Matchers {
     Seq("sh", "-c", "rm -rf /tmp/tensorflow_inception_v1*").!
 
     val inference = new ClusterServingInference(new PreProcessing(helper.chwFlag),
-      helper.modelType, "", helper.coreNum, helper.resize)
+      helper.modelType, "", helper.thrdPerModel, helper.resize)
     val in = List(("1", b64string), ("2", b64string), ("3", b64string))
     val postProcessed = inference.multiThreadPipeline(in)
 
@@ -73,7 +73,7 @@ class TensorflowModelSpec extends FlatSpec with Matchers {
     Seq("sh", "-c", "rm -rf /tmp/tensorflow_mobilenet_v1*").!
 
     val inference = new ClusterServingInference(new PreProcessing(helper.chwFlag),
-      helper.modelType, "", helper.coreNum, helper.resize)
+      helper.modelType, "", helper.thrdPerModel, helper.resize)
     val in = List(("1", b64string), ("2", b64string), ("3", b64string))
     val postProcessed = inference.multiThreadPipeline(in)
 
@@ -103,7 +103,7 @@ class TensorflowModelSpec extends FlatSpec with Matchers {
     Seq("sh", "-c", "rm -rf /tmp/tensorflow_mobilenet_v2*").!
 
     val inference = new ClusterServingInference(new PreProcessing(helper.chwFlag),
-      helper.modelType, "", helper.coreNum, helper.resize)
+      helper.modelType, "", helper.thrdPerModel, helper.resize)
     val in = List(("1", b64string), ("2", b64string), ("3", b64string))
     val postProcessed = inference.multiThreadPipeline(in)
 
@@ -133,7 +133,7 @@ class TensorflowModelSpec extends FlatSpec with Matchers {
     Seq("sh", "-c", "rm -rf /tmp/tensorflow_resnet50*").!
 
     val inference = new ClusterServingInference(new PreProcessing(helper.chwFlag),
-      helper.modelType, "", helper.coreNum, helper.resize)
+      helper.modelType, "", helper.thrdPerModel, helper.resize)
     val in = List(("1", b64string), ("2", b64string), ("3", b64string))
     val postProcessed = inference.multiThreadPipeline(in)
 
@@ -162,7 +162,7 @@ class TensorflowModelSpec extends FlatSpec with Matchers {
     Seq("sh", "-c", "rm -rf /tmp/tensorflow_tfauto*").!
 
     val inference = new ClusterServingInference(new PreProcessing(helper.chwFlag),
-      helper.modelType, "", helper.coreNum, helper.resize)
+      helper.modelType, "", helper.thrdPerModel, helper.resize)
     val in = List(("1", b64string), ("2", b64string), ("3", b64string))
     val postProcessed = inference.multiThreadPipeline(in)
 
@@ -191,7 +191,7 @@ class TensorflowModelSpec extends FlatSpec with Matchers {
     Seq("sh", "-c", "rm -rf /tmp/tensorflow_vgg16*").!
 
     val inference = new ClusterServingInference(new PreProcessing(helper.chwFlag),
-      helper.modelType, "", helper.coreNum, helper.resize)
+      helper.modelType, "", helper.thrdPerModel, helper.resize)
     val in = List(("1", b64string), ("2", b64string), ("3", b64string))
     val postProcessed = inference.multiThreadPipeline(in)
 
@@ -220,7 +220,7 @@ class TensorflowModelSpec extends FlatSpec with Matchers {
     Seq("sh", "-c", "rm -rf /tmp/tensorflow_tf_2out*").!
 
     val inference = new ClusterServingInference(new PreProcessing(helper.chwFlag),
-      helper.modelType, "", helper.coreNum, helper.resize)
+      helper.modelType, "", helper.thrdPerModel, helper.resize)
     val in = List(("1", b64string), ("2", b64string), ("3", b64string))
     val postProcessed = inference.multiThreadPipeline(in)
 


### PR DESCRIPTION
@jason-dai user can just set `model_num`, model number in serving pipeline  and `core_num`, core number each model would use.

To make this more readable, in code, `coreNum` is renamed to `thrdPerModel`

The whole pipeline parallelism will be controlled by `model_num`, this would be consistent with inference model design