### PR TITLE
Give the plug-in customized model a better way to save/load

### DIFF
--- a/pyzoo/test/zoo/automl/model/test_tcn.py
+++ b/pyzoo/test/zoo/automl/model/test_tcn.py
@@ -51,7 +51,7 @@ class TestTcn(TestCase):
         self.model.fit_eval(self.train_data[0], self.train_data[1], self.val_data, **config)
         mse, smape = self.model.evaluate(self.val_data[0],
                                          self.val_data[1],
-                                         metric=["mse", "smape"])
+                                         metrics=["mse", "smape"])
         assert len(mse) == self.val_data[1].shape[-1] * self.val_data[1].shape[-2]
         assert len(smape) == self.val_data[1].shape[-1] * self.val_data[1].shape[-2]
 

--- a/pyzoo/zoo/automl/model/base_pytorch_model.py
+++ b/pyzoo/zoo/automl/model/base_pytorch_model.py
@@ -149,14 +149,14 @@ class PytorchBaseModel(BaseModel):
         for i in range(len(list(self.model.parameters()))):
             print(list(self.model.parameters())[i].size())
 
-    def evaluate(self, x, y, metric=['mse']):
+    def evaluate(self, x, y, metrics=['mse']):
         # reshape 1dim input
         x = self._reshape_input(x)
         y = self._reshape_input(y)
 
         yhat = self.predict(x)
         eval_result = [Evaluator.evaluate(m, y_true=y, y_pred=yhat, multioutput="raw_values")
-                       for m in metric]
+                       for m in metrics]
         return eval_result
 
     def predict(self, x, mc=False):

--- a/pyzoo/zoo/automl/model/model_builder.py
+++ b/pyzoo/zoo/automl/model/model_builder.py
@@ -62,7 +62,7 @@ class ModelBuilder:
     def from_cls(cls, estimator):
         return cls(cls=estimator)
 
-    def restore(self, checkpoint_filename):
+    def build_from_ckpt(self, checkpoint_filename):
         '''Restore from a saved model'''
         if self.backend == "pytorch":
             from zoo.automl.model.base_pytorch_model import PytorchBaseModel

--- a/pyzoo/zoo/automl/model/model_builder.py
+++ b/pyzoo/zoo/automl/model/model_builder.py
@@ -61,8 +61,23 @@ class ModelBuilder:
     @classmethod
     def from_cls(cls, estimator):
         return cls(cls=estimator)
+    
+    def restore(self, checkpoint_filename):
+        '''Restore from a saved model'''
+        if self.backend == "pytorch":
+            from zoo.automl.model.base_pytorch_model import PytorchBaseModel
+            model = PytorchBaseModel(**self.params)
+            model.restore(checkpoint_filename)
+            return model
+
+        elif self.backend == "keras":
+            from zoo.automl.model.base_keras_model import KerasBaseModel
+            model = KerasBaseModel(**self.params)
+            model.restore(checkpoint_filename)
+            return model
 
     def build(self, config):
+        '''Build a new model'''
         if self.backend == "pytorch":
             from zoo.automl.model.base_pytorch_model import PytorchBaseModel
             model = PytorchBaseModel(**self.params)

--- a/pyzoo/zoo/automl/model/model_builder.py
+++ b/pyzoo/zoo/automl/model/model_builder.py
@@ -61,7 +61,7 @@ class ModelBuilder:
     @classmethod
     def from_cls(cls, estimator):
         return cls(cls=estimator)
-    
+
     def restore(self, checkpoint_filename):
         '''Restore from a saved model'''
         if self.backend == "pytorch":

--- a/pyzoo/zoo/automl/search/ray_tune_search_engine.py
+++ b/pyzoo/zoo/automl/search/ray_tune_search_engine.py
@@ -389,16 +389,19 @@ class RayTuneSearchEngine(SearchEngine):
                                               # verbose=1,
                                               **config)
                 reward_m = result if Evaluator.get_metric_mode(metric) == "max" else -result
-                ckpt_name = "best.ckpt"
-                if best_reward_m is None or reward_m > best_reward_m:
-                    best_reward_m = reward_m
-                    save_zip(ckpt_name, trial_ft, trial_model, config)
-                    if remote_dir is not None:
-                        upload_ppl_hdfs(remote_dir, ckpt_name)
+                checkpoint_filename = "best.ckpt"
+                if isinstance(model_create_func, ModelBuilder):
+                    trial_model.save(checkpoint_filename)
+                else:
+                    if best_reward_m is None or reward_m > best_reward_m:
+                        best_reward_m = reward_m
+                        save_zip(checkpoint_filename, trial_ft, trial_model, config)
+                        if remote_dir is not None:
+                            upload_ppl_hdfs(remote_dir, checkpoint_filename)
 
                 tune.track.log(training_iteration=i,
                                reward_metric=reward_m,
-                               checkpoint="best.ckpt")
+                               checkpoint=checkpoint_filename)
 
         return train_func
 

--- a/pyzoo/zoo/examples/automl/plugin_model_demo.py
+++ b/pyzoo/zoo/examples/automl/plugin_model_demo.py
@@ -114,7 +114,6 @@ if __name__ == "__main__":
                    validation_data=(data["val_x"], data["val_y"]),
                    epochs=20)
     val_result_pytorch_manual = model.evaluate(x=data["x"], y=data["y"], metrics=['rmse'])
-    
 
     # 3. try another modelbuilder based on tfkeras
     modelBuilder_keras = ModelBuilder.from_tfkeras(model_creator_keras)

--- a/pyzoo/zoo/examples/automl/plugin_model_demo.py
+++ b/pyzoo/zoo/examples/automl/plugin_model_demo.py
@@ -60,8 +60,8 @@ class SimpleRecipe(Recipe):
 
     def search_space(self, all_available_features):
         return {
-            "lr": tune.uniform(0.001, 0.01),
-            "batch_size": tune.choice([32, 64])
+            "lr": tune.uniform(0.01, 0.02),
+            "batch_size": tune.choice([16, 32, 64])
         }
 
 
@@ -99,17 +99,22 @@ if __name__ == "__main__":
     best_trials = searcher.get_best_trials(k=1)
     print(best_trials[0].config)
 
+    # rebuild this best config model and evaluate
+    best_model = modelBuilder.restore(best_trials[0].model_path)
+    searched_best_model = best_model.evaluate(data["val_x"], data["val_y"], metrics=["rmse"])
+
     # 2. you can also use the model builder with a fix config
     model = modelBuilder.build(config={
         "lr": 1e-2,  # used in optimizer_creator
         "batch_size": 32,  # used in data_creator
     })
 
-    val_result = model.fit_eval(x=data["x"],
-                                y=data["y"],
-                                validation_data=(data["val_x"], data["val_y"]),
-                                epochs=20)
-    print(val_result)
+    model.fit_eval(x=data["x"],
+                   y=data["y"],
+                   validation_data=(data["val_x"], data["val_y"]),
+                   epochs=20)
+    val_result_pytorch_manual = model.evaluate(x=data["x"], y=data["y"], metrics=['rmse'])
+    
 
     # 3. try another modelbuilder based on tfkeras
     modelBuilder_keras = ModelBuilder.from_tfkeras(model_creator_keras)
@@ -119,8 +124,11 @@ if __name__ == "__main__":
         "metric": "mse"
     })
 
-    val_result = model.fit_eval(x=data["x"],
-                                y=data["y"],
-                                validation_data=(data["val_x"], data["val_y"]),
-                                epochs=20)
-    print(val_result)
+    model.fit_eval(x=data["x"],
+                   y=data["y"],
+                   validation_data=(data["val_x"], data["val_y"]),
+                   epochs=20)
+    val_result_tensorflow_manual = model.evaluate(x=data["x"], y=data["y"], metrics=['rmse'])
+    print("Searched best model validation rmse:", searched_best_model)
+    print("Pytorch model validation rmse:", val_result_pytorch_manual)
+    print("Tensorflow model validation rmse:", val_result_tensorflow_manual)

--- a/pyzoo/zoo/examples/automl/plugin_model_demo.py
+++ b/pyzoo/zoo/examples/automl/plugin_model_demo.py
@@ -100,7 +100,7 @@ if __name__ == "__main__":
     print(best_trials[0].config)
 
     # rebuild this best config model and evaluate
-    best_model = modelBuilder.restore(best_trials[0].model_path)
+    best_model = modelBuilder.build_from_ckpt(best_trials[0].model_path)
     searched_best_model = best_model.evaluate(data["val_x"], data["val_y"], metrics=["rmse"])
 
     # 2. you can also use the model builder with a fix config

--- a/pyzoo/zoo/zouwu/model/forecast/tcn_forecaster.py
+++ b/pyzoo/zoo/zouwu/model/forecast/tcn_forecaster.py
@@ -78,10 +78,10 @@ class TCNForecaster(Forecaster):
             raise RuntimeError("You must call fit or restore first before calling predict!")
         return self.internal.predict(x)
 
-    def evaluate(self, x, y, metric=['mse']):
+    def evaluate(self, x, y, metrics=['mse']):
         if not self.internal.model_built:
             raise RuntimeError("You must call fit or restore first before calling evaluate!")
-        return self.internal.evaluate(x, y, metric=metric)
+        return self.internal.evaluate(x, y, metrics=metrics)
 
     def save(self, checkpoint_file):
         if not self.internal.model_built:


### PR DESCRIPTION
Major changes:

1. When RaySearcher find out that a customized model is used, then it will call the save directly.
2. Add a restore method for modelbuilder, so that user can restore easily from the checkpoint even if they stop the search midway.
3. Change the plugin model demo and show the usage of this new easy save/load

Some minor changes:

1. Change base_pytorch_model's evaluation method's param from metric to metrics
2. Add a comparation between searched model and manually fixed hyperparam model, which demos that searched model has a better result.