### PR TITLE
enable python API doc in readthedocs website after passing test

### DIFF
--- a/docs/readthedocs/source/conf.py
+++ b/docs/readthedocs/source/conf.py
@@ -21,7 +21,7 @@ import urllib
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, '.')
 sys.path.insert(0, os.path.abspath('.'))
-sys.path.insert(0, os.path.abspath("../../pyzoo/"))
+sys.path.insert(0, os.path.abspath("../../../pyzoo/"))
 
 
 # -- Project information -----------------------------------------------------

--- a/docs/readthedocs/source/index.rst
+++ b/docs/readthedocs/source/index.rst
@@ -53,7 +53,7 @@ Analytics Zoo includes the **Orca** library that seamlessly scale out your singl
    :maxdepth: 1
    :caption: Python API
    
-   doc/PythonAPI/Orca/zoo.orca.rst
+   doc/PythonAPI/Orca/orca.rst
    
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
enable python API doc in readthedocs website after passing test
1) update index.rst
2) update conf.py

test demo: https://testhelendoc.readthedocs.io/en/latest/doc/PythonAPI/Orca/orca.html