### PR TITLE
Change automl onnx import error message to runtime error

### DIFF
--- a/pyzoo/zoo/automl/model/base_pytorch_model.py
+++ b/pyzoo/zoo/automl/model/base_pytorch_model.py
@@ -242,7 +242,7 @@ class PytorchBaseModel(BaseModel):
             import onnx
             import onnxruntime
         except:
-            print("You should install onnx and onnxruntime to use onnx based method.")
+            raise RuntimeError("You should install onnx and onnxruntime to use onnx based method.")
         if dirname is None:
             dirname = tempfile.mkdtemp(prefix="onnx_cache_")
         # code adapted from


### PR DESCRIPTION
if onnx/onnxruntime is not installed, the error message will show through a runtime error.