### PR TITLE
Fixed issue #3656, deprecated pandas api (DatetimeProperties.weekofye…

### DIFF
--- a/pyzoo/zoo/zouwu/feature/time_sequence.py
+++ b/pyzoo/zoo/zouwu/feature/time_sequence.py
@@ -539,7 +539,7 @@ class TimeSequenceFeatureTransformer(BaseFeatureTransformer):
         # built in time features
         for attr in TIME_FEATURE:
             if attr == "WEEKOFYEAR":
-                # DatetimeProperties.weekofyear has been deprecated since pandas 1.1.0, 
+                # DatetimeProperties.weekofyear has been deprecated since pandas 1.1.0,
                 # convert to DatetimeIndex to fix
                 field_datetime = pd.to_datetime(field.values.astype(np.int64))
                 df[attr + "({})".format(self.dt_col)] = field_datetime.isocalendar().week

--- a/pyzoo/zoo/zouwu/feature/time_sequence.py
+++ b/pyzoo/zoo/zouwu/feature/time_sequence.py
@@ -22,6 +22,7 @@ from sklearn.preprocessing import StandardScaler
 import pandas as pd
 import numpy as np
 import json
+from packaging import version
 
 TIME_FEATURE = ("MINUTE", "DAY", "DAYOFYEAR", "HOUR", "WEEKDAY", "WEEKOFYEAR", "MONTH")
 ADDITIONAL_TIME_FEATURE = ("IS_AWAKE", "IS_BUSY_HOURS", "IS_WEEKEND")
@@ -538,7 +539,8 @@ class TimeSequenceFeatureTransformer(BaseFeatureTransformer):
 
         # built in time features
         for attr in TIME_FEATURE:
-            if attr == "WEEKOFYEAR":
+            if attr == "WEEKOFYEAR" and \
+                    version.parse(pd.__version__) >= version.parse("1.1.0"):
                 # DatetimeProperties.weekofyear has been deprecated since pandas 1.1.0,
                 # convert to DatetimeIndex to fix, and call pd.Int64Index to return a index
                 field_datetime = pd.to_datetime(field.values.astype(np.int64))

--- a/pyzoo/zoo/zouwu/feature/time_sequence.py
+++ b/pyzoo/zoo/zouwu/feature/time_sequence.py
@@ -538,7 +538,13 @@ class TimeSequenceFeatureTransformer(BaseFeatureTransformer):
 
         # built in time features
         for attr in TIME_FEATURE:
-            df[attr + "({})".format(self.dt_col)] = getattr(field.dt, attr.lower())
+            if attr == "WEEKOFYEAR":
+                # DatetimeProperties.weekofyear has been deprecated since pandas 1.1.0, 
+                # convert to DatetimeIndex to fix
+                field_datetime = pd.to_datetime(field.values.astype(np.int64))
+                df[attr + "({})".format(self.dt_col)] = field_datetime.isocalendar().week
+            else:
+                df[attr + "({})".format(self.dt_col)] = getattr(field.dt, attr.lower())
 
         # additional time features
         hour = field.dt.hour

--- a/pyzoo/zoo/zouwu/feature/time_sequence.py
+++ b/pyzoo/zoo/zouwu/feature/time_sequence.py
@@ -540,9 +540,10 @@ class TimeSequenceFeatureTransformer(BaseFeatureTransformer):
         for attr in TIME_FEATURE:
             if attr == "WEEKOFYEAR":
                 # DatetimeProperties.weekofyear has been deprecated since pandas 1.1.0,
-                # convert to DatetimeIndex to fix
+                # convert to DatetimeIndex to fix, and call pd.Int64Index to return a index
                 field_datetime = pd.to_datetime(field.values.astype(np.int64))
-                df[attr + "({})".format(self.dt_col)] = field_datetime.isocalendar().week
+                df[attr + "({})".format(self.dt_col)] =\
+                    pd.Int64Index(field_datetime.isocalendar().week)
             else:
                 df[attr + "({})".format(self.dt_col)] = getattr(field.dt, attr.lower())
 

--- a/pyzoo/zoo/zouwu/model/tcmf/time.py
+++ b/pyzoo/zoo/zouwu/model/tcmf/time.py
@@ -47,6 +47,7 @@
 
 import pandas as pd
 import numpy as np
+from packaging import version
 
 
 class TimeCovariates(object):
@@ -94,7 +95,9 @@ class TimeCovariates(object):
         return monthYear
 
     def _week_of_year(self):
-        weekYear = np.array(pd.Int64Index(self.dti.isocalendar().week), dtype=np.float)
+        weekYear = np.array(pd.Int64Index(self.dti.isocalendar().week), dtype=np.float) if\
+            version.parse(pd.__version__) >= version.parse("1.1.0") else\
+            np.array(self.dti.weekofyear, dtype=np.float)
         if self.normalized:
             weekYear = weekYear / 51.0 - 0.5
         return weekYear

--- a/pyzoo/zoo/zouwu/model/tcmf/time.py
+++ b/pyzoo/zoo/zouwu/model/tcmf/time.py
@@ -94,7 +94,7 @@ class TimeCovariates(object):
         return monthYear
 
     def _week_of_year(self):
-        weekYear = np.array(self.dti.weekofyear, dtype=np.float)
+        weekYear = np.array(pd.Int64Index(self.dti.isocalendar().week), dtype=np.float)
         if self.normalized:
             weekYear = weekYear / 51.0 - 0.5
         return weekYear


### PR DESCRIPTION
Fix issue #3656, deprecated pandas api (DatetimeProperties.weekofyear) used in Zouwu Feature Transformer.

Convert "outdated" (but not totally deprecated yet) `DatetimeProperties` to its modernized alternative `DatetimeIndex` to fix the issue.
