### PR TITLE
Fix Orca pytorch metrics MAE and MSE

### DIFF
--- a/pyzoo/test/zoo/orca/learn/test_metrics.py
+++ b/pyzoo/test/zoo/orca/learn/test_metrics.py
@@ -97,11 +97,11 @@ def test_torch_MAE():
     pred = torch.tensor([[1.5, 2.5], [1.0, 1.0]])
     target = torch.tensor([[0.2, 1.1], [0.5, 1.0]])
     m(pred, target)
-    assert abs(m.compute() - 0.85) < 1e-6
+    assert abs(m.compute() - 0.85) < 1e-7   # add float tolerance for floating point precision
     pred = torch.tensor([[1.5, 2.5, 1.5, 2.5], [1.8, 2.0, 0.5, 4.5]])
     target = torch.tensor([[0, 1, 0, 0], [0, 1, 2, 2]])
     m(pred, target)
-    assert abs(m.compute() - 1.2) < 1e-6
+    assert abs(m.compute() - 1.2) < 1e-7
 
 
 def test_torch_MSE():
@@ -118,11 +118,11 @@ def test_torch_MSE():
     pred = torch.tensor([[1.3, 1.0], [0.2, 1.0]])
     target = torch.tensor([[1.1, 1.0], [0.0, 1.0]])
     m(pred, target)
-    assert abs(m.compute() - 0.84) < 1e-6
+    assert abs(m.compute() - 0.84) < 1e-7
     pred = torch.tensor([[1.2, 1.2, 1.2, 1.8], [0.2, 0.8, 0.9, 1.1]])
     target = torch.tensor([[1, 1, 1, 2], [0, 1, 1, 1]])
     m(pred, target)
-    assert abs(m.compute() - 0.517) < 1e-6
+    assert abs(m.compute() - 0.517) < 1e-7
 
 
 def test_torch_BinaryCrossEntropy():

--- a/pyzoo/test/zoo/orca/learn/test_metrics.py
+++ b/pyzoo/test/zoo/orca/learn/test_metrics.py
@@ -97,7 +97,7 @@ def test_torch_MAE():
     pred = torch.tensor([[1.5, 2.5], [1.0, 1.0]])
     target = torch.tensor([[0.2, 1.1], [0.5, 1.0]])
     m(pred, target)
-    assert abs(m.compute() - 0.85) < 1e-7   # add float tolerance for floating point precision
+    assert abs(m.compute() - 0.85) < 1e-7   # add fault tolerance for floating point precision
     pred = torch.tensor([[1.5, 2.5, 1.5, 2.5], [1.8, 2.0, 0.5, 4.5]])
     target = torch.tensor([[0, 1, 0, 0], [0, 1, 2, 2]])
     m(pred, target)

--- a/pyzoo/test/zoo/orca/learn/test_metrics.py
+++ b/pyzoo/test/zoo/orca/learn/test_metrics.py
@@ -97,11 +97,11 @@ def test_torch_MAE():
     pred = torch.tensor([[1.5, 2.5], [1.0, 1.0]])
     target = torch.tensor([[0.2, 1.1], [0.5, 1.0]])
     m(pred, target)
-    assert abs(m.compute() - 0.85) < 1e-6 
-    pred = torch.tensor([[1.5, 2.5], [1.8, 2.0]])
-    target = torch.tensor([[0, 1], [0, 1]])
+    assert abs(m.compute() - 0.85) < 1e-6
+    pred = torch.tensor([[1.5, 2.5, 1.5, 2.5], [1.8, 2.0, 0.5, 4.5]])
+    target = torch.tensor([[0, 1, 0, 0], [0, 1, 2, 2]])
     m(pred, target)
-    assert abs(m.compute() - 1) < 1e-6 
+    assert abs(m.compute() - 1.2) < 1e-6
 
 
 def test_torch_MSE():
@@ -119,10 +119,10 @@ def test_torch_MSE():
     target = torch.tensor([[1.1, 1.0], [0.0, 1.0]])
     m(pred, target)
     assert abs(m.compute() - 0.84) < 1e-6
-    pred = torch.tensor([[1.2, 1.2], [0.2, 0.8]])
-    target = torch.tensor([[1, 1], [0, 1]])
+    pred = torch.tensor([[1.2, 1.2, 1.2, 1.8], [0.2, 0.8, 0.9, 1.1]])
+    target = torch.tensor([[1, 1, 1, 2], [0, 1, 1, 1]])
     m(pred, target)
-    assert abs(m.compute() - 0.64) < 1e-6
+    assert abs(m.compute() - 0.517) < 1e-6
 
 
 def test_torch_BinaryCrossEntropy():

--- a/pyzoo/test/zoo/orca/learn/test_metrics.py
+++ b/pyzoo/test/zoo/orca/learn/test_metrics.py
@@ -94,6 +94,14 @@ def test_torch_MAE():
     target = torch.tensor([[0, 1], [0, 1]])
     m(pred, target)
     assert m.compute() == 0.875
+    pred = torch.tensor([[1.5, 2.5], [1.0, 1.0]])
+    target = torch.tensor([[0.2, 1.1], [0.5, 1.0]])
+    m(pred, target)
+    assert abs(m.compute() - 0.85) < 1e-6 
+    pred = torch.tensor([[1.5, 2.5], [1.8, 2.0]])
+    target = torch.tensor([[0, 1], [0, 1]])
+    m(pred, target)
+    assert abs(m.compute() - 1) < 1e-6 
 
 
 def test_torch_MSE():
@@ -107,6 +115,14 @@ def test_torch_MSE():
     target = torch.tensor([[1, 1], [0, 1]])
     m(pred, target)
     assert m.compute() == 1.25
+    pred = torch.tensor([[1.3, 1.0], [0.2, 1.0]])
+    target = torch.tensor([[1.1, 1.0], [0.0, 1.0]])
+    m(pred, target)
+    assert abs(m.compute() - 0.84) < 1e-6
+    pred = torch.tensor([[1.2, 1.2], [0.2, 0.8]])
+    target = torch.tensor([[1, 1], [0, 1]])
+    m(pred, target)
+    assert abs(m.compute() - 0.64) < 1e-6
 
 
 def test_torch_BinaryCrossEntropy():

--- a/pyzoo/zoo/orca/learn/pytorch/pytorch_metrics.py
+++ b/pyzoo/zoo/orca/learn/pytorch/pytorch_metrics.py
@@ -229,11 +229,10 @@ class MSE(PytorchMetric):
 
     def __init__(self):
         self.total = torch.tensor(0)
-        self.sum_squared_error = torch.tensor(0)
+        self.sum_squared_error = torch.tensor(0.0)
 
     def __call__(self, preds, targets):
         _check_same_shape(preds, targets)
-        preds = preds.type_as(targets)
         self.sum_squared_error += torch.sum(torch.square(torch.sub(preds, targets)))
         self.total += targets.numel()
 
@@ -259,16 +258,15 @@ class MAE(PytorchMetric):
 
     def __init__(self):
         self.total = torch.tensor(0)
-        self.sum_abs_error = torch.tensor(0)
+        self.sum_abs_error = torch.tensor(0.0)
 
     def __call__(self, preds, targets):
         _check_same_shape(preds, targets)
-        preds = preds.type_as(targets)
         self.sum_abs_error += torch.sum(torch.abs(torch.sub(preds, targets)))
         self.total += targets.numel()
 
     def compute(self):
-        return self.sum_abs_error.float() / self.total
+        return self.sum_abs_error / self.total
 
 
 class BinaryCrossEntropy(PytorchMetric):

--- a/pyzoo/zoo/orca/learn/pytorch/pytorch_metrics.py
+++ b/pyzoo/zoo/orca/learn/pytorch/pytorch_metrics.py
@@ -237,7 +237,7 @@ class MSE(PytorchMetric):
         self.total += targets.numel()
 
     def compute(self):
-        return self.sum_squared_error.float() / self.total
+        return self.sum_squared_error / self.total
 
 
 class MAE(PytorchMetric):


### PR DESCRIPTION
Modify MAE and MSE to support float labels.
Remove the line making the type of `preds` the same as `target`. (reference: https://pytorch.org/docs/stable/generated/torch.sub.html#torch.sub
https://pytorch.org/docs/stable/tensor_attributes.html#type-promotion-doc
)
Add and run unit test.