### PR TITLE
save and load methods for orca tf estimator

### DIFF
--- a/docs/docs/Orca/orca-pytorch-estimator.md
+++ b/docs/docs/Orca/orca-pytorch-estimator.md
@@ -79,12 +79,12 @@ evaluate(self, data, num_steps=None, profile=False, info=None)
 You can get the trained model using `get_model(self)`
 
 #### **Save model**
-You can save model using `save(self, checkpoint)`
-* `checkpoint`: (str) Path to target checkpoint file.
+You can save model using `save(self, model_path)`
+* `model_path`: (str) Path to save the model.
 
 #### **Load model**
-You can load saved model using `load(self, checkpoint)`
-* `checkpoint`: (str) Path to target checkpoint file.
+You can load saved model using `load(self, model_path)`
+* `model_path`: (str) Path to the existing model.
 
 #### **Shutdown workers**
 You can shut down workers and releases resources using `shutdown(self, force=False)`
@@ -126,10 +126,21 @@ predict(self, data, batch_size=4, feature_cols=None)
 #### **Get model**
 You can get model using `get_model(self)`
 
+#### **Save model**
+You can save model using `save(self, model_path)`
+* `model_path`: (str) Path to save the model.
+
 #### **Load model**
-You can load saved model using `load(self, checkpoint, loss=None)`
-* `checkpoint`: (str) Path to target checkpoint file.
-* `loss`: PyTorch loss function.
+You can load saved model using `load(self, model_path)`
+* `model_path`: (str) Path to the existing model.
+
+#### **Load orca checkpoint**
+You can load saved orca checkpoint using `load_orca_checkpoint(self, path, version, prefix)`. To load a specific checkpoint, 
+please provide both `version` and `perfix`. If `version` is None, then the latest checkpoint will be loaded.
+* `path`: Path to the existing checkpoint (or directory containing Orca checkpoint files if `version` is None).
+* `version`: checkpoint version, which is the suffix of model.* file, i.e., for
+               modle.4 file, the version is 4. If it is `None`, then load the latest checkpoint.
+* `prefix`: optimMethod prefix, for example 'optimMethod-TorchModelf53bddcc'. If loading the latest checkpoint, just leave it as `None`.
 
 #### **Clear gradient clipping**
 You can clear gradient clipping parameters using `clear_gradient_clipping(self)`. In this case, gradient clipping will not be applied.

--- a/docs/docs/Orca/orca-tf-estimator.md
+++ b/docs/docs/Orca/orca-tf-estimator.md
@@ -350,16 +350,16 @@ assert 'prediction' in predictions[0]
 During training, Orca TF Estimator would save Orca checkpoint every epoch. You can also specify `checkpoint_trigger` in fit() to set checkpoint interval. The Orca checckpoints are saved in `model_dir` which is specified when you create estimator. You can load previous Orca checkpoint and resume train with it with such APIs:
  
 ```
-load_latest_orca_checkpoint(path)
+load_orca_checkpoint(path, version=None)
 ``` 
 * path: directory containing Orca checkpoint files.
 
-This method load latest checkpoint under specified directory.
+With `version=None`, this method load latest checkpoint under specified directory.
 
 E.g.
 ```
 est = Estimator.from_keras(keras_model=model, model_dir=model_dir)
-est.load_latest_orca_checkpoint(model_dir)
+est.load_orca_checkpoint(model_dir, version=None)
 est.fit(data=data_shard,
         batch_size=8,
         epochs=10,

--- a/pyzoo/test/zoo/orca/learn/spark/test_estimator_for_spark.py
+++ b/pyzoo/test/zoo/orca/learn/spark/test_estimator_for_spark.py
@@ -609,6 +609,75 @@ class TestEstimatorForGraph(TestCase):
 
         shutil.rmtree(temp)
 
+    def test_estimator_save_load(self):
+        import zoo.orca.data.pandas
+
+        tf.reset_default_graph()
+        # save
+        model = SimpleModel()
+
+        file_path = os.path.join(resource_path, "orca/learn/ncf.csv")
+        data_shard = zoo.orca.data.pandas.read_csv(file_path)
+
+        def transform(df):
+            result = {
+                "x": (df['user'].to_numpy(), df['item'].to_numpy()),
+                "y": df['label'].to_numpy()
+            }
+            return result
+
+        data_shard = data_shard.transform_shard(transform)
+
+        est = Estimator.from_graph(
+            inputs=[model.user, model.item],
+            labels=[model.label],
+            outputs=[model.logits],
+            loss=model.loss,
+            optimizer=tf.train.AdamOptimizer(),
+            metrics={"loss": model.loss},
+            sess=None
+        )
+
+        est.fit(data=data_shard,
+                batch_size=8,
+                epochs=5,
+                validation_data=data_shard)
+        
+        temp = tempfile.mkdtemp()
+        model_checkpoint = os.path.join(temp, 'tmp.ckpt')
+        est.save(model_checkpoint)
+        est.shutdown()
+        tf.reset_default_graph()
+
+        # load
+        with tf.Session() as sess:
+            model = SimpleModel()
+
+            est = Estimator.from_graph(
+                inputs=[model.user, model.item],
+                labels=[model.label],
+                outputs=[model.logits],
+                loss=model.loss,
+                metrics={"loss": model.loss},
+                sess=sess
+            )
+
+            est.load(model_checkpoint)
+            data_shard = zoo.orca.data.pandas.read_csv(file_path)
+
+            def transform(df):
+                result = {
+                    "x": (df['user'].to_numpy(), df['item'].to_numpy()),
+                }
+                return result
+
+            data_shard = data_shard.transform_shard(transform)
+            predictions = est.predict(data_shard).collect()
+            assert 'prediction' in predictions[0]
+            print(predictions)
+
+        shutil.rmtree(temp)
+
     def test_estimator_graph_with_bigdl_optim_method(self):
         import zoo.orca.data.pandas
 

--- a/pyzoo/test/zoo/orca/learn/spark/test_estimator_for_spark.py
+++ b/pyzoo/test/zoo/orca/learn/spark/test_estimator_for_spark.py
@@ -642,7 +642,7 @@ class TestEstimatorForGraph(TestCase):
                 batch_size=8,
                 epochs=5,
                 validation_data=data_shard)
-        
+
         temp = tempfile.mkdtemp()
         model_checkpoint = os.path.join(temp, 'tmp.ckpt')
         est.save(model_checkpoint)

--- a/pyzoo/test/zoo/orca/learn/spark/test_estimator_for_spark.py
+++ b/pyzoo/test/zoo/orca/learn/spark/test_estimator_for_spark.py
@@ -262,7 +262,7 @@ class TestEstimatorForGraph(TestCase):
             model_dir=model_dir
         )
 
-        est.load_latest_orca_checkpoint(model_dir)
+        est.load_orca_checkpoint(model_dir)
 
         est.fit(data=data_shard,
                 batch_size=8,

--- a/pyzoo/test/zoo/orca/learn/spark/test_estimator_keras_for_spark.py
+++ b/pyzoo/test/zoo/orca/learn/spark/test_estimator_keras_for_spark.py
@@ -233,7 +233,7 @@ class TestEstimatorForKeras(TestCase):
         model = self.create_model()
 
         est = Estimator.from_keras(keras_model=model, model_dir=model_dir)
-        est.load_latest_orca_checkpoint(model_dir)
+        est.load_orca_checkpoint(model_dir)
         est.fit(data=data_shard,
                 batch_size=8,
                 epochs=10,

--- a/pyzoo/zoo/orca/learn/tf/estimator.py
+++ b/pyzoo/zoo/orca/learn/tf/estimator.py
@@ -1023,10 +1023,10 @@ class KerasEstimator(Estimator):
         """
         Load existing keras model
 
-        :param checkpoint: Path to the existing keras model.
+        :param model_path: Path to the existing keras model.
         :return:
         """
-        self.load_keras_model(model_path)
+        self.model = KerasModel.load_model(model_path)
 
     def clear_gradient_clipping(self):
         """

--- a/pyzoo/zoo/orca/learn/tf/estimator.py
+++ b/pyzoo/zoo/orca/learn/tf/estimator.py
@@ -239,14 +239,6 @@ class Estimator(SparkEstimator):
         """
         raise NotImplementedError
 
-    def load_keras_model(self, path):
-        """
-        Load tensorflow keras model to this estimator.
-
-        :param path: keras model path.
-        """
-        raise NotImplementedError
-
     def save_keras_weights(self, filepath, overwrite=True, save_format=None):
         """
         Save tensorflow keras model weights in this estimator.
@@ -1007,14 +999,6 @@ class KerasEstimator(Estimator):
         :param overwrite: Whether to silently overwrite any existing file at the target location.
         """
         self.model.save_model(path, overwrite=overwrite)
-
-    def load_keras_model(self, path):
-        """
-        Load tensorflow keras model to this estimator.
-
-        :param path: keras model path.
-        """
-        self.model = KerasModel.load_model(path)
 
     def get_model(self):
         """

--- a/pyzoo/zoo/orca/learn/tf/estimator.py
+++ b/pyzoo/zoo/orca/learn/tf/estimator.py
@@ -31,7 +31,7 @@ from zoo.tfpark import TFOptimizer, TFNet, ZooOptimizer
 from zoo.tfpark.tf_optimizer import StatelessMetric
 from zoo.tfpark.utils import evaluate_metrics
 from zoo.util import nest
-from zoo.util.tf import save_tf_checkpoint
+from zoo.util.tf import save_tf_checkpoint, load_tf_checkpoint
 from zoo.orca.learn.spark_estimator import Estimator as SparkEstimator
 
 
@@ -125,14 +125,14 @@ class Estimator(SparkEstimator):
         """
         raise NotImplementedError
 
-    def load(self, checkpoint, **kwargs):
+    def load(self, model_path):
         """
-        Load existing checkpoint
+        Load existing model 
 
-        :param checkpoint: Path to the existing checkpoint.
+        :param model_path: Path to the existing model.
         :return:
         """
-        self.load_latest_orca_checkpoint(checkpoint)
+        raise NotImplementedError
 
     def clear_gradient_clipping(self):
         """
@@ -222,12 +222,28 @@ class Estimator(SparkEstimator):
         """
         raise NotImplementedError
 
+    def load_tf_checkpoint(self, path):
+        """
+        Load tensorflow checkpoint to this estimator.
+
+        :param path: tensorflow checkpoint path.
+        """
+        raise NotImplementedError
+
     def save_keras_model(self, path, overwrite=True):
         """
         Save tensorflow keras model in this estimator.
 
         :param path: keras model save path.
         :param overwrite: Whether to silently overwrite any existing file at the target location.
+        """
+        raise NotImplementedError
+
+    def load_keras_model(self, path):
+        """
+        Load tensorflow keras model to this estimator.
+
+        :param path: keras model path.
         """
         raise NotImplementedError
 
@@ -254,29 +270,24 @@ class Estimator(SparkEstimator):
         """
         raise NotImplementedError
 
-    def load_orca_checkpoint(self, path, version):
+    def load_orca_checkpoint(self, path, version=None):
         """
-        Load specified Orca checkpoint.
+        Load Orca checkpoint. To load a specific checkpoint, please provide a `version`.
+        If `version` is None, then the latest checkpoint will be loaded.
 
         :param path: checkpoint directory which contains model.* and
                optimMethod-TFParkTraining.* files.
         :param version: checkpoint version, which is the suffix of model.* file,
                i.e., for modle.4 file, the version is 4.
         """
+        if version is None:
+            path, _, version = find_latest_checkpoint(path, model_type="tf")
+            if path is None:
+                raise Exception("Cannot find checkpoint")
+        
         self.load_checkpoint = True
         self.checkpoint_path = path
         self.checkpoint_version = version
-
-    def load_latest_orca_checkpoint(self, path):
-        """
-        Load latest Orca checkpoint under specified directory.
-
-        :param path: directory containing Orca checkpoint files.
-        """
-        ckpt_path, _, version = find_latest_checkpoint(path, model_type="tf")
-        if ckpt_path is None:
-            raise Exception("Cannot find checkpoint")
-        self.load_orca_checkpoint(ckpt_path, version)
 
     @staticmethod
     def from_graph(*, inputs, outputs=None,
@@ -708,6 +719,13 @@ class TensorFlowEstimator(Estimator):
         """
         save_tf_checkpoint(self.sess, path)
 
+    def load_tf_checkpoint(self, path):
+        """
+        Load tensorflow checkpoint to this estimator.
+        :param path: tensorflow checkpoint path.
+        """
+        load_tf_checkpoint(self.sess, path)
+
     def get_model(self):
         """
         Get_model is not supported in tensorflow graph estimator
@@ -716,12 +734,20 @@ class TensorFlowEstimator(Estimator):
 
     def save(self, model_path):
         """
-        Save model to model_path
+        Save model (tensorflow checkpoint) to model_path
 
         :param model_path: path to save the trained model.
         :return:
         """
         self.save_tf_checkpoint(model_path)
+
+    def load(self, model_path):
+        """
+        Load existing model (tensorflow checkpoint) from model_path
+        :param model_path: Path to the existing tensorflow checkpoint.
+        :return:
+        """
+        self.load_tf_checkpoint(model_path)
 
     def clear_gradient_clipping(self):
         """
@@ -982,6 +1008,14 @@ class KerasEstimator(Estimator):
         """
         self.model.save_model(path, overwrite=overwrite)
 
+    def load_keras_model(self, path):
+        """
+        Load tensorflow keras model to this estimator.
+
+        :param path: keras model path.
+        """
+        self.model = KerasModel.load_model(path)
+
     def get_model(self):
         """
         Get the trained Keras model
@@ -1000,6 +1034,15 @@ class KerasEstimator(Estimator):
         :return:
         """
         self.save_keras_model(model_path, overwrite=overwrite)
+
+    def load(self, model_path):
+        """
+        Load existing keras model
+
+        :param checkpoint: Path to the existing keras model.
+        :return:
+        """
+        self.load_keras_model(model_path)
 
     def clear_gradient_clipping(self):
         """

--- a/pyzoo/zoo/orca/learn/tf/estimator.py
+++ b/pyzoo/zoo/orca/learn/tf/estimator.py
@@ -127,7 +127,7 @@ class Estimator(SparkEstimator):
 
     def load(self, model_path):
         """
-        Load existing model 
+        Load existing model
 
         :param model_path: Path to the existing model.
         :return:
@@ -275,8 +275,9 @@ class Estimator(SparkEstimator):
         if version is None:
             path, _, version = find_latest_checkpoint(path, model_type="tf")
             if path is None:
-                raise Exception("Cannot find checkpoint")
-        
+                raise ValueError("Cannot find tf checkpoint, please check your checkpoint"
+                                 " path.")
+
         self.load_checkpoint = True
         self.checkpoint_path = path
         self.checkpoint_version = version


### PR DESCRIPTION
This PR relates to issue #3345. Current modification logic for tf estimator:
1. Add `load_tf_checkpoint` 
2. Remove implementation of `load` in super class; implement `load` in `TensorFlowEstimator` and `KerasEstimator` seperately
3. Change `load_orca_checkpoint` and remove `load_latest_orca_checkpoint`

Other things to be changed related to orca `save` and `load` methods:

1. Update `zoo.orca.learn.bigdl.estimator` and `zoo.orca.learn.openvino.estimator`
2. Add tests for `save` and `load` (tf estimator)
