### PR TITLE
batch_size related changes for Orca PyTorch

### DIFF
--- a/docs/docs/Orca/orca-pytorch-estimator.md
+++ b/docs/docs/Orca/orca-pytorch-estimator.md
@@ -57,7 +57,7 @@ After an Estimator is created, you can call estimator API to train PyTorch model
 ```
 fit(self, data, epochs=1, profile=False, reduce_results=True, info=None)
 ```
-* `data`: (callable) a funtion that takes a config dict as input and return a data loader containing the training data.
+* `data`: (callable) a funtion that takes a config dict and `batch_size` as input and return a data loader containing the training data.
 * `epochs`: (int) Number of epochs to train the model
 * `profile`: (bool) Returns time stats for the training procedure.
 * `reduce_results`: (bool) Whether to average all metrics across all workers into one dict. If a metric is a non-numerical value (or nested dictionaries), one value will be randomly selected among the workers. If False, returns a list of dicts.
@@ -68,7 +68,7 @@ After Training, you can call estimator API to evaluate PyTorch model:
 ```
 evaluate(self, data, num_steps=None, profile=False, info=None)
 ```
-* `data`: (callable) a funtion that takes a config dict as input and return a data loader containing the validation data.
+* `data`: (callable) a funtion that takes a config dict and `batch_size` as input and return a data loader containing the validation data.
 * `num_steps`: (int) Number of batches to compute update steps on. This corresponds also to the number of times ``TrainingOperator.validate_batch`` is called.
 * `profile`: (bool) Returns time stats for the evaluation procedure.
 * `info`: (dict) Optional dictionary passed to the training operator for `validate` and `validate_batch`.

--- a/docs/docs/Orca/orca-pytorch-quickstart.md
+++ b/docs/docs/Orca/orca-pytorch-quickstart.md
@@ -104,21 +104,21 @@ test_loader = torch.utils.data.DataLoader(
 First, Create an Estimator
 
 ```python
-from zoo.orca.learn.pytorch import Estimator 
+from zoo.orca.learn.pytorch import Estimator
+from zoo.orca.learn.metrics import Accuracy 
 
-est = Estimator.from_torch(model=model, optimizer=adam, loss=criterion)
+est = Estimator.from_torch(model=model, optimizer=adam, loss=criterion, metrics=[Accuracy()])
 ```
 
 Next, fit and evaluate using the Estimator
 
 ```python
-from zoo.orca.learn.metrics import Accuracy
 from zoo.orca.learn.trigger import EveryEpoch 
 
 est.fit(data=train_loader, epochs=10, validation_data=test_loader,
-        validation_metrics=[Accuracy()], checkpoint_trigger=EveryEpoch())
+        checkpoint_trigger=EveryEpoch())
 
-result = est.evaluate(data=test_loader, validation_metrics=[Accuracy()])
+result = est.evaluate(data=test_loader)
 for r in result:
     print(str(r))
 ```

--- a/pyzoo/test/zoo/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
+++ b/pyzoo/test/zoo/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
@@ -95,20 +95,21 @@ class MultiInputNet(nn.Module):
         return x
 
 
-def train_data_loader(config):
+def train_data_loader(config, batch_size):
     train_dataset = LinearDataset(size=config.get("data_size", 1000))
     train_loader = torch.utils.data.DataLoader(
         train_dataset,
-        batch_size=config.get("batch_size", 32),
+        batch_size=batch_size
     )
     return train_loader
 
 
-def val_data_loader(config):
+def val_data_loader(config, batch_size):
     val_dataset = LinearDataset(size=config.get("val_size", 400))
     validation_loader = torch.utils.data.DataLoader(
         val_dataset,
-        batch_size=config.get("batch_size", 32))
+        batch_size=batch_size
+    )
     return validation_loader
 
 

--- a/pyzoo/zoo/automl/model/tcmf/local_model_distributed_trainer.py
+++ b/pyzoo/zoo/automl/model/tcmf/local_model_distributed_trainer.py
@@ -107,11 +107,11 @@ def data_creator(config):
     return train_loader, val_loader
 
 
-def train_data_creator(config):
+def train_data_creator(config, batch_size):
     return DataLoader(TcmfTrainDatasetHorovod(config), batch_size=None)
 
 
-def val_data_creator(config):
+def val_data_creator(config, batch_size):
     return DataLoader(TcmfValDataset(config), batch_size=None)
 
 

--- a/pyzoo/zoo/examples/orca/learn/horovod/pytorch_estimator.py
+++ b/pyzoo/zoo/examples/orca/learn/horovod/pytorch_estimator.py
@@ -59,20 +59,21 @@ def scheduler_creator(optimizer, config):
     return torch.optim.lr_scheduler.StepLR(optimizer, step_size=5, gamma=0.9)
 
 
-def train_data_creator(config):
+def train_data_creator(config, batch_size):
     train_dataset = LinearDataset(2, 5, size=config.get("data_size", 1000))
     train_loader = torch.utils.data.DataLoader(
         train_dataset,
-        batch_size=config.get("batch_size", 32),
+        batch_size=batch_size
     )
     return train_loader
 
 
-def validation_data_creator(config):
+def validation_data_creator(config, batch_size):
     val_dataset = LinearDataset(2, 5, size=config.get("val_size", 400))
     validation_loader = torch.utils.data.DataLoader(
         val_dataset,
-        batch_size=config.get("batch_size", 32))
+        batch_size=batch_size
+    )
     return validation_loader
 
 

--- a/pyzoo/zoo/examples/orca/learn/pytorch/fashion_mnist/fashion_mnist.py
+++ b/pyzoo/zoo/examples/orca/learn/pytorch/fashion_mnist/fashion_mnist.py
@@ -45,7 +45,7 @@ def train_data_creator(config, batch_size):
                                                  download=True,
                                                  train=True,
                                                  transform=transform)
-    trainloader = torch.utils.data.DataLoader(trainset, batch_size=4,
+    trainloader = torch.utils.data.DataLoader(trainset, batch_size=batch_size,
                                               shuffle=True, num_workers=2)
     return trainloader
 
@@ -56,7 +56,7 @@ def validation_data_creator(config, batch_size):
          transforms.Normalize((0.5,), (0.5,))])
     testset = torchvision.datasets.FashionMNIST(root='./data', train=False,
                                                 download=True, transform=transform)
-    testloader = torch.utils.data.DataLoader(testset, batch_size=4,
+    testloader = torch.utils.data.DataLoader(testset, batch_size=batch_size,
                                              shuffle=False, num_workers=2)
     return testloader
 
@@ -120,7 +120,7 @@ def main():
                'Sandal', 'Shirt', 'Sneaker', 'Bag', 'Ankle Boot')
 
     # plot some random training images
-    dataiter = iter(train_data_creator(config={}))
+    dataiter = iter(train_data_creator(config={}, 4))
     images, labels = dataiter.next()
 
     # create grid of images
@@ -147,7 +147,7 @@ def main():
     for stat in stats:
         writer.add_scalar("training_loss", stat['train_loss'], stat['epoch'])
     print("Train stats: {}".format(stats))
-    val_stats = orca_estimator.evaluate(validation_data_creator)
+    val_stats = orca_estimator.evaluate(validation_data_creator, batch_size=4)
     print("Validation stats: {}".format(val_stats))
     orca_estimator.shutdown()
 

--- a/pyzoo/zoo/examples/orca/learn/pytorch/fashion_mnist/fashion_mnist.py
+++ b/pyzoo/zoo/examples/orca/learn/pytorch/fashion_mnist/fashion_mnist.py
@@ -36,7 +36,7 @@ from zoo.orca import init_orca_context, stop_orca_context
 from zoo.orca.learn.pytorch import Estimator
 
 
-def train_data_creator(config):
+def train_data_creator(config, batch_size):
     transform = transforms.Compose(
         [transforms.ToTensor(),
          transforms.Normalize((0.5,), (0.5,))])
@@ -50,7 +50,7 @@ def train_data_creator(config):
     return trainloader
 
 
-def validation_data_creator(config):
+def validation_data_creator(config, batch_size):
     transform = transforms.Compose(
         [transforms.ToTensor(),
          transforms.Normalize((0.5,), (0.5,))])

--- a/pyzoo/zoo/examples/orca/learn/pytorch/fashion_mnist/fashion_mnist.py
+++ b/pyzoo/zoo/examples/orca/learn/pytorch/fashion_mnist/fashion_mnist.py
@@ -120,7 +120,7 @@ def main():
                'Sandal', 'Shirt', 'Sneaker', 'Bag', 'Ankle Boot')
 
     # plot some random training images
-    dataiter = iter(train_data_creator(config={}, 4))
+    dataiter = iter(train_data_creator(config={}, batch_size=4))
     images, labels = dataiter.next()
 
     # create grid of images

--- a/pyzoo/zoo/examples/orca/learn/pytorch/super_resolution/super_resolution.py
+++ b/pyzoo/zoo/examples/orca/learn/pytorch/super_resolution/super_resolution.py
@@ -145,7 +145,7 @@ def target_transform(crop_size):
     ])
 
 
-def train_data_creator(config):
+def train_data_creator(config, batch_size):
     def get_training_set(upscale_factor):
         root_dir = download_bsd300()
         train_dir = join(root_dir, "train")
@@ -157,13 +157,13 @@ def train_data_creator(config):
 
     train_set = get_training_set(config.get("upscale_factor", 3))
     training_data_loader = DataLoader(dataset=train_set,
-                                      batch_size=config.get("batch_size", 64),
+                                      batch_size=batch_size,
                                       num_workers=config.get("threads", 4),
                                       shuffle=True)
     return training_data_loader
 
 
-def validation_data_creator(config):
+def validation_data_creator(config, batch_size):
     def get_test_set(upscale_factor):
         root_dir = download_bsd300()
         test_dir = join(root_dir, "test")
@@ -175,7 +175,7 @@ def validation_data_creator(config):
 
     test_set = get_test_set(config.get("upscale_factor", 3))
     testing_data_loader = DataLoader(dataset=test_set,
-                                     batch_size=config.get("batch_size", 64),
+                                     batch_size=batch_size,
                                      num_workers=config.get("threads", 4),
                                      shuffle=False)
     return testing_data_loader

--- a/pyzoo/zoo/examples/orca/learn/pytorch/super_resolution/super_resolution.py
+++ b/pyzoo/zoo/examples/orca/learn/pytorch/super_resolution/super_resolution.py
@@ -229,7 +229,6 @@ estimator = Estimator.from_torch(
     config={
         "lr": opt.lr,
         "upscale_factor": opt.upscale_factor,
-        "batch_size": opt.batch_size,
         "threads": opt.threads,
         "seed": opt.seed
     }

--- a/pyzoo/zoo/orca/learn/pytorch/estimator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/estimator.py
@@ -88,7 +88,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                  backend="torch_distributed",
                  workers_per_node=1):
 
-        if "batch_size" in config:
+        if config is not None and "batch_size" in config:
             raise Exception("Please do not specify batch_size in config. Input batch_size in the"
                             " fit/evaluate function of the estimator instead.")
 

--- a/pyzoo/zoo/orca/learn/pytorch/estimator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/estimator.py
@@ -117,8 +117,8 @@ class PyTorchRayEstimator(OrcaRayEstimator):
         :param epochs: The number of epochs to train the model. Default is 1.
         :param batch_size: The number of samples per batch for each worker. Default is 32.
         The total batch size would be workers_per_node*num_nodes.
-        If you training data is a function, you can set batch_size to be config["batch_size"]
-        for the PyTorch DataLoader.
+        If your training data is a function, you can set batch_size to be the input batch_size
+        of the function for the PyTorch DataLoader.
         :param profile: Boolean. Whether to return time stats for the training procedure.
         Default is False.
         :param reduce_results: Boolean. Whether to average all metrics across all workers into
@@ -169,8 +169,8 @@ class PyTorchRayEstimator(OrcaRayEstimator):
         takes config and batch_size as argument and returns a PyTorch DataLoader for validation.
         :param batch_size: The number of samples per batch for each worker. Default is 32.
         The total batch size would be workers_per_node*num_nodes.
-        If you validation data is a function, you can set batch_size to be config["batch_size"]
-        for the PyTorch DataLoader.
+        If your validation data is a function, you can set batch_size to be the input batch_size
+        of the function for the PyTorch DataLoader.
         :param num_steps: The number of batches to compute the validation results on. This
         corresponds to the number of times `TrainingOperator.validate_batch` is called.
         :param profile: Boolean. Whether to return time stats for the training procedure.

--- a/pyzoo/zoo/orca/learn/pytorch/estimator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/estimator.py
@@ -90,7 +90,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
 
         if config is not None and "batch_size" in config:
             raise Exception("Please do not specify batch_size in config. Input batch_size in the"
-                            " fit/evaluate function of the estimator instead.")
+                            " fit/evaluate/predict function of the estimator instead.")
 
         from zoo.orca.learn.pytorch.pytorch_ray_estimator import PyTorchRayEstimator
         self.estimator = PyTorchRayEstimator(model_creator=model_creator,

--- a/pyzoo/zoo/orca/learn/pytorch/estimator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/estimator.py
@@ -87,6 +87,11 @@ class PyTorchRayEstimator(OrcaRayEstimator):
                  use_tqdm=False,
                  backend="torch_distributed",
                  workers_per_node=1):
+
+        if "batch_size" in config:
+            raise Exception("Please do not specify batch_size in config. Input batch_size in the"
+                            " fit/evaluate function of the estimator instead.")
+
         from zoo.orca.learn.pytorch.pytorch_ray_estimator import PyTorchRayEstimator
         self.estimator = PyTorchRayEstimator(model_creator=model_creator,
                                              optimizer_creator=optimizer_creator,
@@ -108,7 +113,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
         Calls `TrainingOperator.train_epoch()` on N parallel workers simultaneously
         underneath the hood.
         :param data: An instance of SparkXShards, a Spark DataFrame or a function that
-        takes config as argument and returns a PyTorch DataLoader for training.
+        takes config and batch_size as argument and returns a PyTorch DataLoader for training.
         :param epochs: The number of epochs to train the model. Default is 1.
         :param batch_size: The number of samples per batch for each worker. Default is 32.
         The total batch size would be workers_per_node*num_nodes.
@@ -161,7 +166,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
         Calls `TrainingOperator.validate()` on N parallel workers simultaneously
         underneath the hood.
         :param data: An instance of SparkXShards, a Spark DataFrame or a function that
-        takes config as argument and returns a PyTorch DataLoader for validation.
+        takes config and batch_size as argument and returns a PyTorch DataLoader for validation.
         :param batch_size: The number of samples per batch for each worker. Default is 32.
         The total batch size would be workers_per_node*num_nodes.
         If you validation data is a function, you can set batch_size to be config["batch_size"]

--- a/pyzoo/zoo/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -69,7 +69,6 @@ def shards_ref_to_creator(shards_ref):
             def __getitem__(self, i):
                 return index_data(self.x, i), index_data(self.y, i)
 
-        assert "batch_size" in config, "batch_size must be set in config"
         params = {"batch_size": batch_size, "shuffle": True}
         for arg in ["shuffle", "sampler", "batch_sampler", "num_workers", "collate_fn",
                     "pin_memory", "drop_last", "timeout", "worker_init_fn",

--- a/pyzoo/zoo/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -54,7 +54,7 @@ def check_for_failure(remote_values):
 
 def shards_ref_to_creator(shards_ref):
 
-    def data_creator(config):
+    def data_creator(config, batch_size):
         from zoo.orca.data.utils import ray_partition_get_data_label, index_data, get_size
         from torch.utils.data import Dataset, DataLoader
 
@@ -70,7 +70,7 @@ def shards_ref_to_creator(shards_ref):
                 return index_data(self.x, i), index_data(self.y, i)
 
         assert "batch_size" in config, "batch_size must be set in config"
-        params = {"batch_size": config["batch_size"], "shuffle": True}
+        params = {"batch_size": batch_size, "shuffle": True}
         for arg in ["shuffle", "sampler", "batch_sampler", "num_workers", "collate_fn",
                     "pin_memory", "drop_last", "timeout", "worker_init_fn",
                     "multiprocessing_context"]:

--- a/pyzoo/zoo/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -307,7 +307,7 @@ class PyTorchRayEstimator:
         ray_xshards = RayXShards.from_spark_xshards(xshards)
 
         def transform_func(worker, shards_ref):
-            data_creator = lambda config: shards_ref
+            data_creator = lambda config, batch_size: shards_ref
             return worker.predict.remote(
                 data_creator, **param)
 

--- a/pyzoo/zoo/orca/learn/pytorch/torch_runner.py
+++ b/pyzoo/zoo/orca/learn/pytorch/torch_runner.py
@@ -249,14 +249,13 @@ class TorchRunner:
     def train_epochs(self, data_creator, epochs=1, batch_size=32, profile=False,
                      info=None, wrap_dataloader=None):
         config = self.config.copy()
-        if "batch_size" not in config:
-            config["batch_size"] = batch_size
+        config["batch_size"] = batch_size
         if OrcaContext.serialize_data_creator:
             with FileLock(
                     os.path.join(tempfile.gettempdir(), ".orcadata.lock")):
-                loader = data_creator(config)
+                loader = data_creator(config, batch_size)
         else:
-            loader = data_creator(config)
+            loader = data_creator(config, batch_size)
 
         if wrap_dataloader is None:
             if TorchRunner.should_wrap_dataloader(loader):
@@ -299,17 +298,16 @@ class TorchRunner:
                  info=None, wrap_dataloader=None):
         """Evaluates the model on the validation data set."""
         config = self.config.copy()
-        if "batch_size" not in config:
-            config["batch_size"] = batch_size
+        config["batch_size"] = batch_size
         info = info or {}
         self._toggle_profiling(profile=profile)
 
         if OrcaContext.serialize_data_creator:
             with FileLock(
                     os.path.join(tempfile.gettempdir(), ".orcadata.lock")):
-                loader = data_creator(config)
+                loader = data_creator(config, batch_size)
         else:
-            loader = data_creator(config)
+            loader = data_creator(config, batch_size)
 
         if wrap_dataloader is None:
             if TorchRunner.should_wrap_dataloader(loader):
@@ -328,11 +326,10 @@ class TorchRunner:
     def predict(self, data_creator, batch_size=32, profile=False):
         """Evaluates the model on the validation data set."""
         config = self.config.copy()
-        if "batch_size" not in config:
-            config["batch_size"] = batch_size
+        config["batch_size"] = batch_size
         self._toggle_profiling(profile=profile)
 
-        shards_ref = data_creator(config)
+        shards_ref = data_creator(config, batch_size)
         if not isinstance(shards_ref, ray.ObjectID):
             raise ValueError("Only xshards is supported for predict")
 

--- a/pyzoo/zoo/orca/learn/pytorch/torch_runner.py
+++ b/pyzoo/zoo/orca/learn/pytorch/torch_runner.py
@@ -329,7 +329,7 @@ class TorchRunner:
         config["batch_size"] = batch_size
         self._toggle_profiling(profile=profile)
 
-        shards_ref = data_creator(config, batch_size)
+        shards_ref = data_creator(config)
         if not isinstance(shards_ref, ray.ObjectID):
             raise ValueError("Only xshards is supported for predict")
 

--- a/pyzoo/zoo/orca/learn/pytorch/torch_runner.py
+++ b/pyzoo/zoo/orca/learn/pytorch/torch_runner.py
@@ -249,7 +249,6 @@ class TorchRunner:
     def train_epochs(self, data_creator, epochs=1, batch_size=32, profile=False,
                      info=None, wrap_dataloader=None):
         config = self.config.copy()
-        config["batch_size"] = batch_size
         if OrcaContext.serialize_data_creator:
             with FileLock(
                     os.path.join(tempfile.gettempdir(), ".orcadata.lock")):
@@ -298,7 +297,6 @@ class TorchRunner:
                  info=None, wrap_dataloader=None):
         """Evaluates the model on the validation data set."""
         config = self.config.copy()
-        config["batch_size"] = batch_size
         info = info or {}
         self._toggle_profiling(profile=profile)
 

--- a/pyzoo/zoo/orca/learn/pytorch/torch_runner.py
+++ b/pyzoo/zoo/orca/learn/pytorch/torch_runner.py
@@ -324,15 +324,14 @@ class TorchRunner:
     def predict(self, data_creator, batch_size=32, profile=False):
         """Evaluates the model on the validation data set."""
         config = self.config.copy()
-        config["batch_size"] = batch_size
         self._toggle_profiling(profile=profile)
 
-        shards_ref = data_creator(config)
+        shards_ref = data_creator(config, batch_size)
         if not isinstance(shards_ref, ray.ObjectID):
             raise ValueError("Only xshards is supported for predict")
 
         partition = ray.get(shards_ref)
-        params = {"batch_size": config["batch_size"], "shuffle": False}
+        params = {"batch_size": batch_size, "shuffle": False}
         for arg in ["shuffle", "sampler", "batch_sampler", "num_workers", "collate_fn",
                     "pin_memory", "drop_last", "timeout", "worker_init_fn",
                     "multiprocessing_context"]:

--- a/readthedocs/source/doc/Orca/Overview/data-parallel-processing.md
+++ b/readthedocs/source/doc/Orca/Overview/data-parallel-processing.md
@@ -73,14 +73,14 @@ def train_data_creator(config):
 
 Pytorch:
 ```python
-def train_data_creator(config):
+def train_data_creator(config, batch_size):
     train_loader = torch.utils.data.DataLoader(
             datasets.MNIST(config["dir"], train=True, download=True,
                            transform=transforms.Compose([
                                transforms.ToTensor(),
                                transforms.Normalize((0.1307,), (0.3081,))
                            ])),
-            batch_size=config["batch_size"], shuffle=True)
+            batch_size=batch_size, shuffle=True)
     return train_loader
 ```
 


### PR DESCRIPTION
This PR relates to issue #3446 

Similar to `TF2`, after the changes, the program expects users to input `batch_size` in `fit`, `evaluate` and `predict` functions instead of in `config`. I also removed 
```py
if "batch_size" not in config:
```
in `torch_runner.py` because this may lead the program to ignore the input `batch_size`, for example, in the `validate` function.

In addition, the `data_creator` function should now expect 2 inputs: `config` and `batch_size`. Please have a look if the changes are ok. Thanks