### PR TITLE
add loss option for TCNForecaster

### DIFF
--- a/docs/docs/Zouwu/API/TCNForecaster.md
+++ b/docs/docs/Zouwu/API/TCNForecaster.md
@@ -16,6 +16,7 @@ Temporal Convolutional Networks (TCN) is a neural network that use convolutional
 - **`kernel_size`**: Specify convolutional layer filter height in TCN's encoder. This value defaults to 7.
 - **`dropout`**: Specify the dropout close possibility (i.e. the close possibility to a neuron). This value defaults to 0.2.
 - **`optimizer`**: Specify the optimizer used for training. This value defaults to "Adam".
+- **`loss`**: Specify the loss function used for training. This value defaults to "mse". You can choose from "mse", "mae" and "huber_loss".
 - **`lr`**: Specify the learning rate. This value defaults to 0.001.
 
 ### \_\_init\_\_
@@ -29,6 +30,7 @@ TCNForecaster(past_seq_len,
               kernel_size=7,
               dropout=0.2,
               optimizer="Adam",
+              loss="mse",
               lr=0.001)
 ```
 

--- a/pyzoo/test/zoo/zouwu/model/forecast/test_tcn_forecaster.py
+++ b/pyzoo/test/zoo/zouwu/model/forecast/test_tcn_forecaster.py
@@ -60,8 +60,9 @@ class TestZouwuModelTCNForecaster(TestCase):
                                    output_feature_num=1,
                                    kernel_size=4,
                                    num_channels=[16, 16],
+                                   loss="mae",
                                    lr=0.01)
-        train_mse = forecaster.fit(train_data[0], train_data[1], epochs=2)
+        train_loss = forecaster.fit(train_data[0], train_data[1], epochs=2)
         test_pred = forecaster.predict(test_data[0])
         assert test_pred.shape == test_data[1].shape
         test_mse = forecaster.evaluate(test_data[0], test_data[1])

--- a/pyzoo/zoo/zouwu/model/forecast/model/base_pytorch_model.py
+++ b/pyzoo/zoo/zouwu/model/forecast/model/base_pytorch_model.py
@@ -22,6 +22,10 @@ from zoo.automl.common.metrics import Evaluator
 import pandas as pd
 
 
+PYTORCH_REGRESSION_LOSS_MAP = {"mse": "MSELoss", 
+                               "mae": "L1Loss",
+                               "huber_loss": "SmoothL1Loss"}
+
 class PytorchBaseModel(BaseModel):
     def __init__(self, model_creator, optimizer_creator, loss_creator,
                  check_optional_config=False):

--- a/pyzoo/zoo/zouwu/model/forecast/model/base_pytorch_model.py
+++ b/pyzoo/zoo/zouwu/model/forecast/model/base_pytorch_model.py
@@ -22,9 +22,10 @@ from zoo.automl.common.metrics import Evaluator
 import pandas as pd
 
 
-PYTORCH_REGRESSION_LOSS_MAP = {"mse": "MSELoss", 
+PYTORCH_REGRESSION_LOSS_MAP = {"mse": "MSELoss",
                                "mae": "L1Loss",
                                "huber_loss": "SmoothL1Loss"}
+
 
 class PytorchBaseModel(BaseModel):
     def __init__(self, model_creator, optimizer_creator, loss_creator,

--- a/pyzoo/zoo/zouwu/model/forecast/model/tcn.py
+++ b/pyzoo/zoo/zouwu/model/forecast/model/tcn.py
@@ -151,7 +151,8 @@ def loss_creator(config):
     if loss_name in PYTORCH_REGRESSION_LOSS_MAP:
         loss_name = PYTORCH_REGRESSION_LOSS_MAP[loss_name]
     else:
-        raise RuntimeError("You need to provide valid loss name within mse, mae and huber_loss")
+        raise RuntimeError(f"Got \"{loss_name}\" for loss name,\
+                           where \"mse\", \"mae\" or \"huber_loss\" is expected")
     return getattr(torch.nn, loss_name)()
 
 

--- a/pyzoo/zoo/zouwu/model/forecast/model/tcn.py
+++ b/pyzoo/zoo/zouwu/model/forecast/model/tcn.py
@@ -43,7 +43,7 @@ import torch
 import torch.nn as nn
 from torch.nn.utils import weight_norm
 from zoo.zouwu.model.forecast.model.base_pytorch_model import PytorchBaseModel, \
-                                                              PYTORCH_REGRESSION_LOSS_MAP
+    PYTORCH_REGRESSION_LOSS_MAP
 
 
 class Chomp1d(nn.Module):

--- a/pyzoo/zoo/zouwu/model/forecast/model/tcn.py
+++ b/pyzoo/zoo/zouwu/model/forecast/model/tcn.py
@@ -148,9 +148,11 @@ def optimizer_creator(model, config):
 
 def loss_creator(config):
     loss_name = config.get("loss", "mse")
-    if not PYTORCH_REGRESSION_LOSS_MAP.has_key(loss_name):
+    if loss_name in PYTORCH_REGRESSION_LOSS_MAP:
+        loss_name = PYTORCH_REGRESSION_LOSS_MAP[loss_name]
+    else:
         raise RuntimeError("You need to provide valid loss name within mse, mae and huber_loss")
-    return getattr(torch.nn, loss_name)
+    return getattr(torch.nn, loss_name)()
 
 
 class TCNPytorch(PytorchBaseModel):

--- a/pyzoo/zoo/zouwu/model/forecast/model/tcn.py
+++ b/pyzoo/zoo/zouwu/model/forecast/model/tcn.py
@@ -42,7 +42,8 @@
 import torch
 import torch.nn as nn
 from torch.nn.utils import weight_norm
-from zoo.zouwu.model.forecast.model.base_pytorch_model import PytorchBaseModel
+from zoo.zouwu.model.forecast.model.base_pytorch_model import PytorchBaseModel, \
+                                                              PYTORCH_REGRESSION_LOSS_MAP
 
 
 class Chomp1d(nn.Module):
@@ -146,7 +147,10 @@ def optimizer_creator(model, config):
 
 
 def loss_creator(config):
-    return nn.MSELoss()
+    loss_name = config.get("loss", "mse")
+    if not PYTORCH_REGRESSION_LOSS_MAP.has_key(loss_name):
+        raise RuntimeError("You need to provide valid loss name within mse, mae and huber_loss")
+    return getattr(torch.nn, loss_name)
 
 
 class TCNPytorch(PytorchBaseModel):

--- a/pyzoo/zoo/zouwu/model/forecast/tcn_forecaster.py
+++ b/pyzoo/zoo/zouwu/model/forecast/tcn_forecaster.py
@@ -29,6 +29,7 @@ class TCNForecaster(Forecaster):
                  kernel_size=7,
                  dropout=0.2,
                  optimizer="Adam",
+                 loss="mse",
                  lr=0.001):
         """
         Build a TCN Forecast Model.
@@ -45,6 +46,9 @@ class TCNForecaster(Forecaster):
                possibility to a neuron). This value defaults to 0.2.
         :param optimizer: Specify the optimizer used for training. This value
                defaults to "Adam".
+        :param loss: Specify the loss function used for training. This value
+               defaults to "mse". You can choose within "mse", "mae" and 
+               "huber_loss"
         :param lr: Specify the learning rate. This value defaults to 0.001.
         """
         self.internal = TCNPytorch(check_optional_config=False)
@@ -56,6 +60,7 @@ class TCNForecaster(Forecaster):
         }
         self.config = {
             "lr": lr,
+            "loss": loss,
             "num_channels": num_channels,
             "kernel_size": kernel_size,
             "optim": optimizer,

--- a/pyzoo/zoo/zouwu/model/forecast/tcn_forecaster.py
+++ b/pyzoo/zoo/zouwu/model/forecast/tcn_forecaster.py
@@ -47,7 +47,7 @@ class TCNForecaster(Forecaster):
         :param optimizer: Specify the optimizer used for training. This value
                defaults to "Adam".
         :param loss: Specify the loss function used for training. This value
-               defaults to "mse". You can choose from "mse", "mae" and 
+               defaults to "mse". You can choose from "mse", "mae" and
                "huber_loss".
         :param lr: Specify the learning rate. This value defaults to 0.001.
         """

--- a/pyzoo/zoo/zouwu/model/forecast/tcn_forecaster.py
+++ b/pyzoo/zoo/zouwu/model/forecast/tcn_forecaster.py
@@ -47,8 +47,8 @@ class TCNForecaster(Forecaster):
         :param optimizer: Specify the optimizer used for training. This value
                defaults to "Adam".
         :param loss: Specify the loss function used for training. This value
-               defaults to "mse". You can choose within "mse", "mae" and 
-               "huber_loss"
+               defaults to "mse". You can choose from "mse", "mae" and 
+               "huber_loss".
         :param lr: Specify the learning rate. This value defaults to 0.001.
         """
         self.internal = TCNPytorch(check_optional_config=False)


### PR DESCRIPTION
1. Add a `PYTORCH_REGRESSION_LOSS_MAP` for future use in built-in model
2. add loss option for TCNForecaster