### PR TITLE
`load_orca_checkpoint` related updates for Orca BigDL / OpenVINO estimator

### DIFF
--- a/pyzoo/zoo/orca/learn/openvino/estimator.py
+++ b/pyzoo/zoo/orca/learn/openvino/estimator.py
@@ -239,9 +239,3 @@ class OpenvinoEstimator(SparkEstimator):
         Load_orca_checkpoint is not supported in OpenVINOEstimator
         """
         raise NotImplementedError
-
-    def load_latest_orca_checkpoint(self, path):
-        """
-        Load_latest_orca_checkpoint is not supported in OpenVINOEstimator
-        """
-        raise NotImplementedError

--- a/pyzoo/zoo/orca/learn/pytorch/estimator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/estimator.py
@@ -516,7 +516,7 @@ class PyTorchSparkEstimator(OrcaSparkEstimator):
         `perfix`. If `version` is None, then the latest checkpoint will be loaded.
 
         :param path: Path to the existing checkpoint (or directory containing Orca checkpoint
-               files if `version` is None).
+               files).
         :param version: checkpoint version, which is the suffix of model.* file, i.e., for
                modle.4 file, the version is 4. If it is None, then load the latest checkpoint.
         :param prefix: optimMethod prefix, for example 'optimMethod-TorchModelf53bddcc'.


### PR DESCRIPTION
Remove `load_latest_orca_checkpoint` and modify `load_orca_checkpoint` to include the functionality of loading the latest checkpoint. Main modifications in this PR is related to Orca BigDL estimator.

There's also a minor update in the comment of orca pytorch estimator for consistency.