### PR TITLE
TCNForecaster test bugfix

### DIFF
--- a/pyzoo/test/zoo/zouwu/model/forecast/test_tcn_forecaster.py
+++ b/pyzoo/test/zoo/zouwu/model/forecast/test_tcn_forecaster.py
@@ -83,7 +83,7 @@ class TestZouwuModelTCNForecaster(TestCase):
             pred_onnx = forecaster.predict_with_onnx(test_data[0])
             np.testing.assert_almost_equal(pred, pred_onnx, decimal=5)
             mse = forecaster.evaluate(test_data[0], test_data[1])
-            mse_onnx = forecaster.evaluate(test_data[0], test_data[1])
+            mse_onnx = forecaster.evaluate_with_onnx(test_data[0], test_data[1])
             np.testing.assert_almost_equal(mse, mse_onnx, decimal=5)
         except ImportError:
             pass


### PR DESCRIPTION
`mse_onnx = forecaster.evaluate(test_data[0], test_data[1])`
on https://github.com/intel-analytics/analytics-zoo/blob/master/pyzoo/test/zoo/zouwu/model/forecast/test_tcn_forecaster.py#L86