### PR TITLE
Implement nn_estimator evaluating method in Orca Bigdl estimator

### DIFF
--- a/pyzoo/test/zoo/orca/learn/spark/test_estimator_for_bigdl.py
+++ b/pyzoo/test/zoo/orca/learn/spark/test_estimator_for_bigdl.py
@@ -140,15 +140,15 @@ class TestEstimatorForKeras(TestCase):
             assert abs(res5_c[idx]["prediction"][0][1] - res6_c[idx]["prediction"][1]) == 0
 
     def test_nnEstimator_evaluation(self):
-        df, _ = self.get_estimator_df2()
+        df = self.get_estimator_df2()
         linear_model = Sequential().add(Linear(2, 2)).add(LogSoftMax())
 
         est = Estimator.from_bigdl(model=linear_model, loss=ClassNLLCriterion(), optimizer=Adam(),
                                    feature_preprocessing=SeqToTensor([2]),
                                    label_preprocessing=SeqToTensor([1]),
                                    metrics=Accuracy())
-        est.fit(data=df, epochs=10, batch_size=6, validation_data=df, validation_trigger=EveryEpoch())
-        result = est.evaluate(df, batch_size=4)
+        est.fit(data=df, epochs=10, batch_size=8)
+        result = est.evaluate(df, batch_size=8)
 
         shift = udf(lambda p: float(p.index(max(p))), DoubleType())
         pred = est.predict(df).withColumn("prediction", shift(col('prediction'))).cache()

--- a/pyzoo/test/zoo/orca/learn/spark/test_estimator_for_bigdl.py
+++ b/pyzoo/test/zoo/orca/learn/spark/test_estimator_for_bigdl.py
@@ -20,6 +20,7 @@ from unittest import TestCase
 from bigdl.nn.criterion import *
 from bigdl.nn.layer import *
 from pyspark.sql.types import *
+from pyspark.sql.functions import col, udf
 
 from zoo.common.nncontext import *
 from zoo.feature.common import *
@@ -137,6 +138,25 @@ class TestEstimatorForKeras(TestCase):
         for idx in range(len(res5_c)):
             assert abs(res5_c[idx]["prediction"][0][0] - res6_c[idx]["prediction"][0]) == 0
             assert abs(res5_c[idx]["prediction"][0][1] - res6_c[idx]["prediction"][1]) == 0
+
+    def test_nnEstimator_evaluation(self):
+        df, _ = self.get_estimator_df2()
+        linear_model = Sequential().add(Linear(2, 2)).add(LogSoftMax())
+
+        est = Estimator.from_bigdl(model=linear_model, loss=ClassNLLCriterion(), optimizer=Adam(),
+                                   feature_preprocessing=SeqToTensor([2]),
+                                   label_preprocessing=SeqToTensor([1]),
+                                   metrics=Accuracy())
+        est.fit(data=df, epochs=10, batch_size=6, validation_data=df, validation_trigger=EveryEpoch())
+        result = est.evaluate(df, batch_size=4)
+
+        shift = udf(lambda p: float(p.index(max(p))), DoubleType())
+        pred = est.predict(df).withColumn("prediction", shift(col('prediction'))).cache()
+
+        correct = pred.filter("label=prediction").count()
+        overall = pred.count()
+        accuracy = correct * 1.0 / overall
+        assert accuracy == round(result['Top1Accuracy'], 2)
 
     def test_nnEstimator_multiInput(self):
         zx1 = ZLayer.Input(shape=(1,))

--- a/pyzoo/zoo/orca/learn/bigdl/estimator.py
+++ b/pyzoo/zoo/orca/learn/bigdl/estimator.py
@@ -134,8 +134,8 @@ class BigDLEstimator(OrcaSparkEstimator):
                     BigDLEstimator._combine_cols(data, label_cols, col_name="label",
                                                  val_data=validation_data)
 
-            self.nn_estimator.setBatchSize(batch_size).setMaxEpoch(epochs)\
-                .setCachingSample(caching_sample).setFeaturesCol(feature_cols)\
+            self.nn_estimator.setBatchSize(batch_size).setMaxEpoch(epochs) \
+                .setCachingSample(caching_sample).setFeaturesCol(feature_cols) \
                 .setLabelCol(label_cols)
 
             if validation_data is not None:
@@ -227,7 +227,7 @@ class BigDLEstimator(OrcaSparkEstimator):
             raise ValueError("Data should be XShards or Spark DataFrame, but get " +
                              data.__class__.__name__)
 
-    def evaluate(self, data, batch_size=32, feature_cols=None, label_cols=None):
+    def evaluate(self, data, batch_size=32, feature_cols="features", label_cols="label"):
         """
         Evaluate model.
 
@@ -246,7 +246,27 @@ class BigDLEstimator(OrcaSparkEstimator):
                                          " argument when creating this estimator."
 
         if isinstance(data, DataFrame):
-            raise NotImplementedError
+            if isinstance(feature_cols, list):
+                data, _, feature_cols = \
+                    BigDLEstimator._combine_cols(data, [feature_cols], col_name="features")
+
+            if isinstance(label_cols, list):
+                data, _, label_cols = \
+                    BigDLEstimator._combine_cols(data, label_cols, col_name="label")
+
+            self.nn_estimator.setNNBatchSize(batch_size).setNNFeaturesCol(feature_cols) \
+                .setNNLabelCol(label_cols)
+
+            self.nn_estimator.setValidation(None, data,
+                                            self.metrics, batch_size)
+            if self.log_dir is not None and self.app_name is not None:
+                from bigdl.optim.optimizer import TrainSummary
+                from bigdl.optim.optimizer import ValidationSummary
+                val_summary = ValidationSummary(log_dir=self.log_dir, app_name=self.app_name)
+                self.nn_estimator.setValidationSummary(val_summary)
+
+            result = self.nn_estimator.eval(data)
+
         elif isinstance(data, SparkXShards):
             from zoo.orca.data.utils import xshard_to_sample
             val_feature_set = FeatureSet.sample_rdd(data.rdd.flatMap(xshard_to_sample))

--- a/pyzoo/zoo/orca/learn/bigdl/estimator.py
+++ b/pyzoo/zoo/orca/learn/bigdl/estimator.py
@@ -231,9 +231,9 @@ class BigDLEstimator(OrcaSparkEstimator):
         """
         Evaluate model.
 
-        :param data: validation data. It can be XShardsor or Spark DataFrame, each partition is a dictionary of
-               {'x': feature, 'y': label}, where feature(label) is a numpy array or a list of numpy
-               arrays.
+        :param data: validation data. It can be XShardsor or Spark DataFrame, each partition is
+               a dictionary of {'x': feature, 'y': label}, where feature(label) is a numpy array
+               or a list of numpy arrays.
         :param batch_size: Batch size used for validation. Default: 32.
         :param feature_cols: (Not supported yet) Feature column name(s) of data. Only used when
                data is a Spark  DataFrame. Default: None.

--- a/pyzoo/zoo/orca/learn/bigdl/estimator.py
+++ b/pyzoo/zoo/orca/learn/bigdl/estimator.py
@@ -231,7 +231,7 @@ class BigDLEstimator(OrcaSparkEstimator):
         """
         Evaluate model.
 
-        :param data: validation data. It can be XShards, each partition is a dictionary of
+        :param data: validation data. It can be XShardsor or Spark DataFrame, each partition is a dictionary of
                {'x': feature, 'y': label}, where feature(label) is a numpy array or a list of numpy
                arrays.
         :param batch_size: Batch size used for validation. Default: 32.
@@ -254,8 +254,8 @@ class BigDLEstimator(OrcaSparkEstimator):
                 data, _, label_cols = \
                     BigDLEstimator._combine_cols(data, label_cols, col_name="label")
 
-            self.nn_estimator.setNNBatchSize(batch_size).setNNFeaturesCol(feature_cols) \
-                .setNNLabelCol(label_cols)
+            self.nn_estimator._setNNBatchSize(batch_size)._setNNFeaturesCol(feature_cols) \
+                ._setNNLabelCol(label_cols)
 
             self.nn_estimator.setValidation(None, None,
                                             self.metrics, batch_size)

--- a/pyzoo/zoo/orca/learn/bigdl/estimator.py
+++ b/pyzoo/zoo/orca/learn/bigdl/estimator.py
@@ -257,7 +257,7 @@ class BigDLEstimator(OrcaSparkEstimator):
             self.nn_estimator.setNNBatchSize(batch_size).setNNFeaturesCol(feature_cols) \
                 .setNNLabelCol(label_cols)
 
-            self.nn_estimator.setValidation(None, data,
+            self.nn_estimator.setValidation(None, None,
                                             self.metrics, batch_size)
             if self.log_dir is not None and self.app_name is not None:
                 from bigdl.optim.optimizer import TrainSummary

--- a/pyzoo/zoo/orca/learn/bigdl/estimator.py
+++ b/pyzoo/zoo/orca/learn/bigdl/estimator.py
@@ -265,7 +265,7 @@ class BigDLEstimator(OrcaSparkEstimator):
                 val_summary = ValidationSummary(log_dir=self.log_dir, app_name=self.app_name)
                 self.nn_estimator.setValidationSummary(val_summary)
 
-            result = self.nn_estimator.eval(data)
+            result = self.nn_estimator._eval(data)
 
         elif isinstance(data, SparkXShards):
             from zoo.orca.data.utils import xshard_to_sample

--- a/pyzoo/zoo/pipeline/nnframes/nn_classifier.py
+++ b/pyzoo/zoo/pipeline/nnframes/nn_classifier.py
@@ -25,7 +25,6 @@ from bigdl.util.common import *
 from zoo.feature.common import *
 from zoo import init_nncontext
 
-
 if sys.version >= '3':
     long = int
     unicode = str
@@ -384,6 +383,24 @@ class NNEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, 
         """
         return self.validation_config
 
+    def setNNBatchSize(self, batch_size):
+        pythonBigDL_method_name = "setNNBatchSize"
+        callZooFunc(self.bigdl_type, pythonBigDL_method_name, self.value,
+                           batch_size)
+        return self
+
+    def setNNFeaturesCol(self, feature_cols):
+        pythonBigDL_method_name = "setNNFeaturesCol"
+        callZooFunc(self.bigdl_type, pythonBigDL_method_name, self.value,
+                           feature_cols)
+        return self
+
+    def setNNLabelCol(self, label_cols):
+        pythonBigDL_method_name = "setNNLabelCol"
+        callZooFunc(self.bigdl_type, pythonBigDL_method_name, self.value,
+                           label_cols)
+        return self
+
     def clearGradientClipping(self):
         """
         Clear clipping params, in this case, clipping will not be applied.
@@ -472,6 +489,12 @@ class NNEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, 
         Sets the value of :py:attr:`labelCol`.
         """
         return self._set(labelCol=value)
+
+    def eval(self, val_data):
+        pythonBigDL_method_name = "internalEval"
+        result = callZooFunc(self.bigdl_type, pythonBigDL_method_name, self.value,
+                             val_data)
+        return result
 
 
 class NNModel(JavaTransformer, MLWritable, MLReadable, HasFeaturesCol, HasPredictionCol,

--- a/pyzoo/zoo/pipeline/nnframes/nn_classifier.py
+++ b/pyzoo/zoo/pipeline/nnframes/nn_classifier.py
@@ -383,19 +383,31 @@ class NNEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, 
         """
         return self.validation_config
 
-    def setNNBatchSize(self, batch_size):
+    def _setNNBatchSize(self, batch_size):
+        """
+        Set BatchSize in NNEstimator directly instead of Deserialized from python object
+        For evaluting use ONLY
+        """
         pythonBigDL_method_name = "setNNBatchSize"
         callZooFunc(self.bigdl_type, pythonBigDL_method_name, self.value,
                     batch_size)
         return self
 
-    def setNNFeaturesCol(self, feature_cols):
+    def _setNNFeaturesCol(self, feature_cols):
+        """
+        Set FeaturesCol in NNEstimator directly instead of Deserialized from python object
+        For evaluting use ONLY
+        """
         pythonBigDL_method_name = "setNNFeaturesCol"
         callZooFunc(self.bigdl_type, pythonBigDL_method_name, self.value,
                     feature_cols)
         return self
 
-    def setNNLabelCol(self, label_cols):
+    def _setNNLabelCol(self, label_cols):
+        """
+        Set LabelCol in NNEstimator directly instead of Deserialized from python object
+        For evaluting use ONLY
+        """
         pythonBigDL_method_name = "setNNLabelCol"
         callZooFunc(self.bigdl_type, pythonBigDL_method_name, self.value,
                     label_cols)
@@ -491,6 +503,11 @@ class NNEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, 
         return self._set(labelCol=value)
 
     def _eval(self, val_data):
+        """
+        Call Evaluting process.
+
+        :param val_data: validation data. Spark DataFrame
+        """
         pythonBigDL_method_name = "internalEval"
         result = callZooFunc(self.bigdl_type, pythonBigDL_method_name, self.value,
                              val_data)

--- a/pyzoo/zoo/pipeline/nnframes/nn_classifier.py
+++ b/pyzoo/zoo/pipeline/nnframes/nn_classifier.py
@@ -490,7 +490,7 @@ class NNEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, 
         """
         return self._set(labelCol=value)
 
-    def eval(self, val_data):
+    def _eval(self, val_data):
         pythonBigDL_method_name = "internalEval"
         result = callZooFunc(self.bigdl_type, pythonBigDL_method_name, self.value,
                              val_data)

--- a/pyzoo/zoo/pipeline/nnframes/nn_classifier.py
+++ b/pyzoo/zoo/pipeline/nnframes/nn_classifier.py
@@ -386,19 +386,19 @@ class NNEstimator(JavaEstimator, HasFeaturesCol, HasLabelCol, HasPredictionCol, 
     def setNNBatchSize(self, batch_size):
         pythonBigDL_method_name = "setNNBatchSize"
         callZooFunc(self.bigdl_type, pythonBigDL_method_name, self.value,
-                           batch_size)
+                    batch_size)
         return self
 
     def setNNFeaturesCol(self, feature_cols):
         pythonBigDL_method_name = "setNNFeaturesCol"
         callZooFunc(self.bigdl_type, pythonBigDL_method_name, self.value,
-                           feature_cols)
+                    feature_cols)
         return self
 
     def setNNLabelCol(self, label_cols):
         pythonBigDL_method_name = "setNNLabelCol"
         callZooFunc(self.bigdl_type, pythonBigDL_method_name, self.value,
-                           label_cols)
+                    label_cols)
         return self
 
     def clearGradientClipping(self):

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimator.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimator.scala
@@ -489,6 +489,8 @@ class NNEstimator[T: ClassTag] private[zoo](
     wrapBigDLModel(model)
   }
 
+  // todo: Maybe try 
+  // https://spark.apache.org/docs/latest/api/python/reference/pyspark.ml.html#evaluation
   def internalEval(dataFrame: DataFrame): JList[EvaluatedResult] = {
     val validationFeatureset = getDataSet(dataFrame, validationBatchSize)
     val optimizer = new InternalDistriOptimizer(model, null, criterion)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimator.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimator.scala
@@ -489,7 +489,7 @@ class NNEstimator[T: ClassTag] private[zoo](
     wrapBigDLModel(model)
   }
 
-  // todo: Maybe try 
+  // todo: Maybe try
   // https://spark.apache.org/docs/latest/api/python/reference/pyspark.ml.html#evaluation
   def internalEval(dataFrame: DataFrame): JList[EvaluatedResult] = {
     val validationFeatureset = getDataSet(dataFrame, validationBatchSize)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimator.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimator.scala
@@ -575,18 +575,18 @@ object NNEstimator {
    * Float, Double, Int, Array[Float], Array[Double], Array[Int] and MLlib Vector. The feature and
    * label data are converted to Tensors with the specified sizes before sending to the model.
    *
-   * @param model       BigDL module to be optimized
-   * @param criterion   BigDL criterion method
+   * @param model BigDL module to be optimized
+   * @param criterion BigDL criterion method
    * @param featureSize The size (Tensor dimensions) of the feature data. e.g. an image may be with
    *                    width * height = 28 * 28, featureSize = Array(28, 28).
-   * @param labelSize   The size (Tensor dimensions) of the label data.
+   * @param labelSize The size (Tensor dimensions) of the label data.
    */
   def apply[T: ClassTag](
-                          model: Module[T],
-                          criterion: Criterion[T],
-                          featureSize: Array[Int],
-                          labelSize: Array[Int]
-                        )(implicit ev: TensorNumeric[T]): NNEstimator[T] = {
+      model: Module[T],
+      criterion: Criterion[T],
+      featureSize: Array[Int],
+      labelSize: Array[Int]
+    )(implicit ev: TensorNumeric[T]): NNEstimator[T] = {
     new NNEstimator(model, criterion)
       .setSamplePreprocessing(FeatureLabelPreprocessing(
         SeqToTensor(featureSize), SeqToTensor(labelSize))
@@ -613,7 +613,7 @@ object NNEstimator {
       criterion: Criterion[T],
       featureSize: Array[Array[Int]],
       labelSize: Array[Int]
-     )(implicit ev: TensorNumeric[T]): NNEstimator[T] = {
+    )(implicit ev: TensorNumeric[T]): NNEstimator[T] = {
     new NNEstimator(model, criterion)
       .setSamplePreprocessing(FeatureLabelPreprocessing(
         SeqToMultipleTensors(featureSize),
@@ -826,9 +826,9 @@ object NNModel extends MLReadable[NNModel[_]] {
    * @param featureSize The sizes (Tensor dimensions) of the feature data.
    */
   def apply[T: ClassTag](
-                          model: Module[T],
-                          featureSize: Array[Array[Int]]
-                        )(implicit ev: TensorNumeric[T]): NNModel[T] = {
+      model: Module[T],
+      featureSize: Array[Array[Int]]
+    )(implicit ev: TensorNumeric[T]): NNModel[T] = {
     new NNModel(model)
       .setSamplePreprocessing(SeqToMultipleTensors(featureSize) -> MultiTensorsToSample())
   }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimator.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimator.scala
@@ -195,20 +195,20 @@ private[nnframes] trait NNParams[@specialized(Float, Double) T] extends HasFeatu
  * conversion and training.
  * More concrete examples are available in package [[com.intel.analytics.zoo.examples.nnframes]]
  *
- * @param model     BigDL module to be optimized
+ * @param model BigDL module to be optimized
  * @param criterion BigDL criterion
  * @tparam T data type of BigDL Model
  */
 class NNEstimator[T: ClassTag] private[zoo](
-                                             @transient val model: Module[T],
-                                             val criterion: Criterion[T],
-                                             override val uid: String = Identifiable.randomUID("nnestimator")
-                                           )(implicit ev: TensorNumeric[T])
+    @transient val model: Module[T],
+    val criterion: Criterion[T],
+    override val uid: String = Identifiable.randomUID("nnestimator")
+  )(implicit ev: TensorNumeric[T])
   extends DLEstimatorBase[NNEstimator[T], NNModel[T]] with NNParams[T]
     with TrainingParams[T] {
 
   def setSamplePreprocessing[FF <: Any, LL <: Any](
-                                                    value: Preprocessing[(FF, Option[LL]), Sample[T]]): this.type =
+      value: Preprocessing[(FF, Option[LL]), Sample[T]]): this.type =
     set(samplePreprocessing, value.asInstanceOf[Preprocessing[Any, Sample[T]]])
 
   def setFeaturesCol(featuresColName: String): this.type = set(featuresCol, featuresColName)
@@ -322,10 +322,10 @@ class NNEstimator[T: ClassTag] private[zoo](
   /**
    * Set a validate evaluation during training. Default: not enabled.
    *
-   * @param trigger      how often to evaluation validation set
+   * @param trigger how often to evaluation validation set
    * @param validationDF validate data set
-   * @param vMethods     a set of validation method [[ValidationMethod]]
-   * @param batchSize    batch size for validation
+   * @param vMethods a set of validation method [[ValidationMethod]]
+   * @param batchSize batch size for validation
    * @return this estimator
    */
   def setValidation(trigger: Trigger, validationDF: DataFrame,
@@ -356,9 +356,9 @@ class NNEstimator[T: ClassTag] private[zoo](
   /**
    * Set check points during training. Not enabled by default.
    *
-   * @param path        the directory to save
-   * @param trigger     how often to save the check point
-   * @param isOverWrite : whether to overwrite existing snapshots in path. Default is True
+   * @param path the directory to save
+   * @param trigger how often to save the check point
+   * @param isOverWrite: whether to overwrite existing snapshots in path. Default is True
    * @return this estimator
    */
   def setCheckpoint(path: String, trigger: Trigger, isOverWrite: Boolean = true): this.type = {
@@ -391,8 +391,8 @@ class NNEstimator[T: ClassTag] private[zoo](
   }
 
   private def getDataSet(
-                          dataFrame: DataFrame,
-                          batchSize: Int): FeatureSet[MiniBatch[T]] = {
+      dataFrame: DataFrame,
+      batchSize: Int): FeatureSet[MiniBatch[T]] = {
 
     val sp = $(samplePreprocessing).asInstanceOf[Preprocessing[(Any, Option[Any]), Sample[T]]]
     val featureColIndex = dataFrame.schema.fieldIndex($(featuresCol))
@@ -558,13 +558,13 @@ object NNEstimator {
   /**
    * Construct a [[NNEstimator]] with default Preprocessing: A SeqToTensor
    *
-   * @param model     BigDL module to be optimized
+   * @param model BigDL module to be optimized
    * @param criterion BigDL criterion method
    */
   def apply[T: ClassTag](
-                          model: Module[T],
-                          criterion: Criterion[T]
-                        )(implicit ev: TensorNumeric[T]): NNEstimator[T] = {
+      model: Module[T],
+      criterion: Criterion[T]
+    )(implicit ev: TensorNumeric[T]): NNEstimator[T] = {
     new NNEstimator(model, criterion)
       .setSamplePreprocessing(FeatureLabelPreprocessing(SeqToTensor(), SeqToTensor()))
   }
@@ -602,18 +602,18 @@ object NNEstimator {
    * This API is used for multi-input model, where user need to specify the tensor sizes for
    * each of the model input.
    *
-   * @param model       BigDL module to be optimized
-   * @param criterion   BigDL criterion method
+   * @param model BigDL module to be optimized
+   * @param criterion BigDL criterion method
    * @param featureSize The sizes (Tensor dimensions) of the feature data. e.g. an image may be with
    *                    width * height = 28 * 28, featureSize = Array(28, 28).
-   * @param labelSize   The size (Tensor dimensions) of the label data.
+   * @param labelSize The size (Tensor dimensions) of the label data.
    */
   def apply[T: ClassTag](
-                          model: Module[T],
-                          criterion: Criterion[T],
-                          featureSize: Array[Array[Int]],
-                          labelSize: Array[Int]
-                        )(implicit ev: TensorNumeric[T]): NNEstimator[T] = {
+      model: Module[T],
+      criterion: Criterion[T],
+      featureSize: Array[Array[Int]],
+      labelSize: Array[Int]
+     )(implicit ev: TensorNumeric[T]): NNEstimator[T] = {
     new NNEstimator(model, criterion)
       .setSamplePreprocessing(FeatureLabelPreprocessing(
         SeqToMultipleTensors(featureSize),
@@ -625,17 +625,17 @@ object NNEstimator {
   /**
    * Construct a [[NNEstimator]] with a feature Preprocessing and label Preprocessing.
    *
-   * @param model                BigDL module to be optimized
-   * @param criterion            BigDL criterion method
+   * @param model BigDL module to be optimized
+   * @param criterion BigDL criterion method
    * @param featurePreprocessing Preprocessing[Any, Tensor[T] ]
-   * @param labelPreprocessing   Preprocessing[Any, Tensor[T] ]
+   * @param labelPreprocessing Preprocessing[Any, Tensor[T] ]
    */
   def apply[F, L, T: ClassTag](
-                                model: Module[T],
-                                criterion: Criterion[T],
-                                featurePreprocessing: Preprocessing[F, Tensor[T]],
-                                labelPreprocessing: Preprocessing[L, Tensor[T]]
-                              )(implicit ev: TensorNumeric[T]): NNEstimator[T] = {
+      model: Module[T],
+      criterion: Criterion[T],
+      featurePreprocessing: Preprocessing[F, Tensor[T]],
+      labelPreprocessing: Preprocessing[L, Tensor[T]]
+    )(implicit ev: TensorNumeric[T]): NNEstimator[T] = {
     new NNEstimator(model, criterion)
       .setSamplePreprocessing(FeatureLabelPreprocessing(featurePreprocessing, labelPreprocessing))
   }
@@ -644,16 +644,16 @@ object NNEstimator {
    * Construct a [[NNEstimator]] with a featurePreprocessing only. The constructor is useful
    * when both feature and label are derived from the same column of the original DataFrame.
    *
-   * @param model                BigDL module to be optimized
-   * @param criterion            BigDL criterion method
+   * @param model BigDL module to be optimized
+   * @param criterion BigDL criterion method
    * @param featurePreprocessing A [[Preprocessing]] that transforms the feature data to a
-   *                             Sample[T].
+   *        Sample[T].
    */
   def apply[F, T: ClassTag](
-                             model: Module[T],
-                             criterion: Criterion[T],
-                             featurePreprocessing: Preprocessing[F, Sample[T]]
-                           )(implicit ev: TensorNumeric[T]): NNEstimator[T] = {
+      model: Module[T],
+      criterion: Criterion[T],
+      featurePreprocessing: Preprocessing[F, Sample[T]]
+    )(implicit ev: TensorNumeric[T]): NNEstimator[T] = {
     new NNEstimator(model, criterion)
       .setSamplePreprocessing(TupleToFeatureAdapter(featurePreprocessing))
   }
@@ -675,8 +675,8 @@ object NNEstimator {
  * @param model trained BigDL models to use in prediction.
  */
 class NNModel[T: ClassTag] private[zoo](
-                                         @transient val model: Module[T],
-                                         override val uid: String = "DLModel")(implicit ev: TensorNumeric[T])
+    @transient val model: Module[T],
+    override val uid: String = "DLModel")(implicit ev: TensorNumeric[T])
   extends DLTransformerBase[NNModel[T]] with NNParams[T]
     with HasBatchSize with MLWritable {
 
@@ -696,7 +696,6 @@ class NNModel[T: ClassTag] private[zoo](
 
   /**
    * set Preprocessing.
-   *
    * @param value : A [[Preprocessing]] that transforms the feature data to a Sample[T].
    */
   def setSamplePreprocessing[FF <: Any](value: Preprocessing[FF, Sample[T]]): this.type =
@@ -792,8 +791,8 @@ object NNModel extends MLReadable[NNModel[_]] {
    * @param model BigDL module to be optimized
    */
   def apply[T: ClassTag](
-                          model: Module[T]
-                        )(implicit ev: TensorNumeric[T]): NNModel[T] = {
+      model: Module[T]
+    )(implicit ev: TensorNumeric[T]): NNModel[T] = {
     new NNModel(model)
       .setSamplePreprocessing(SeqToTensor() -> TensorToSample())
   }
@@ -801,14 +800,14 @@ object NNModel extends MLReadable[NNModel[_]] {
   /**
    * Construct a [[NNModel]] with a feature size.
    *
-   * @param model       BigDL module to be optimized
+   * @param model BigDL module to be optimized
    * @param featureSize The size (Tensor dimensions) of the feature data. e.g. an image may be with
    *                    width * height = 28 * 28, featureSize = Array(28, 28).
    */
   def apply[T: ClassTag](
-                          model: Module[T],
-                          featureSize: Array[Int]
-                        )(implicit ev: TensorNumeric[T]): NNModel[T] = {
+      model: Module[T],
+      featureSize: Array[Int]
+    )(implicit ev: TensorNumeric[T]): NNModel[T] = {
     new NNModel(model)
       .setSamplePreprocessing(SeqToTensor(featureSize) -> TensorToSample())
   }
@@ -823,7 +822,7 @@ object NNModel extends MLReadable[NNModel[_]] {
    * This API is used for multi-input model, where user need to specify the tensor sizes for
    * each of the model input.
    *
-   * @param model       model to be used, which should be a multi-input model.
+   * @param model model to be used, which should be a multi-input model.
    * @param featureSize The sizes (Tensor dimensions) of the feature data.
    */
   def apply[T: ClassTag](
@@ -841,9 +840,9 @@ object NNModel extends MLReadable[NNModel[_]] {
    * @param featurePreprocessing Preprocessing[F, Tensor[T] ].
    */
   def apply[F, T: ClassTag](
-                             model: Module[T],
-                             featurePreprocessing: Preprocessing[F, Tensor[T]]
-                           )(implicit ev: TensorNumeric[T]): NNModel[T] = {
+      model: Module[T],
+      featurePreprocessing: Preprocessing[F, Tensor[T]]
+    )(implicit ev: TensorNumeric[T]): NNModel[T] = {
     new NNModel(model).setSamplePreprocessing(featurePreprocessing -> TensorToSample())
   }
 
@@ -895,7 +894,7 @@ object NNModel extends MLReadable[NNModel[_]] {
   }
 
   class NNModelWriter[@specialized(Float, Double) T: ClassTag](
-                                                                instance: NNModel[T])(implicit ev: TensorNumeric[T]) extends MLWriter {
+    instance: NNModel[T])(implicit ev: TensorNumeric[T]) extends MLWriter {
     override protected def saveImpl(path: String): Unit = {
       NNModel.saveImpl[T](instance, instance.model,
         path, sc, shouldOverwrite)
@@ -907,17 +906,17 @@ object NNModel extends MLReadable[NNModel[_]] {
    * For compatibility with spark ml pipeline, TensorDataType is stored separately in extraMetadata.
    *
    * @tparam T TensorDataType
-   * @param instance      NNModel
-   * @param path          Path to which to save the NNModel.
+   * @param instance NNModel
+   * @param path Path to which to save the NNModel.
    * @param extraMetadata Metadata such as featureSize.
    */
   private[nnframes] def saveImpl[@specialized(Float, Double) T: ClassTag](
-                                                                           instance: NNModel[T],
-                                                                           module: Module[T],
-                                                                           path: String,
-                                                                           sc: SparkContext,
-                                                                           isOverWrite: Boolean = false,
-                                                                           extraMetadata: Option[JObject] = None)(implicit ev: TensorNumeric[T]): Unit = {
+      instance: NNModel[T],
+      module: Module[T],
+      path: String,
+      sc: SparkContext,
+      isOverWrite: Boolean = false,
+      extraMetadata: Option[JObject] = None)(implicit ev: TensorNumeric[T]): Unit = {
 
     val tensorDataType = ev.getType() match {
       case TensorDouble => "TensorDouble"

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/python/PythonNNFrames.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/python/PythonNNFrames.scala
@@ -16,10 +16,11 @@
 
 package com.intel.analytics.zoo.pipeline.nnframes.python
 
-import java.util.{ArrayList => JArrayList, List => JList}
+import java.util.{ArrayList => JArrayList, List => JList, Map => JMap}
 
 import com.intel.analytics.bigdl.dataset.{Sample, Transformer}
-import com.intel.analytics.bigdl.optim.{OptimMethod, Trigger, ValidationMethod}
+import com.intel.analytics.bigdl.optim.{OptimMethod, Trigger, ValidationMethod, ValidationResult}
+import com.intel.analytics.bigdl.python.api.EvaluatedResult
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.visualization.{TrainSummary, ValidationSummary}
@@ -250,5 +251,25 @@ class PythonNNFrames[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonZ
   def transformXGBClassifierModel(model: XGBClassifierModel,
                                         dataset: DataFrame): DataFrame = {
     model.transform(dataset)
+  }
+
+  def internalEval(estimator: NNEstimator[T],
+                   dataFrame: DataFrame): JList[EvaluatedResult] = {
+    estimator.internalEval(dataFrame)
+  }
+
+  def setNNFeaturesCol(estimator: NNEstimator[T],
+                       featuresColName: String): NNEstimator[T] = {
+    estimator.setFeaturesCol(featuresColName)
+  }
+
+  def setNNLabelCol(estimator: NNEstimator[T],
+                    labelColName: String): NNEstimator[T] = {
+    estimator.setLabelCol(labelColName)
+  }
+
+  def setNNBatchSize(estimator: NNEstimator[T],
+                     value: Int): NNEstimator[T] = {
+    estimator.setBatchSize(value)
   }
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/python/PythonNNFrames.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/python/PythonNNFrames.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.zoo.pipeline.nnframes.python
 
-import java.util.{ArrayList => JArrayList, List => JList, Map => JMap}
+import java.util.{ArrayList => JArrayList, List => JList}
 
 import com.intel.analytics.bigdl.dataset.{Sample, Transformer}
 import com.intel.analytics.bigdl.optim.{OptimMethod, Trigger, ValidationMethod, ValidationResult}

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimatorSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimatorSpec.scala
@@ -34,6 +34,7 @@ import com.intel.analytics.zoo.pipeline.api.keras.layers.Merge.merge
 import com.intel.analytics.zoo.pipeline.api.keras.layers.{Dense, Input}
 import com.intel.analytics.zoo.pipeline.api.keras.models.Model
 import com.intel.analytics.zoo.pipeline.api.keras.ZooSpecHelper
+import org.apache.flink.types.Nothing
 import org.apache.spark.SparkContext
 import org.apache.spark.ml.{Pipeline, PipelineModel}
 import org.apache.spark.ml.feature.MinMaxScaler
@@ -362,7 +363,7 @@ class NNEstimatorSpec extends ZooSpecHelper {
     val df = sqlContext.createDataFrame(data).toDF("features", "label")
     val estimator = NNEstimator(model, criterion, Array(6), Array(1))
       .setBatchSize(4)
-      .setValidation(None, None, Array(new Loss[Float]()), 2)
+      .setValidation(null, null, Array(new Loss[Float]()), 2)
       .setValidationSummary(ValidationSummary(logdir.getPath, "NNEstimatorValidation"))
 
     val result = estimator.internalEval(df)

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimatorSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimatorSpec.scala
@@ -632,10 +632,10 @@ private case class MinibatchData[T](featureData: Array[T], labelData: Array[T])
 object NNEstimatorSpec {
   // Generate noisy input of the form Y = signum(x.dot(weights) + intercept + noise)
   def generateTestInput(
-                         numRecords: Int,
-                         weight: Array[Double],
-                         intercept: Double,
-                         seed: Long): Seq[(Array[Double], Double)] = {
+      numRecords: Int,
+      weight: Array[Double],
+      intercept: Double,
+      seed: Long): Seq[(Array[Double], Double)] = {
     val rnd = RandomGenerator.RNG
     val data = (1 to numRecords)
       .map(i => Array.tabulate(weight.length)(index => rnd.uniform(0, 1) * 2 - 1))

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimatorSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimatorSpec.scala
@@ -45,8 +45,8 @@ import scala.reflect.io.Path
 
 
 class NNEstimatorSpec extends ZooSpecHelper {
-  var sc : SparkContext = _
-  var sqlContext : SQLContext = _
+  var sc: SparkContext = _
+  var sqlContext: SQLContext = _
   var smallData: Seq[(Array[Double], Double)] = _
   val nRecords = 100
   val maxEpoch = 20
@@ -354,6 +354,21 @@ class NNEstimatorSpec extends ZooSpecHelper {
     logdir.deleteOnExit()
   }
 
+  "An NNEstimator" should "supports Evaluation" in {
+    val model = new Sequential().add(Linear[Float](6, 2)).add(LogSoftMax[Float])
+    val criterion = ZooClassNLLCriterion[Float]()
+    val logdir = createTmpDir()
+    val data = sc.parallelize(smallData)
+    val df = sqlContext.createDataFrame(data).toDF("features", "label")
+    val estimator = NNEstimator(model, criterion, Array(6), Array(1))
+      .setBatchSize(4)
+      .setValidation(None, None, Array(new Loss[Float]()), 2)
+      .setValidationSummary(ValidationSummary(logdir.getPath, "NNEstimatorValidation"))
+
+    val result = estimator.internalEval(df)
+    result
+  }
+
   "An NNEstimator" should "throw exception when EndWhen and MaxEpoch are set" in {
     val model = new Sequential().add(Linear[Float](6, 2)).add(LogSoftMax[Float])
     val criterion = ZooClassNLLCriterion[Float]()
@@ -361,7 +376,7 @@ class NNEstimatorSpec extends ZooSpecHelper {
 
     val data = sc.parallelize(smallData)
     val df = sqlContext.createDataFrame(data).toDF("features", "label")
-    val estimator = NNEstimator( model, criterion, Array(6), Array(1))
+    val estimator = NNEstimator(model, criterion, Array(6), Array(1))
       .setBatchSize(4)
       .setEndWhen(Trigger.maxIteration(5))
       .setMaxEpoch(5)
@@ -382,7 +397,7 @@ class NNEstimatorSpec extends ZooSpecHelper {
         .setMax(1).setMin(-1)
       val model = new Sequential().add(Linear[Float](6, 2)).add(LogSoftMax[Float])
       val criterion = ZooClassNLLCriterion[Float]()
-      val estimator = NNEstimator( model, criterion, Array(6), Array(1))
+      val estimator = NNEstimator(model, criterion, Array(6), Array(1))
         .setOptimMethod(new LBFGS[Float]())
         .setLearningRate(0.1)
         .setBatchSize(nRecords)
@@ -466,14 +481,14 @@ class NNEstimatorSpec extends ZooSpecHelper {
 
   "An NNModel" should "support save/load keras model" in {
     val modelLocation = getClass.getClassLoader.getResource("models/nnframes_keras").getFile
-    /**   code to generate model
-     *  import com.intel.analytics.zoo.pipeline.api.keras.layers.{Dense, Embedding, Input}
-     *  import com.intel.analytics.zoo.pipeline.api.keras.models.Model
-     *  val input = Input(inputShape = Shape(6))
-     *  val output = Dense(2).inputs(input)
-     *  val module = Model(input, output)
-     *  val nnModel = NNModel(module, Array(6)).setBatchSize(10)
-     *  nnModel.write.overwrite().save(modelLocation)
+    /** code to generate model
+     * import com.intel.analytics.zoo.pipeline.api.keras.layers.{Dense, Embedding, Input}
+     * import com.intel.analytics.zoo.pipeline.api.keras.models.Model
+     * val input = Input(inputShape = Shape(6))
+     * val output = Dense(2).inputs(input)
+     * val module = Model(input, output)
+     * val nnModel = NNModel(module, Array(6)).setBatchSize(10)
+     * nnModel.write.overwrite().save(modelLocation)
      */
     var appSparkVersion = org.apache.spark.SPARK_VERSION
     if (appSparkVersion.trim.startsWith("2")) {
@@ -529,7 +544,7 @@ class NNEstimatorSpec extends ZooSpecHelper {
     val data = sc.parallelize(
       smallData.map(p => (org.apache.spark.mllib.linalg.Vectors.dense(p._1), p._2)))
     val df: DataFrame = sqlContext.createDataFrame(data).toDF("abc", "la")
-    val estimator = NNEstimator( model, criterion, Array(6), Array(1))
+    val estimator = NNEstimator(model, criterion, Array(6), Array(1))
       .setBatchSize(32)
       .setOptimMethod(new LBFGS[Float]())
       .setLearningRate(0.123)
@@ -612,18 +627,18 @@ class NNEstimatorSpec extends ZooSpecHelper {
   }
 }
 
-private case class MinibatchData[T](featureData : Array[T], labelData : Array[T])
+private case class MinibatchData[T](featureData: Array[T], labelData: Array[T])
 
 object NNEstimatorSpec {
   // Generate noisy input of the form Y = signum(x.dot(weights) + intercept + noise)
   def generateTestInput(
-      numRecords: Int,
-      weight: Array[Double],
-      intercept: Double,
-      seed: Long): Seq[(Array[Double], Double)] = {
+                         numRecords: Int,
+                         weight: Array[Double],
+                         intercept: Double,
+                         seed: Long): Seq[(Array[Double], Double)] = {
     val rnd = RandomGenerator.RNG
     val data = (1 to numRecords)
-      .map( i => Array.tabulate(weight.length)(index => rnd.uniform(0, 1) * 2 - 1))
+      .map(i => Array.tabulate(weight.length)(index => rnd.uniform(0, 1) * 2 - 1))
       .map { record =>
         val y = record.zip(weight).map(t => t._1 * t._2).sum
         +intercept + 0.01 * rnd.normal(0, 1)


### PR DESCRIPTION
Related issue: #3507
When call `estimator.evaluate` to deal with a dataFrame, it will call scala method `internalEval` to process data.

Usage:
```python
 result = est.evaluate(data=validationDF, batch_size=16, feature_cols="image")
```
As a result it returns a Jlist of EvaluatedResult, which will be converted to a python dict like:
```
2021-03-16 00:04:27 INFO  DistriOptimizer$:1759 - Top1Accuracy is Accuracy(correct: 8, count: 26, accuracy: 0.3076923076923077)
{'Top1Accuracy': 0.3076923191547394}
```
Working Progress:
- [x] Scala internalEval method
- [x] Python nn_estimator eval method
- [x] UT

And if there is any spark official evaluating trait or base class you know, pls leave your comments, thanks!
