### PR TITLE
update some formats in python API doc

### DIFF
--- a/pyzoo/zoo/orca/learn/bigdl/estimator.py
+++ b/pyzoo/zoo/orca/learn/bigdl/estimator.py
@@ -501,7 +501,7 @@ class BigDLEstimator(OrcaSparkEstimator):
    * - 'StatelessMetric'
      - '${name}'
      
- :param tag: The string variable represents the scalar wanted
+   :param tag: The string variable represents the scalar wanted
         """
         if self.is_nnframe_fit:
             assert tag is not None, "You should provide tag which should match the name of " \

--- a/pyzoo/zoo/orca/learn/bigdl/estimator.py
+++ b/pyzoo/zoo/orca/learn/bigdl/estimator.py
@@ -465,6 +465,40 @@ class BigDLEstimator(OrcaSparkEstimator):
         Please look up following form to pass tag parameter.
         Left side is your metric during compile.
         Right side is the tag you should pass.
+        
+        'Accuracy'                  |   'Top1Accuracy'
+        
+        'BinaryAccuracy'            |   'Top1Accuracy'
+        
+        'CategoricalAccuracy'       |   'Top1Accuracy'
+        
+        'SparseCategoricalAccuracy' |   'Top1Accuracy'
+        
+        'AUC'                       |   'AucScore'
+        
+        'HitRatio'                  |   'HitRate@k' (k is Top-k)
+        
+        'Loss'                      |   'Loss'
+        
+        'MAE'                       |   'MAE'
+        
+        'NDCG'                      |   'NDCG'
+        
+        'TFValidationMethod'        |   '${name + " " + valMethod.toString()}'
+        
+        'Top5Accuracy'              |   'Top5Accuracy'
+        
+        'TreeNNAccuracy'            |   'TreeNNAccuracy()'
+        
+        'MeanAveragePrecision'      |   'MAP@k' (k is Top-k) (BigDL)
+        
+        'MeanAveragePrecision'      |   'PascalMeanAveragePrecision' (Zoo)
+        
+        'StatelessMetric'           |   '${name}'
+        
+        
+        
+        
 
 .. list-table::
    :widths: 50 50

--- a/pyzoo/zoo/orca/learn/bigdl/estimator.py
+++ b/pyzoo/zoo/orca/learn/bigdl/estimator.py
@@ -466,23 +466,42 @@ class BigDLEstimator(OrcaSparkEstimator):
         Left side is your metric during compile.
         Right side is the tag you should pass.
 
-        >>> 'Accuracy'                  |   'Top1Accuracy'
-        >>> 'BinaryAccuracy'            |   'Top1Accuracy'
-        >>> 'CategoricalAccuracy'       |   'Top1Accuracy'
-        >>> 'SparseCategoricalAccuracy' |   'Top1Accuracy'
-        >>> 'AUC'                       |   'AucScore'
-        >>> 'HitRatio'                  |   'HitRate@k' (k is Top-k)
-        >>> 'Loss'                      |   'Loss'
-        >>> 'MAE'                       |   'MAE'
-        >>> 'NDCG'                      |   'NDCG'
-        >>> 'TFValidationMethod'        |   '${name + " " + valMethod.toString()}'
-        >>> 'Top5Accuracy'              |   'Top5Accuracy'
-        >>> 'TreeNNAccuracy'            |   'TreeNNAccuracy()'
-        >>> 'MeanAveragePrecision'      |   'MAP@k' (k is Top-k) (BigDL)
-        >>> 'MeanAveragePrecision'      |   'PascalMeanAveragePrecision' (Zoo)
-        >>> 'StatelessMetric'           |   '${name}'
-
-        :param tag: The string variable represents the scalar wanted
+.. list-table::
+   :widths: 50 50
+   :header-rows: 1
+   
+   * - your metric during compile
+     - the tag you should pass
+   * - 'Accuracy'
+     - 'Top1Accuracy'
+   * - 'BinaryAccuracy' 
+     - 'Top1Accuracy'
+   * - 'CategoricalAccuracy' 
+     - 'Top1Accuracy'
+   * - SparseCategoricalAccuracy'
+     - 'Top1Accuracy'
+   * - 'AUC'
+     - 'AucScore'
+   * - 'HitRatio' 
+     - 'HitRate@k' (k is Top-k)
+   * - 'Loss' 
+     - 'Loss'
+   * - 'MAE'
+     - 'MAE'
+   * - 'NDCG' 
+     - 'NDCG' 
+   * - 'TFValidationMethod'
+     - '${name + " " + valMethod.toString()}'
+   * - 'Top5Accuracy'
+     - 'Top5Accuracy'
+   * - 'TreeNNAccuracy' 
+     - 'TreeNNAccuracy()'
+   * - 'MeanAveragePrecision' 
+     - 'MAP@k' (k is Top-k) (BigDL)
+   * - 'StatelessMetric'
+     - '${name}'
+     
+ :param tag: The string variable represents the scalar wanted
         """
         if self.is_nnframe_fit:
             assert tag is not None, "You should provide tag which should match the name of " \

--- a/pyzoo/zoo/orca/learn/bigdl/estimator.py
+++ b/pyzoo/zoo/orca/learn/bigdl/estimator.py
@@ -501,7 +501,7 @@ class BigDLEstimator(OrcaSparkEstimator):
    * - 'StatelessMetric'
      - '${name}'
      
-   :param tag: The string variable represents the scalar wanted
+:param tag: The string variable represents the scalar wanted
         """
         if self.is_nnframe_fit:
             assert tag is not None, "You should provide tag which should match the name of " \

--- a/pyzoo/zoo/orca/learn/pytorch/estimator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/estimator.py
@@ -581,24 +581,43 @@ class PyTorchSparkEstimator(OrcaSparkEstimator):
         Please look up following form to pass tag parameter.
         Left side is your metric during compile.
         Right side is the tag you should pass.
-
-        >>> 'Accuracy'                  |   'Top1Accuracy'
-        >>> 'BinaryAccuracy'            |   'Top1Accuracy'
-        >>> 'CategoricalAccuracy'       |   'Top1Accuracy'
-        >>> 'SparseCategoricalAccuracy' |   'Top1Accuracy'
-        >>> 'AUC'                       |   'AucScore'
-        >>> 'HitRatio'                  |   'HitRate@k' (k is Top-k)
-        >>> 'Loss'                      |   'Loss'
-        >>> 'MAE'                       |   'MAE'
-        >>> 'NDCG'                      |   'NDCG'
-        >>> 'TFValidationMethod'        |   '${name + " " + valMethod.toString()}'
-        >>> 'Top5Accuracy'              |   'Top5Accuracy'
-        >>> 'TreeNNAccuracy'            |   'TreeNNAccuracy()'
-        >>> 'MeanAveragePrecision'      |   'MAP@k' (k is Top-k) (BigDL)
-        >>> 'MeanAveragePrecision'      |   'PascalMeanAveragePrecision' (Zoo)
-        >>> 'StatelessMetric'           |   '${name}'
-
-        :param tag: The string variable represents the scalar wanted
+       
+.. list-table::
+   :widths: 50 50
+   :header-rows: 1
+   
+   * - your metric during compile
+     - the tag you should pass
+   * - 'Accuracy'
+     - 'Top1Accuracy'
+   * - 'BinaryAccuracy' 
+     - 'Top1Accuracy'
+   * - 'CategoricalAccuracy' 
+     - 'Top1Accuracy'
+   * - SparseCategoricalAccuracy'
+     - 'Top1Accuracy'
+   * - 'AUC'
+     - 'AucScore'
+   * - 'HitRatio' 
+     - 'HitRate@k' (k is Top-k)
+   * - 'Loss' 
+     - 'Loss'
+   * - 'MAE'
+     - 'MAE'
+   * - 'NDCG' 
+     - 'NDCG' 
+   * - 'TFValidationMethod'
+     - '${name + " " + valMethod.toString()}'
+   * - 'Top5Accuracy'
+     - 'Top5Accuracy'
+   * - 'TreeNNAccuracy' 
+     - 'TreeNNAccuracy()'
+   * - 'MeanAveragePrecision' 
+     - 'MAP@k' (k is Top-k) (BigDL)
+   * - 'StatelessMetric'
+     - '${name}'
+     
+:param tag: The string variable represents the scalar wanted
         """
         return self.estimator.get_validation_summary(tag=tag)
 

--- a/pyzoo/zoo/orca/learn/tf/estimator.py
+++ b/pyzoo/zoo/orca/learn/tf/estimator.py
@@ -188,24 +188,43 @@ class Estimator(SparkEstimator):
         Please look up following form to pass tag parameter.
         Left side is your metric during compile.
         Right side is the tag you should pass.
-
-        >>> 'Accuracy'                  |   'Top1Accuracy'
-        >>> 'BinaryAccuracy'            |   'Top1Accuracy'
-        >>> 'CategoricalAccuracy'       |   'Top1Accuracy'
-        >>> 'SparseCategoricalAccuracy' |   'Top1Accuracy'
-        >>> 'AUC'                       |   'AucScore'
-        >>> 'HitRatio'                  |   'HitRate@k' (k is Top-k)
-        >>> 'Loss'                      |   'Loss'
-        >>> 'MAE'                       |   'MAE'
-        >>> 'NDCG'                      |   'NDCG'
-        >>> 'TFValidationMethod'        |   '${name + " " + valMethod.toString()}'
-        >>> 'Top5Accuracy'              |   'Top5Accuracy'
-        >>> 'TreeNNAccuracy'            |   'TreeNNAccuracy()'
-        >>> 'MeanAveragePrecision'      |   'MAP@k' (k is Top-k) (BigDL)
-        >>> 'MeanAveragePrecision'      |   'PascalMeanAveragePrecision' (Zoo)
-        >>> 'StatelessMetric'           |   '${name}'
-
-        :param tag: The string variable represents the scalar wanted
+        
+.. list-table::
+   :widths: 50 50
+   :header-rows: 1
+   
+   * - your metric during compile
+     - the tag you should pass
+   * - 'Accuracy'
+     - 'Top1Accuracy'
+   * - 'BinaryAccuracy' 
+     - 'Top1Accuracy'
+   * - 'CategoricalAccuracy' 
+     - 'Top1Accuracy'
+   * - SparseCategoricalAccuracy'
+     - 'Top1Accuracy'
+   * - 'AUC'
+     - 'AucScore'
+   * - 'HitRatio' 
+     - 'HitRate@k' (k is Top-k)
+   * - 'Loss' 
+     - 'Loss'
+   * - 'MAE'
+     - 'MAE'
+   * - 'NDCG' 
+     - 'NDCG' 
+   * - 'TFValidationMethod'
+     - '${name + " " + valMethod.toString()}'
+   * - 'Top5Accuracy'
+     - 'Top5Accuracy'
+   * - 'TreeNNAccuracy' 
+     - 'TreeNNAccuracy()'
+   * - 'MeanAveragePrecision' 
+     - 'MAP@k' (k is Top-k) (BigDL)
+   * - 'StatelessMetric'
+     - '${name}'
+     
+:param tag: The string variable represents the scalar wanted
         """
         if self.tf_optimizer:
             for val_method in self.tf_optimizer.tf_model.val_methods:


### PR DESCRIPTION
update some tables format using  ">>>" with the table codes below:

"
 .. list-table::
   :widths: 50 50
   :header-rows: 1

   * - Name
     - Description
    .......
"

you can see the diff in the links below:

 current format:  https://analytics-zoo.readthedocs.io/en/latest/doc/PythonAPI/Orca/orca.html
 updated format:  https://testhelendoc.readthedocs.io/en/latest/doc/PythonAPI/Orca/orca.html