### PR TITLE
Fix orca initialization issue in spark

### DIFF
--- a/pyzoo/zoo/common/nncontext.py
+++ b/pyzoo/zoo/common/nncontext.py
@@ -369,7 +369,7 @@ def init_nncontext(conf=None, spark_log_level="WARN", redirect_spark_log=True):
         sc = getOrCreateSparkContext(conf=conf)
     sc.setLogLevel(spark_log_level)
 
-    if ZooContext.log_output and not has_activate_sc:
+    if ZooContext.log_output and not has_activate_sc and spark_jvm_proc is not None:
         if spark_jvm_proc.stdout is not None:
             stdout_reader = threading.Thread(target=_read_stream,
                                              daemon=True,


### PR DESCRIPTION
When submitting orca tf2 tasks to spark, the system gives error as follows:
```py
Traceback (most recent call last):
    File "/home/jinglei/zoo-tutorials/orca/tf2/tmp_test.py", line 183, in <module>
        init_orca_context(cluster_mode="local", cores=4)  # run in local mode
    File "/home/jinglei/analytics-zoo/dist/lib/analytics-zoo-bigdl_0.12.1-spark_2.4.3-0.10.0-SNAPSHOT-python-api.zip/zoo/orca/common.py", line 194, in init_orca_context
    File "/home/jinglei/analytics-zoo/dist/lib/analytics-zoo-bigdl_0.12.1-spark_2.4.3-0.10.0-SNAPSHOT-python-api.zip/zoo/common/nncontext.py", line 53, in init_spark_on_local
    File "/home/jinglei/analytics-zoo/dist/lib/analytics-zoo-bigdl_0.12.1-spark_2.4.3-0.10.0-SNAPSHOT-python-api.zip/zoo/util/spark.py", line 57, in init_spark_on_local
    File "/home/jinglei/analytics-zoo/dist/lib/analytics-zoo-bigdl_0.12.1-spark_2.4.3-0.10.0-SNAPSHOT-python-api.zip/zoo/common/nncontext.py", line 373, in init_nncontext
    AttributeError: 'NoneType' object has no attribute 'stdout'
Stopping orca context
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
    File "/home/jinglei/analytics-zoo/dist/lib/analytics-zoo-bigdl_0.12.1-spark_2.4.3-0.10.0-SNAPSHOT-python-api.zip/zoo/orca/common.py", line 269, in stop_orca_context
    File "/home/jinglei/analytics-zoo/dist/lib/analytics-zoo-bigdl_0.12.1-spark_2.4.3-0.10.0-SNAPSHOT-python-api.zip/zoo/ray/raycontext.py", line 393, in get
    Exception: No active RayContext. Please create a RayContext and init it first
```
This PR will fix the issue.