### PR TITLE
Add MPI support for Pytorch distributed training

### DIFF
--- a/pyzoo/zoo/orca/learn/mpi/__init__.py
+++ b/pyzoo/zoo/orca/learn/mpi/__init__.py
@@ -1,0 +1,15 @@
+#
+# Copyright 2018 Analytics Zoo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/pyzoo/zoo/orca/learn/mpi/__init__.py
+++ b/pyzoo/zoo/orca/learn/mpi/__init__.py
@@ -13,3 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from .mpi_runner import MPIRunner
+from .mpi_estimator import MPIEstimator

--- a/pyzoo/zoo/orca/learn/mpi/mpi_estimator.py
+++ b/pyzoo/zoo/orca/learn/mpi/mpi_estimator.py
@@ -370,7 +370,7 @@ def validate(config, model, valid_ld, metrics, validate_batches):
     with torch.no_grad():
         for j in range(validate_batches):
             # Iterate again from the beginning if running out of batches.
-            if j > 0 and j % len(validate_batches) == 0:
+            if j > 0 and j % len(valid_ld) == 0:
                 valid_iter = iter(valid_ld)
             x, y = next(valid_iter)
             o = model(x, y)

--- a/pyzoo/zoo/orca/learn/mpi/mpi_estimator.py
+++ b/pyzoo/zoo/orca/learn/mpi/mpi_estimator.py
@@ -262,18 +262,6 @@ class PlasmaNDArrayDataset(Dataset):
         y_np = np.concatenate(y_list)
         # Can put collate_fn into train_func if necessary.
         return x_np, y_np
-        # assert X_int_np.shape == (self.batch_size, 13)
-        # assert X_cat_np.shape == (self.batch_size, 26)
-        # assert y_np.shape == (self.batch_size,)
-        # X_int = torch.tensor(X_int_np, dtype=torch.float)
-        # X_cat = torch.tensor(X_cat_np, dtype=torch.long)
-        # T = torch.tensor(y_np, dtype=torch.float32).view(-1, 1)
-        #
-        # batch_size = X_cat.shape[0]
-        # feature_count = X_cat.shape[1]
-        # lS_i = X_cat.t()
-        # lS_o = torch.arange(batch_size).reshape(1, -1).repeat(feature_count, 1)
-        # return X_int, lS_o, lS_i, T
 
 
 def plasma_data_creator(meta_data, object_store_address,

--- a/pyzoo/zoo/orca/learn/mpi/mpi_estimator.py
+++ b/pyzoo/zoo/orca/learn/mpi/mpi_estimator.py
@@ -1,0 +1,302 @@
+import os
+import types
+import numpy as np
+import subprocess
+import cloudpickle
+from pyspark import RDD
+from pyspark.sql import DataFrame
+from torch.utils.data import Dataset, DataLoader
+from zoo.util.utils import get_node_ip
+from .mpi_runner import MPIRunner
+
+
+class MPIEstimator:
+    def __init__(self,
+                 model_creator,
+                 optimizer_creator,
+                 loss_creator,
+                 scheduler_creator,
+                 config=None,
+                 init_func=None,  # Init the distributed environment for MPI if any
+                 hosts=None,
+                 workers_per_node=1,
+                 env=None):
+        self.dir = os.getcwd()
+        self.mpi_runner = MPIRunner(hosts=hosts, processes_per_node=workers_per_node, env=env)
+        with open("saved_mpi_estimator.pkl", "wb") as f:
+            cloudpickle.dump(
+                (model_creator, optimizer_creator, loss_creator, scheduler_creator, config, init_func), f)
+        for host in self.mpi_runner.remote_hosts:
+            p = subprocess.Popen(["scp", "saved_mpi_estimator.pkl",
+                                  "root@{}:{}/".format(host, self.dir)])
+            os.waitpid(p.pid, 0)
+            # train.py is within analytics-zoo and should be available on all nodes
+            # p = subprocess.Popen(["scp", "train.py",
+            #                       "root@{}:{}/".format(host, self.dir)])
+            # os.waitpid(p.pid, 0)
+
+    def fit(self, data, epochs=1, batch_size=32, validation_data=None, validate_batch_size=32,
+            train_func=None, validate_func=None, train_steps=None, validate_steps=None):
+        if isinstance(data, DataFrame):   # Row: x (first column, can be a dict), y (second column)
+            data = data.rdd
+            if validation_data:
+                assert isinstance(validation_data, DataFrame)
+                validation_data = validation_data.rdd
+        if isinstance(data, RDD):
+            # Launch plasma
+            object_store_address = self.mpi_runner.launch_plasma()
+            # partition_id (not used), partition_size, object_id, node_ip
+            plasma_meta = data.mapPartitionsWithIndex(
+                put_to_plasma(object_store_address)).collect()
+            data_creator = create_plasma_dataloader(plasma_meta, object_store_address,
+                                                    self.mpi_runner.processes_per_node, batch_size)
+            if validation_data:
+                assert isinstance(validation_data, RDD)
+                validate_plasma_meta = validation_data.mapPartitionsWithIndex(
+                    put_to_plasma(object_store_address)).collect()
+                validation_data_creator = create_plasma_dataloader(
+                    validate_plasma_meta, object_store_address,
+                    self.mpi_runner.processes_per_node, validate_batch_size)
+            else:
+                validation_data_creator = None
+        else:
+            assert isinstance(data, types.FunctionType)
+            data_creator = data
+            if validation_data:
+                assert isinstance(validation_data, types.FunctionType)
+                validation_data_creator = validation_data
+            else:
+                validation_data_creator = None
+        if not train_func:
+            train_func = train_epoch
+        if validation_data_creator:
+            if not validate_func:
+                validate_func = validate
+
+        with open("mpi_train_data.pkl", "wb") as f:
+            cloudpickle.dump((data_creator, epochs, validation_data_creator,
+                              train_func, validate_func, train_steps, validate_steps), f)
+        for host in self.mpi_runner.remote_hosts:
+            p = subprocess.Popen(["scp", "mpi_train_data.pkl",
+                                  "root@{}:{}/".format(host, self.dir)])
+            os.waitpid(p.pid, 0)
+        self.mpi_runner.run("mpi_train.py", pkl_path=self.dir)
+
+    def shutdown(self):
+        self.mpi_runner.shutdown_plasma()
+
+
+def put_to_plasma(address):
+    import pyarrow.plasma as plasma
+
+    def f(index, iterator):
+        client = plasma.connect(address)
+        part_size = 1000000  # TODO: Make this configurable?
+        buffer = []
+        for record in iterator:
+            if len(buffer) == part_size:
+                import random
+                random.shuffle(buffer)  # TODO: Make shuffle configurable?
+                buffer_x = [record[0] for record in buffer]
+                buffer_y = [record[1] for record in buffer]
+                res_buffer = {"y": np.array(buffer_y)}  # TODO: int features and label of type int32?
+                if isinstance(buffer_x[0], dict):
+                    res_x = {}
+                    for k in list(buffer_x[0].keys()):
+                        res_x[k] = np.array([record[k] for record in buffer_x])
+                    res_buffer["x"] = res_x
+                else:
+                    res_buffer["x"] = np.array(buffer_x)
+                # TODO: add list support
+                object_id = client.put(res_buffer)
+                buffer = [record]
+                yield index, part_size, object_id, get_node_ip()
+            else:
+                buffer.append(record)
+        remain_size = len(buffer)
+        if remain_size > 0:
+            import random
+            random.shuffle(buffer)
+            buffer_x = [record[0] for record in buffer]
+            buffer_y = [record[1] for record in buffer]
+            res_buffer = {"y": np.array(buffer_y)}  # int32?
+            if isinstance(buffer_x[0], dict):
+                for k in list(buffer_x[0].keys()):
+                    res_buffer[k] = np.array([record[k] for record in buffer_x])
+            object_id = client.put(res_buffer)
+            buffer = []
+            client.disconnect()
+            yield index, remain_size, object_id, get_node_ip()
+        else:
+            client.disconnect()
+
+    return f
+
+
+class PlasmaNDArrayDataset(Dataset):
+    def __init__(self, meta_data, object_store_address, workers_per_node=1, batch_size=1):
+        import pyarrow.plasma as plasma
+        self.client = plasma.connect(object_store_address)
+        print("Connected to plasma")
+
+        # All the subpartitions on this node
+        all_data = [subpartition for subpartition in meta_data if subpartition[3] == get_node_ip()]
+        rank = os.environ.get("PMI_RANK", 0)
+        local_rank = rank % workers_per_node
+        data_splits = list(chunks(all_data, workers_per_node))
+        worker_data = data_splits[local_rank]
+        if len(data_splits) == (workers_per_node + 1):  # Can't evenly split among workers
+            remain_data = data_splits[-1]
+            if local_rank < len(remain_data):
+                worker_data += [remain_data[local_rank]]
+        self.object_ids = [subpartition[2] for subpartition in worker_data]
+        self.sizes = [subpartition[1] for subpartition in worker_data]
+        self.batch_size = batch_size
+        offsets = []
+        for i in self.sizes:
+            if len(offsets) == 0:
+                offsets.append(i)
+            else:
+                offsets.append(offsets[-1] + i)
+        self.offsets = offsets
+        self.current_index = 0  # Current index for object_id; data loaded
+        self.load_from_plasma(self.current_index)
+
+    def reset(self):
+        self.current_index = 0
+        self.load_from_plasma(self.current_index)
+
+    def load_from_plasma(self, index):
+        # print("Loading partition {}".format(index))
+        current_data = self.client.get(self.object_ids[index], timeout_ms=0)
+        self.current_x = current_data["x"]
+        self.current_y = current_data["y"]
+        self.current_offset = self.offsets[index]
+
+    def __len__(self):
+        return sum(self.sizes) // self.batch_size
+
+    def __getitem__(self, i):  # Directly get a batch
+        # print("Loading batch ", i)
+        if i == 0 and self.current_index != 0:
+            self.reset()
+        current_available_size = self.current_offset - i * self.batch_size
+        x_list = []
+        y_list = []
+        if current_available_size < self.batch_size:
+            if current_available_size != 0:
+                # Add all the remaining records into this batch
+                x_list.append(index(self.current_x, start=-current_available_size))
+                y_list.append(index(self.current_y, start=-current_available_size))
+            # Load subsequent file(s) to complete the batch
+            remain_size = self.batch_size - current_available_size
+            while True:
+                self.current_index += 1
+                self.load_from_plasma(self.current_index)
+                if self.sizes[self.current_index] >= remain_size:
+                    x_list.append(index(self.current_x, end=remain_size))
+                    y_list.append(index(self.current_y, end=remain_size))
+                    break
+                else:
+                    x_list.append(self.current_x)
+                    y_list.append(self.current_y)
+                    remain_size -= self.sizes[self.current_index]
+                    if remain_size == 0:
+                        break
+        # The current file contains a full batch
+        elif current_available_size == self.batch_size:
+            x_list.append(index(self.current_x, start=-current_available_size))
+            y_list.append(index(self.current_y, start=-current_available_size))
+        else:
+            x_list.append(index(self.current_x, start=-current_available_size, end=-current_available_size + self.batch_size))
+            y_list.append(index(self.current_y, start=-current_available_size, end=-current_available_size + self.batch_size))
+
+        if isinstance(self.current_x, dict):
+            x_np = {}
+            for k in self.current_x.keys():
+                x_np[k] = np.concatenate([x[k] for x in x_list])
+        else:
+            x_np = np.concatenate(x_list)
+        y_np = np.concatenate(y_list)
+        # Can put collate_fn into train_func if necessary.
+        return x_np, y_np
+        # assert X_int_np.shape == (self.batch_size, 13)
+        # assert X_cat_np.shape == (self.batch_size, 26)
+        # assert y_np.shape == (self.batch_size,)
+        # X_int = torch.tensor(X_int_np, dtype=torch.float)
+        # X_cat = torch.tensor(X_cat_np, dtype=torch.long)
+        # T = torch.tensor(y_np, dtype=torch.float32).view(-1, 1)
+        #
+        # batch_size = X_cat.shape[0]
+        # feature_count = X_cat.shape[1]
+        # lS_i = X_cat.t()
+        # lS_o = torch.arange(batch_size).reshape(1, -1).repeat(feature_count, 1)
+        # return X_int, lS_o, lS_i, T
+
+
+def create_plasma_dataloader(meta_data, object_store_address, workers_per_node=1, batch_size=1):
+    dataset = PlasmaNDArrayDataset(meta_data, object_store_address, workers_per_node, batch_size)
+    # TODO: support more options
+    loader = DataLoader(
+        dataset,
+        batch_size=None,
+        shuffle=False,
+        collate_fn=None,
+    )
+    return loader
+
+
+def chunks(lst, n):
+    """Yield successive n-sized chunks from lst."""
+    for i in range(0, len(lst), n):
+        yield lst[i:i + n]
+
+
+def index(x, start=None, end=None):
+    # TODO: support list
+    if isinstance(x, dict):
+        res = {}
+        for k, v in x.items():
+            res[k] = index_numpy(v, start, end)
+        return res
+    else:
+        return index_numpy(x, start, end)
+
+
+def index_numpy(x, start=None, end=None):
+    if start:
+        if end:
+            return x[start:end]
+        else:
+            return x[start:]
+    else:
+        if end:
+            return x[:end]
+        else:
+            return x
+
+
+def train_epoch(model, train_ld, train_batches, optimizer, loss, scheduler):
+    train_iter = iter(train_ld)
+    for j in range(train_batches):
+        if j > 0 and j % len(train_ld) == 0:  # For the case where there are not enough batches.
+            train_iter = iter(train_ld)
+        x, y = next(train_iter)
+        o = model(x, y)
+        l = loss(o, y)
+        optimizer.zero_grad()
+        l.backward()
+        optimizer.step()
+        if scheduler:
+            scheduler.step()
+
+
+def validate(model, valid_ld, validate_batches):
+    valid_iter = iter(valid_ld)
+    for j in range(validate_batches):
+        if j > 0 and j % len(validate_batches) == 0:  # For the case where there are not enough batches.
+            valid_iter = iter(valid_ld)
+        x, y = next(valid_iter)
+        o = model(x, y)
+        # TODO: Compute accuracy or add metrics
+        return

--- a/pyzoo/zoo/orca/learn/mpi/mpi_estimator.py
+++ b/pyzoo/zoo/orca/learn/mpi/mpi_estimator.py
@@ -39,8 +39,8 @@ class MPIEstimator:
         self.dir = os.getcwd()
         self.mpi_runner = MPIRunner(hosts=hosts, processes_per_node=workers_per_node, env=env)
         with open("saved_mpi_estimator.pkl", "wb") as f:
-            cloudpickle.dump(
-                (model_creator, optimizer_creator, loss_creator, scheduler_creator, config, init_func), f)
+            cloudpickle.dump((model_creator, optimizer_creator, loss_creator,
+                              scheduler_creator, config, init_func), f)
         for host in self.mpi_runner.remote_hosts:
             p = subprocess.Popen(["scp", "saved_mpi_estimator.pkl",
                                   "root@{}:{}/".format(host, self.dir)])
@@ -49,8 +49,8 @@ class MPIEstimator:
     # Specify feature_cols and label_cols for Spark DataFrame data.
     # Specify train_func or validate_func for customized training and validation logic.
     # Specify train_batches and validate_batches in case of unbalance data.
-    # Specify validate_steps to validate periodically. Note that validation would always be triggered at
-    # the end of an epoch.
+    # Specify validate_steps to validate periodically. Note that validation would always be
+    # triggered at the end of an epoch.
     def fit(self, data, epochs=1, batch_size=32, validation_data=None, validate_batch_size=32,
             train_func=None, validate_func=None, train_batches=None, validate_batches=None,
             validate_steps=None, feature_cols=None, label_cols=None):
@@ -271,8 +271,10 @@ class PlasmaNDArrayDataset(Dataset):
             x_list.append(index(self.current_x, start=-current_available_size))
             y_list.append(index(self.current_y, start=-current_available_size))
         else:
-            x_list.append(index(self.current_x, start=-current_available_size, end=-current_available_size + self.batch_size))
-            y_list.append(index(self.current_y, start=-current_available_size, end=-current_available_size + self.batch_size))
+            x_list.append(index(self.current_x, start=-current_available_size,
+                                end=-current_available_size + self.batch_size))
+            y_list.append(index(self.current_y, start=-current_available_size,
+                                end=-current_available_size + self.batch_size))
 
         if isinstance(self.current_x, list):
             x_np = []
@@ -297,10 +299,12 @@ class PlasmaNDArrayDataset(Dataset):
         # return X_int, lS_o, lS_i, T
 
 
-def plasma_data_creator(meta_data, object_store_address, workers_per_node=1, batch_size=1):
+def plasma_data_creator(meta_data, object_store_address,
+                        workers_per_node=1, batch_size=1):
 
     def create_plasma_dataloader(config):
-        dataset = PlasmaNDArrayDataset(meta_data, object_store_address, workers_per_node, batch_size)
+        dataset = PlasmaNDArrayDataset(meta_data, object_store_address,
+                                       workers_per_node, batch_size)
         # TODO: support more options
         loader = DataLoader(
             dataset,
@@ -357,7 +361,8 @@ def train_epoch(model, train_ld, train_batches, optimizer, loss, scheduler):
 def validate(model, valid_ld, validate_batches):
     valid_iter = iter(valid_ld)
     for j in range(validate_batches):
-        if j > 0 and j % len(validate_batches) == 0:  # For the case where there are not enough batches.
+        # Iterate again from the beginning if running out of batches.
+        if j > 0 and j % len(validate_batches) == 0:
             valid_iter = iter(valid_ld)
         x, y = next(valid_iter)
         o = model(x, y)

--- a/pyzoo/zoo/orca/learn/mpi/mpi_estimator.py
+++ b/pyzoo/zoo/orca/learn/mpi/mpi_estimator.py
@@ -96,7 +96,7 @@ class MPIEstimator:
             p = subprocess.Popen(["scp", "mpi_train_data.pkl",
                                   "root@{}:{}/".format(host, self.dir)])
             os.waitpid(p.pid, 0)
-        self.mpi_runner.run("mpi_train.py", pkl_path=self.dir)
+        self.mpi_runner.run(os.path.abspath(__file__ + "/../mpi_train.py"), pkl_path=self.dir)
         self.mpi_runner.shutdown_plasma()
 
     def shutdown(self):

--- a/pyzoo/zoo/orca/learn/mpi/mpi_estimator.py
+++ b/pyzoo/zoo/orca/learn/mpi/mpi_estimator.py
@@ -66,7 +66,7 @@ class MPIEstimator:
             # partition_id, subpartition_id, subpartition_size, object_id, node_ip
             plasma_meta = data.mapPartitionsWithIndex(
                 put_to_plasma(object_store_address)).collect()
-            # Can remove the following. Debug and confirmation purpose only.
+            # The following is mainly for debugging and confirmation purpose.
             train_size_map = {}
             for partition_id, subpartition_id, subpartition_size, object_id, ip in plasma_meta:
                 if ip not in train_size_map:
@@ -92,7 +92,8 @@ class MPIEstimator:
                 validate_plasma_meta = validation_data.mapPartitionsWithIndex(
                     put_to_plasma(object_store_address)).collect()
                 validate_size_map = {}
-                for partition_id, subpartition_id, subpartition_size, object_id, ip in validate_plasma_meta:
+                for partition_id, subpartition_id, subpartition_size, object_id, ip \
+                        in validate_plasma_meta:
                     if ip not in validate_size_map:
                         validate_size_map[ip] = {}
                     if partition_id not in validate_size_map[ip]:
@@ -104,7 +105,8 @@ class MPIEstimator:
                     for partition_id, subpartition_size in meta.items():
                         size += sum(subpartition_size)
                         count += len(subpartition_size)
-                    print("Node {} has {} subpartitions and {} test records".format(node, count, size))
+                    print("Node {} has {} subpartitions and {} test records"
+                          .format(node, count, size))
                     size = 0
                     count = 0
                 validation_data_creator = plasma_data_creator(

--- a/pyzoo/zoo/orca/learn/mpi/mpi_estimator.py
+++ b/pyzoo/zoo/orca/learn/mpi/mpi_estimator.py
@@ -128,8 +128,8 @@ class MPIEstimator:
                 validate_func = validate
 
         with open("mpi_train_data.pkl", "wb") as f:
-            cloudpickle.dump((data_creator, epochs, validation_data_creator,
-                              train_func, validate_func, train_batches,
+            cloudpickle.dump((data_creator, epochs, batch_size, validation_data_creator,
+                              validate_batch_size, train_func, validate_func, train_batches,
                               validate_batches, validate_steps), f)
         self.mpi_runner.scp_file("mpi_train_data.pkl", self.dir)
         self.mpi_runner.run("{}/mpi_train.py".format(self.dir), pkl_path=self.dir)

--- a/pyzoo/zoo/orca/learn/mpi/mpi_runner.py
+++ b/pyzoo/zoo/orca/learn/mpi/mpi_runner.py
@@ -109,7 +109,8 @@ class MPIRunner:
         self.plasma_path = "/".join(sys.executable.split("/")[:-1] + ["plasma_store"])
         self.object_store_memory = resource_to_bytes(object_store_memory)
         self.object_store_address = "/tmp/analytics_zoo_plasma"
-        command = "{} -m {} -s {}".format(self.plasma_path, self.object_store_memory, self.object_store_address)
+        command = "{} -m {} -s {}".format(
+            self.plasma_path, self.object_store_memory, self.object_store_address)
         for host in self.hosts:
             if host != get_node_ip():
                 p = subprocess.Popen(["ssh", "root@{}".format(host), command])

--- a/pyzoo/zoo/orca/learn/mpi/mpi_runner.py
+++ b/pyzoo/zoo/orca/learn/mpi/mpi_runner.py
@@ -65,10 +65,8 @@ class MPIRunner:
         file_path = os.path.abspath(file)
         assert os.path.exists(file_path)
         file_dir = "/".join(file_path.split("/")[:-1])
-        for host in self.remote_hosts:
-            p = subprocess.Popen(["scp", file_path,
-                                  "root@{}:{}".format(host, file_dir)])
-            os.waitpid(p.pid, 0)
+        self.scp_file(file_path, file_dir)
+
         # cmd = ["mpiexec.openmpi"]
         cmd = ["mpiexec.hydra"]
         # -l would label the output with process rank. -l/-ppn not available for openmpi.
@@ -100,6 +98,12 @@ class MPIRunner:
         # print(mpi_env)
         process = subprocess.Popen(cmd, env=mpi_env)
         process.wait()
+
+    def scp_file(self, file, remote_dir):
+        for host in self.remote_hosts:
+            p = subprocess.Popen(["scp", file,
+                                  "root@{}:{}/".format(host, remote_dir)])
+            os.waitpid(p.pid, 0)
 
     def launch_plasma(self, object_store_memory="2g"):
         import atexit

--- a/pyzoo/zoo/orca/learn/mpi/mpi_runner.py
+++ b/pyzoo/zoo/orca/learn/mpi/mpi_runner.py
@@ -1,0 +1,106 @@
+#
+# Copyright 2018 Analytics Zoo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import sys
+import subprocess
+from zoo.util.utils import get_node_ip
+from zoo.orca import OrcaContext
+
+# Assumption:
+# 1. All hosts has mpi installed
+# 2. The driver can ssh all hosts without password
+# 3. All hosts have the same working directory.
+# 4. All hosts have the same Python environment in the same location.
+class MPIRunner:
+    def __init__(self,
+                 hosts=None,
+                 processes_per_node=1,
+                 env=None):
+        driver_ip = get_node_ip()
+        if hosts is None:  # Single node
+            self.hosts = [driver_ip]
+        elif hosts == "all":  # All executor nodes in the cluster
+            def get_ip(iter):
+                yield get_node_ip()
+
+            sc = OrcaContext.get_spark_context()
+            num_executors = sc.getConf().get("spark.executor.instances")
+            self.hosts = list(set(sc.range(0, num_executors, numSlices=num_executors).barrier()
+                                  .mapPartitions(get_ip).collect()))
+        else:  # User specified hosts, assumed to be non-duplicate
+            assert isinstance(hosts, list)
+            self.hosts = hosts
+
+        self.master = self.hosts[0]
+        print("Master: ", self.master)
+        self.remote_hosts = []
+        for host in hosts:
+            if host != driver_ip:
+                self.remote_hosts.append(host)
+        print("Remote hosts: ", self.remote_hosts)
+        print("Hosts: ", self.hosts)
+        self.processes_per_node = processes_per_node
+        self.env = env if env else {}
+
+    def run(self, file, **kwargs):
+        file_path = os.path.abspath(file)
+        assert os.path.exists(file_path)
+        file_dir = "/".join(file_path.split("/")[:-1])
+        for host in self.remote_hosts:
+            p = subprocess.Popen(["scp", file_path,
+                                  "root@{}:{}".format(host, file_dir)])
+            os.waitpid(p.pid, 0)
+        cmd = ['mpiexec.hydra']
+        mpi_config = "-l -np {} -ppn {} ".format(
+            self.processes_per_node * len(self.hosts),
+            self.processes_per_node)
+        mpi_env = os.environ.copy()
+        mpi_env.update(self.env)
+        if "I_MPI_PIN_DOMAIN" in mpi_env:
+            mpi_config += "-genv I_MPI_PIN_DOMAIN={} ".format(mpi_env["I_MPI_PIN_DOMAIN"])
+        if "OMP_NUM_THREADS" in mpi_env:
+            mpi_config += "-genv OMP_NUM_THREADS={} ".format(mpi_env["OMP_NUM_THREADS"])
+        if len(self.remote_hosts) > 0:
+            mpi_config += "-hosts {}".format(",".join(self.hosts))
+        cmd.extend(mpi_config.split())
+        # cmd.append("ls")
+        cmd.append(sys.executable)
+        cmd.append("-u")  # This can print as the program runs
+        cmd.append("train.py")
+        for k, v in kwargs.values():
+            cmd.append("--{}={}".format(str(k), str(v)))
+        print(cmd)
+
+        if len(self.remote_hosts) > 0:
+            mpi_env["MASTER_ADDR"] = str(self.master)
+        else:  # Single node
+            mpi_env["MASTER_ADDR"] = "127.0.0.1"
+        # print(mpi_env)
+        process = subprocess.Popen(cmd, env=mpi_env)
+        process.wait()
+
+    def launch_plasma(self):
+        pass  # TODO. Use Spark or SSH
+        # import subprocess
+        # p = subprocess.Popen(
+        #     ["/opt/work/anaconda3/envs/dlrm/bin/plasma_store", "-m", "100000000000", "-s", object_store_address])
+
+    def shutdown_plasma(self):
+        pass
+        # import subprocess
+        # p = subprocess.Popen(["pkill", "plasma"])
+        # os.waitpid(p.pid, 0)

--- a/pyzoo/zoo/orca/learn/mpi/mpi_train.py
+++ b/pyzoo/zoo/orca/learn/mpi/mpi_train.py
@@ -14,12 +14,16 @@
 # limitations under the License.
 #
 
+import os
 import argparse
 import cloudpickle
 from zoo.util.utils import get_node_ip
 
+print("Worker on {} with global rank {}".format(get_node_ip(), os.environ.get("PMI_RANK", 0)))
+
 parser = argparse.ArgumentParser()
-parser.add_argument('--pkl_path', type=str, default="", help='The directory of the pkl files for mpi training.')
+parser.add_argument('--pkl_path', type=str, default="",
+                    help='The directory of the pkl files for mpi training.')
 args = parser.parse_args()
 pkl_path = args.pkl_path
 
@@ -30,7 +34,7 @@ with open("{}/mpi_train_data.pkl".format(pkl_path), "rb") as f:
     train_data_creator, epochs, validation_data_creator, train_func, validate_func, train_steps, validate_steps = cloudpickle.load(f)
 
 if init_func:
-    print("Initializing distributed environment on ", get_node_ip())
+    print("Initializing distributed environment")
     init_func()
 
 # Wrap DDP should be done by users in model_creator

--- a/pyzoo/zoo/orca/learn/mpi/mpi_train.py
+++ b/pyzoo/zoo/orca/learn/mpi/mpi_train.py
@@ -32,8 +32,9 @@ with open("{}/saved_mpi_estimator.pkl".format(pkl_path), "rb") as f:
         scheduler_creator, config, init_func = cloudpickle.load(f)
 
 with open("{}/mpi_train_data.pkl".format(pkl_path), "rb") as f:
-    train_data_creator, epochs, batch_size, validation_data_creator, validate_batch_size, \
-        train_func, validate_func, train_batches, validate_batches, validate_steps = cloudpickle.load(f)
+    train_data_creator, epochs, batch_size, validation_data_creator,\
+        validate_batch_size, train_func, validate_func, train_batches, \
+        validate_batches, validate_steps = cloudpickle.load(f)
 config["batch_size"] = batch_size
 config["validate_batch_size"] = validate_batch_size
 

--- a/pyzoo/zoo/orca/learn/mpi/mpi_train.py
+++ b/pyzoo/zoo/orca/learn/mpi/mpi_train.py
@@ -2,16 +2,15 @@ import argparse
 import cloudpickle
 from zoo.util.utils import get_node_ip
 
-
 parser = argparse.ArgumentParser()
 parser.add_argument('--pkl_path', type=str, default="", help='The directory of the pkl files for mpi training.')
 args = parser.parse_args()
 pkl_path = args.pkl_path
 
-with open("saved_estimator.pkl", "rb") as f:
+with open("{}/saved_mpi_estimator.pkl".format(pkl_path), "rb") as f:
     model_creator, optimizer_creator, loss_creator, scheduler_creator, config, init_func = cloudpickle.load(f)
 
-with open("mpi_train_data.pkl", "rb") as f:
+with open("{}/mpi_train_data.pkl".format(pkl_path), "rb") as f:
     train_data_creator, epochs, validation_data_creator, train_func, validate_func, train_steps, validate_steps = cloudpickle.load(f)
 
 if init_func:
@@ -19,19 +18,28 @@ if init_func:
     init_func()
 
 # Wrap DDP should be done by users in model_creator
-model = model_creator(config)
-optimizer = optimizer_creator(model, config)
-loss = loss_creator  # assume it is an instance
-scheduler = scheduler_creator(optimizer, config)
+# model = model_creator(config)
+# optimizer = optimizer_creator(model, config)
+# loss = loss_creator  # assume it is an instance
+# scheduler = scheduler_creator(optimizer, config)
+# train_ld = train_data_creator(config)
+# train_batches = train_steps if train_steps else len(train_ld)
+# print("Batches to train: ", train_batches)
+# if validation_data_creator:
+#     valid_ld = validation_data_creator(config)
+#     validate_batches = validate_steps if validate_steps else len(valid_ld)
+#     print("Batches to test: ", validate_batches)
+#
+# for i in range(epochs):
+#     train_func(model, train_ld, train_batches, optimizer, loss, scheduler)
+#     if validation_data_creator:
+#         validate_func(model, valid_ld, validate_batches)
+
 train_ld = train_data_creator(config)
 train_batches = train_steps if train_steps else len(train_ld)
 print("Batches to train: ", train_batches)
-if validation_data_creator:
-    valid_ld = validation_data_creator(config)
-    validate_batches = validate_steps if validate_steps else len(valid_ld)
-    print("Batches to test: ", validate_batches)
-
-for i in range(epochs):
-    train_func(model, train_ld, train_batches, optimizer, loss, scheduler)
-    if validation_data_creator:
-        validate_func(model, valid_ld, validate_batches)
+train_iter = iter(train_ld)
+for j in range(train_batches):
+    if j > 0 and j % len(train_ld) == 0:  # For the case where there are not enough batches.
+        train_iter = iter(train_ld)
+    x, y = next(train_iter)

--- a/pyzoo/zoo/orca/learn/mpi/mpi_train.py
+++ b/pyzoo/zoo/orca/learn/mpi/mpi_train.py
@@ -40,31 +40,31 @@ if init_func:
     init_func()
 
 # Wrap DDP should be done by users in model_creator
-# model = model_creator(config)
-# optimizer = optimizer_creator(model, config)
-# loss = loss_creator  # assume it is an instance
-# scheduler = scheduler_creator(optimizer, config)
-# train_ld = train_data_creator(config)
-# train_batches = train_steps if train_steps else len(train_ld)
-# print("Batches to train: ", train_batches)
-# if validation_data_creator:
-#     valid_ld = validation_data_creator(config)
-#     validate_batches = validate_batches if validate_batches else len(valid_ld)
-#     print("Batches to test: ", validate_batches)
-#
-# for i in range(epochs):
-#     train_func(model, train_ld, train_batches, optimizer, loss, scheduler)
-#     if validation_data_creator:
-#         validate_func(model, valid_ld, validate_batches)
-
+model = model_creator(config)
+optimizer = optimizer_creator(model, config)
+loss = loss_creator  # assume it is an instance
+scheduler = scheduler_creator(optimizer, config)
 train_ld = train_data_creator(config)
 train_batches = train_batches if train_batches else len(train_ld)
 print("Batches to train: ", train_batches)
-train_iter = iter(train_ld)
-for j in range(train_batches):
-    if j > 0 and j % len(train_ld) == 0:  # For the case where there are not enough batches.
-        train_iter = iter(train_ld)
-    x, y = next(train_iter)
+if validation_data_creator:
+    valid_ld = validation_data_creator(config)
+    validate_batches = validate_batches if validate_batches else len(valid_ld)
+    print("Batches to test: ", validate_batches)
+
+for i in range(epochs):
+    train_func(model, train_ld, train_batches, optimizer, loss, scheduler, config)
+    if validation_data_creator:
+        validate_func(model, valid_ld, validate_batches, config)
+
+# train_ld = train_data_creator(config)
+# train_batches = train_batches if train_batches else len(train_ld)
+# print("Batches to train: ", train_batches)
+# train_iter = iter(train_ld)
+# for j in range(train_batches):
+#     if j > 0 and j % len(train_ld) == 0:  # For the case where there are not enough batches.
+#         train_iter = iter(train_ld)
+#     x, y = next(train_iter)
     # print("X_int ", x[0].shape)
     # print("X_cat ", x[1].shape)
     # print("y ", y.shape)

--- a/pyzoo/zoo/orca/learn/mpi/mpi_train.py
+++ b/pyzoo/zoo/orca/learn/mpi/mpi_train.py
@@ -1,3 +1,19 @@
+#
+# Copyright 2018 Analytics Zoo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import argparse
 import cloudpickle
 from zoo.util.utils import get_node_ip
@@ -43,3 +59,6 @@ for j in range(train_batches):
     if j > 0 and j % len(train_ld) == 0:  # For the case where there are not enough batches.
         train_iter = iter(train_ld)
     x, y = next(train_iter)
+    # print("X_int ", x[0].shape)
+    # print("X_cat ", x[1].shape)
+    # print("y ", y.shape)

--- a/pyzoo/zoo/orca/learn/mpi/mpi_train.py
+++ b/pyzoo/zoo/orca/learn/mpi/mpi_train.py
@@ -1,0 +1,37 @@
+import argparse
+import cloudpickle
+from zoo.util.utils import get_node_ip
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--pkl_path', type=str, default="", help='The directory of the pkl files for mpi training.')
+args = parser.parse_args()
+pkl_path = args.pkl_path
+
+with open("saved_estimator.pkl", "rb") as f:
+    model_creator, optimizer_creator, loss_creator, scheduler_creator, config, init_func = cloudpickle.load(f)
+
+with open("mpi_train_data.pkl", "rb") as f:
+    train_data_creator, epochs, validation_data_creator, train_func, validate_func, train_steps, validate_steps = cloudpickle.load(f)
+
+if init_func:
+    print("Initializing distributed environment on ", get_node_ip())
+    init_func()
+
+# Wrap DDP should be done by users in model_creator
+model = model_creator(config)
+optimizer = optimizer_creator(model, config)
+loss = loss_creator  # assume it is an instance
+scheduler = scheduler_creator(optimizer, config)
+train_ld = train_data_creator(config)
+train_batches = train_steps if train_steps else len(train_ld)
+print("Batches to train: ", train_batches)
+if validation_data_creator:
+    valid_ld = validation_data_creator(config)
+    validate_batches = validate_steps if validate_steps else len(valid_ld)
+    print("Batches to test: ", validate_batches)
+
+for i in range(epochs):
+    train_func(model, train_ld, train_batches, optimizer, loss, scheduler)
+    if validation_data_creator:
+        validate_func(model, valid_ld, validate_batches)

--- a/pyzoo/zoo/orca/learn/mpi/mpi_train.py
+++ b/pyzoo/zoo/orca/learn/mpi/mpi_train.py
@@ -28,7 +28,7 @@ args = parser.parse_args()
 pkl_path = args.pkl_path
 
 with open("{}/saved_mpi_estimator.pkl".format(pkl_path), "rb") as f:
-    model_creator, optimizer_creator, loss_creator, \
+    model_creator, optimizer_creator, loss_creator, metrics, \
         scheduler_creator, config, init_func = cloudpickle.load(f)
 
 with open("{}/mpi_train_data.pkl".format(pkl_path), "rb") as f:
@@ -59,8 +59,9 @@ else:
     validate_batches = None
 
 for i in range(epochs):
+    config["epoch"] = i
     train_func(config, model, train_ld, train_batches, optimizer, loss, scheduler,
-               validate_func, valid_ld, validate_batches, validate_steps)
+               validate_func, valid_ld, metrics, validate_batches, validate_steps)
 
 # train_ld = train_data_creator(config)
 # train_batches = train_batches if train_batches else len(train_ld)

--- a/pyzoo/zoo/orca/learn/mpi/mpi_train.py
+++ b/pyzoo/zoo/orca/learn/mpi/mpi_train.py
@@ -32,12 +32,14 @@ with open("{}/saved_mpi_estimator.pkl".format(pkl_path), "rb") as f:
         scheduler_creator, config, init_func = cloudpickle.load(f)
 
 with open("{}/mpi_train_data.pkl".format(pkl_path), "rb") as f:
-    train_data_creator, epochs, validation_data_creator, train_func, \
-        validate_func, train_batches, validate_batches, validate_steps = cloudpickle.load(f)
+    train_data_creator, epochs, batch_size, validation_data_creator, validate_batch_size, \
+        train_func, validate_func, train_batches, validate_batches, validate_steps = cloudpickle.load(f)
+config["batch_size"] = batch_size
+config["validate_batch_size"] = validate_batch_size
 
 if init_func:
     print("Initializing distributed environment")
-    init_func()
+    init_func(config)
 
 # Wrap DDP should be done by users in model_creator
 model = model_creator(config)

--- a/pyzoo/zoo/orca/learn/mpi/mpi_train.py
+++ b/pyzoo/zoo/orca/learn/mpi/mpi_train.py
@@ -28,10 +28,12 @@ args = parser.parse_args()
 pkl_path = args.pkl_path
 
 with open("{}/saved_mpi_estimator.pkl".format(pkl_path), "rb") as f:
-    model_creator, optimizer_creator, loss_creator, scheduler_creator, config, init_func = cloudpickle.load(f)
+    model_creator, optimizer_creator, loss_creator, \
+        scheduler_creator, config, init_func = cloudpickle.load(f)
 
 with open("{}/mpi_train_data.pkl".format(pkl_path), "rb") as f:
-    train_data_creator, epochs, validation_data_creator, train_func, validate_func, train_batches, validate_batches, validate_steps = cloudpickle.load(f)
+    train_data_creator, epochs, validation_data_creator, train_func, \
+        validate_func, train_batches, validate_batches, validate_steps = cloudpickle.load(f)
 
 if init_func:
     print("Initializing distributed environment")

--- a/pyzoo/zoo/orca/learn/mpi/mpi_train.py
+++ b/pyzoo/zoo/orca/learn/mpi/mpi_train.py
@@ -51,11 +51,13 @@ if validation_data_creator:
     valid_ld = validation_data_creator(config)
     validate_batches = validate_batches if validate_batches else len(valid_ld)
     print("Batches to test: ", validate_batches)
+else:
+    valid_ld = None
+    validate_batches = None
 
 for i in range(epochs):
-    train_func(model, train_ld, train_batches, optimizer, loss, scheduler, config)
-    if validation_data_creator:
-        validate_func(model, valid_ld, validate_batches, config)
+    train_func(config, model, train_ld, train_batches, optimizer, loss, scheduler,
+               validate_func, valid_ld, validate_batches, validate_steps)
 
 # train_ld = train_data_creator(config)
 # train_batches = train_batches if train_batches else len(train_ld)

--- a/pyzoo/zoo/orca/learn/mpi/mpi_train.py
+++ b/pyzoo/zoo/orca/learn/mpi/mpi_train.py
@@ -31,7 +31,7 @@ with open("{}/saved_mpi_estimator.pkl".format(pkl_path), "rb") as f:
     model_creator, optimizer_creator, loss_creator, scheduler_creator, config, init_func = cloudpickle.load(f)
 
 with open("{}/mpi_train_data.pkl".format(pkl_path), "rb") as f:
-    train_data_creator, epochs, validation_data_creator, train_func, validate_func, train_steps, validate_steps = cloudpickle.load(f)
+    train_data_creator, epochs, validation_data_creator, train_func, validate_func, train_batches, validate_batches, validate_steps = cloudpickle.load(f)
 
 if init_func:
     print("Initializing distributed environment")
@@ -47,7 +47,7 @@ if init_func:
 # print("Batches to train: ", train_batches)
 # if validation_data_creator:
 #     valid_ld = validation_data_creator(config)
-#     validate_batches = validate_steps if validate_steps else len(valid_ld)
+#     validate_batches = validate_batches if validate_batches else len(valid_ld)
 #     print("Batches to test: ", validate_batches)
 #
 # for i in range(epochs):
@@ -56,7 +56,7 @@ if init_func:
 #         validate_func(model, valid_ld, validate_batches)
 
 train_ld = train_data_creator(config)
-train_batches = train_steps if train_steps else len(train_ld)
+train_batches = train_batches if train_batches else len(train_ld)
 print("Batches to train: ", train_batches)
 train_iter = iter(train_ld)
 for j in range(train_batches):

--- a/pyzoo/zoo/orca/learn/mpi/mpi_train.py
+++ b/pyzoo/zoo/orca/learn/mpi/mpi_train.py
@@ -43,7 +43,10 @@ if init_func:
 model = model_creator(config)
 optimizer = optimizer_creator(model, config)
 loss = loss_creator  # assume it is an instance
-scheduler = scheduler_creator(optimizer, config)
+if scheduler_creator:
+    scheduler = scheduler_creator(optimizer, config)
+else:
+    scheduler = None
 train_ld = train_data_creator(config)
 train_batches = train_batches if train_batches else len(train_ld)
 print("Batches to train: ", train_batches)

--- a/pyzoo/zoo/orca/learn/mpi/mpi_train.py
+++ b/pyzoo/zoo/orca/learn/mpi/mpi_train.py
@@ -64,15 +64,3 @@ for i in range(epochs):
     config["epoch"] = i
     train_func(config, model, train_ld, train_batches, optimizer, loss, scheduler,
                validate_func, valid_ld, metrics, validate_batches, validate_steps)
-
-# train_ld = train_data_creator(config)
-# train_batches = train_batches if train_batches else len(train_ld)
-# print("Batches to train: ", train_batches)
-# train_iter = iter(train_ld)
-# for j in range(train_batches):
-#     if j > 0 and j % len(train_ld) == 0:  # For the case where there are not enough batches.
-#         train_iter = iter(train_ld)
-#     x, y = next(train_iter)
-    # print("X_int ", x[0].shape)
-    # print("X_cat ", x[1].shape)
-    # print("y ", y.shape)

--- a/pyzoo/zoo/orca/learn/mpi/utils.py
+++ b/pyzoo/zoo/orca/learn/mpi/utils.py
@@ -1,0 +1,66 @@
+#
+# Copyright 2018 Analytics Zoo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import numpy as np
+
+
+def chunks(lst, n):
+    """Yield successive n-sized chunks from lst."""
+    for i in range(0, len(lst), n):
+        yield lst[i:i + n]
+
+
+def index(x, start=None, end=None):
+    if isinstance(x, list):
+        return [index_numpy(x_i, start, end) for x_i in x]
+    else:
+        return index_numpy(x, start, end)
+
+
+def index_numpy(x, start=None, end=None):
+    if start:
+        if end:
+            return x[start:end]
+        else:
+            return x[start:]
+    else:
+        if end:
+            return x[:end]
+        else:
+            return x
+
+
+def process_records(buffer):
+    import random
+    random.shuffle(buffer)  # TODO: Make shuffle configurable?
+    buffer_x = [record[0] for record in buffer]
+    buffer_y = [record[1] for record in buffer]
+    res_buffer = dict()
+    if isinstance(buffer_x[0], list):
+        res_x = []
+        for i in range(len(buffer_x[0])):
+            res_x.append(np.array([record[i] for record in buffer_x]))
+        res_buffer["x"] = res_x
+    else:
+        res_buffer["x"] = np.array(buffer_x)
+    if isinstance(buffer_y[0], list):
+        res_y = []
+        for i in range(len(buffer_x[0])):
+            res_y.append(np.array([record[i] for record in buffer_y]))
+        res_buffer["y"] = res_y
+    else:  # TODO: int features and label of type int32?
+        res_buffer["y"] = np.array(buffer_y)
+    return res_buffer

--- a/pyzoo/zoo/orca/learn/mpi/utils.py
+++ b/pyzoo/zoo/orca/learn/mpi/utils.py
@@ -47,20 +47,34 @@ def process_records(buffer):
     import random
     random.shuffle(buffer)  # TODO: Make shuffle configurable?
     buffer_x = [record[0] for record in buffer]
-    buffer_y = [record[1] for record in buffer]
+    if len(buffer[0]) > 1:
+        buffer_y = [record[1] for record in buffer]
+    else:
+        buffer_y = None
     res_buffer = dict()
     if isinstance(buffer_x[0], list):
         res_x = []
         for i in range(len(buffer_x[0])):
-            res_x.append(np.array([record[i] for record in buffer_x]))
+            res_x.append(cast_ndarray_type(np.array([record[i] for record in buffer_x])))
         res_buffer["x"] = res_x
     else:
-        res_buffer["x"] = np.array(buffer_x)
-    if isinstance(buffer_y[0], list):
-        res_y = []
-        for i in range(len(buffer_x[0])):
-            res_y.append(np.array([record[i] for record in buffer_y]))
-        res_buffer["y"] = res_y
-    else:  # TODO: int features and label of type int32?
-        res_buffer["y"] = np.array(buffer_y)
+        res_buffer["x"] = cast_ndarray_type(np.array(buffer_x))
+    if buffer_y:
+        if isinstance(buffer_y[0], list):
+            res_y = []
+            for i in range(len(buffer_x[0])):
+                res_y.append(cast_ndarray_type(np.array([record[i] for record in buffer_y])))
+            res_buffer["y"] = res_y
+        else:
+            res_buffer["y"] = cast_ndarray_type(np.array(buffer_y))
     return res_buffer
+
+
+# To save some memory when putting into plasma
+def cast_ndarray_type(x):
+    if x.dtype == np.int64:
+        return x.astype(np.int32)
+    elif x.dtype == np.float64:
+        return x.astype(np.float32)
+    else:
+        return x


### PR DESCRIPTION
@jason-dai Take a look at the initial implementation.

__MPIRunner__ is a general class for running any mpi script. (Probably we can support some optimized configurations in the later stage, refer to https://github.com/intel/intel-extension-for-pytorch/blob/master/intel_pytorch_extension_py/launch.py

__MPIEstimator__ is an Estimator for Pytorch distributed training with MPI. (No extra Python script is needed in this case) Fit accepts Spark DataFrames and put into plasma, and would create a dataloader based on numpy for users to iterate. Users have the flexibility to define init_func, train_func and validate_func, if not specified there are default ones. Users can also input data_creator if they wish.

Verified on dlrm e2e workload on clx cluster and 4-socket cpx.