### PR TITLE
Automl Searcher metric refactor

### DIFF
--- a/pyzoo/test/zoo/automl/searcher/test_ray_tune_search_engine.py
+++ b/pyzoo/test/zoo/automl/searcher/test_ray_tune_search_engine.py
@@ -174,11 +174,12 @@ class TestRayTuneSearchEngine(ZooTestCase):
         searcher = prepare_searcher(data=data_with_val,
                                     name='test_searcher_metric_name',
                                     metric='mse',
-                                    recipe=SimpleRecipe(stop_metric=float('inf')))  # stop at once
+                                    recipe=SimpleRecipe(stop_metric=float('-inf')))  # stop at once
         analysis = searcher.run()
         sorted_results = list(map(lambda x: x.last_result['mse'],
                                   RayTuneSearchEngine._get_sorted_trials(analysis.trials,
-                                                                         metric='mse')))
+                                                                         metric='mse',
+                                                                         mode="min")))
 
         # assert metric name is reported
         assert 'mse' in analysis.trials[0].last_result.keys()
@@ -186,7 +187,8 @@ class TestRayTuneSearchEngine(ZooTestCase):
         assert all(sorted_results[i] <= sorted_results[i+1] for i in range(len(sorted_results)-1))
         # assert _get_best_result get minimum result
         assert RayTuneSearchEngine._get_best_result(analysis.trials,
-                                                    metric='mse')['mse'] == sorted_results[0]
+                                                    metric='mse',
+                                                    mode="min")['mse'] == sorted_results[0]
         # assert the trail stop at once since mse has mode of 'min'
         assert analysis.trials[0].last_result['iterations_since_restore'] == 1
 
@@ -194,11 +196,12 @@ class TestRayTuneSearchEngine(ZooTestCase):
         searcher = prepare_searcher(data=data_with_val,
                                     name='test_searcher_metric_name',
                                     metric='r2',
-                                    recipe=SimpleRecipe(stop_metric=float('-inf')))  # stop at once
+                                    recipe=SimpleRecipe(stop_metric=0))  # stop at once
         analysis = searcher.run()
         sorted_results = list(map(lambda x: x.last_result['r2'],
                                   RayTuneSearchEngine._get_sorted_trials(analysis.trials,
-                                                                         metric='r2')))
+                                                                         metric='r2',
+                                                                         mode="max")))
 
         # assert metric name is reported
         assert 'r2' in analysis.trials[0].last_result.keys()
@@ -206,7 +209,8 @@ class TestRayTuneSearchEngine(ZooTestCase):
         assert all(sorted_results[i] >= sorted_results[i+1] for i in range(len(sorted_results)-1))
         # assert _get_best_result get maximum result
         assert RayTuneSearchEngine._get_best_result(analysis.trials,
-                                                    metric='r2')['r2'] == sorted_results[0]
+                                                    metric='r2',
+                                                    mode="max")['r2'] == sorted_results[0]
         # assert the trail stop at once since mse has mode of 'max'
         assert analysis.trials[0].last_result['iterations_since_restore'] == 1
 
@@ -218,7 +222,8 @@ class TestRayTuneSearchEngine(ZooTestCase):
         analysis = searcher.run()
         sorted_results = list(map(lambda x: x.last_result['mae'],
                                   RayTuneSearchEngine._get_sorted_trials(analysis.trials,
-                                                                         metric='mae')))
+                                                                         metric='mae',
+                                                                         mode="min")))
 
         # assert metric name is reported
         assert 'mae' in analysis.trials[0].last_result.keys()
@@ -226,6 +231,7 @@ class TestRayTuneSearchEngine(ZooTestCase):
         assert all(sorted_results[i] <= sorted_results[i+1] for i in range(len(sorted_results)-1))
         # assert _get_best_result get minimum result
         assert RayTuneSearchEngine._get_best_result(analysis.trials,
-                                                    metric='mae')['mae'] == sorted_results[0]
+                                                    metric='mae',
+                                                    mode="min")['mae'] == sorted_results[0]
         # assert the trail stop at once since mse has mode of 'min'
         assert analysis.trials[0].last_result['iterations_since_restore'] == 20

--- a/pyzoo/test/zoo/automl/searcher/test_ray_tune_search_engine.py
+++ b/pyzoo/test/zoo/automl/searcher/test_ray_tune_search_engine.py
@@ -168,7 +168,8 @@ class TestRayTuneSearchEngine(ZooTestCase):
     def test_searcher_metric(self):
         train_x, train_y, val_x, val_y = get_np_input()
         data_with_val = {'x': train_x, 'y': train_y, 'val_x': val_x, 'val_y': val_y}
-        # test metric name is returned
+
+        # test metric name is returned and max mode can be stopped
         searcher = prepare_searcher(data=data_with_val, 
                                     name='test_searcher_metric_name',
                                     metric='mse',
@@ -194,7 +195,7 @@ class TestRayTuneSearchEngine(ZooTestCase):
         searcher = prepare_searcher(data=data_with_val, 
                                     name='test_searcher_metric_name',
                                     metric='mse',
-                                    recipe=SimpleRecipe(stop_metric=0)) # stop at once
+                                    recipe=SimpleRecipe(stop_metric=0)) # never stop by metric
         analysis = searcher.run()
         # assert metric name is reported
         assert 'mse' in analysis.trials[0].last_result.keys()

--- a/pyzoo/test/zoo/automl/searcher/test_ray_tune_search_engine.py
+++ b/pyzoo/test/zoo/automl/searcher/test_ray_tune_search_engine.py
@@ -171,55 +171,61 @@ class TestRayTuneSearchEngine(ZooTestCase):
         data_with_val = {'x': train_x, 'y': train_y, 'val_x': val_x, 'val_y': val_y}
 
         # test metric name is returned and max mode can be stopped
-        searcher = prepare_searcher(data=data_with_val, 
+        searcher = prepare_searcher(data=data_with_val,
                                     name='test_searcher_metric_name',
                                     metric='mse',
-                                    recipe=SimpleRecipe(stop_metric=float('inf'))) # stop at once
+                                    recipe=SimpleRecipe(stop_metric=float('inf')))  # stop at once
         analysis = searcher.run()
-        sorted_results = list(map(lambda x:x.last_result['mse'],
-                                 RayTuneSearchEngine._get_sorted_trials(analysis.trials,metric='mse')))
+        sorted_results = list(map(lambda x: x.last_result['mse'],
+                                  RayTuneSearchEngine._get_sorted_trials(analysis.trials,
+                                                                         metric='mse')))
 
         # assert metric name is reported
         assert 'mse' in analysis.trials[0].last_result.keys()
         # assert _get_sorted_trials get increasing result
-        assert all(sorted_results[i]<=sorted_results[i+1] for i in range(len(sorted_results)-1))
+        assert all(sorted_results[i] <= sorted_results[i+1] for i in range(len(sorted_results)-1))
         # assert _get_best_result get minimum result
-        assert RayTuneSearchEngine._get_best_result(analysis.trials, metric='mse')['mse'] == sorted_results[0]
+        assert RayTuneSearchEngine._get_best_result(analysis.trials,
+                                                    metric='mse')['mse'] == sorted_results[0]
         # assert the trail stop at once since mse has mode of 'min'
         assert analysis.trials[0].last_result['iterations_since_restore'] == 1
 
         # max mode metric with stop
-        searcher = prepare_searcher(data=data_with_val, 
+        searcher = prepare_searcher(data=data_with_val,
                                     name='test_searcher_metric_name',
                                     metric='r2',
-                                    recipe=SimpleRecipe(stop_metric=float('-inf'))) # stop at once
+                                    recipe=SimpleRecipe(stop_metric=float('-inf')))  # stop at once
         analysis = searcher.run()
-        sorted_results = list(map(lambda x:x.last_result['r2'],
-                                 RayTuneSearchEngine._get_sorted_trials(analysis.trials, metric='r2')))
+        sorted_results = list(map(lambda x: x.last_result['r2'],
+                                  RayTuneSearchEngine._get_sorted_trials(analysis.trials,
+                                                                         metric='r2')))
 
         # assert metric name is reported
         assert 'r2' in analysis.trials[0].last_result.keys()
         # assert _get_sorted_trials get decreasing result
-        assert all(sorted_results[i]>=sorted_results[i+1] for i in range(len(sorted_results)-1))
+        assert all(sorted_results[i] >= sorted_results[i+1] for i in range(len(sorted_results)-1))
         # assert _get_best_result get maximum result
-        assert RayTuneSearchEngine._get_best_result(analysis.trials, metric='r2')['r2'] == sorted_results[0]
+        assert RayTuneSearchEngine._get_best_result(analysis.trials,
+                                                    metric='r2')['r2'] == sorted_results[0]
         # assert the trail stop at once since mse has mode of 'max'
         assert analysis.trials[0].last_result['iterations_since_restore'] == 1
 
         # test min mode metric without stop
-        searcher = prepare_searcher(data=data_with_val, 
+        searcher = prepare_searcher(data=data_with_val,
                                     name='test_searcher_metric_name',
                                     metric='mae',
-                                    recipe=SimpleRecipe(stop_metric=0)) # never stop by metric
+                                    recipe=SimpleRecipe(stop_metric=0))  # never stop by metric
         analysis = searcher.run()
-        sorted_results = list(map(lambda x:x.last_result['mae'],
-                                 RayTuneSearchEngine._get_sorted_trials(analysis.trials,metric='mae')))
+        sorted_results = list(map(lambda x: x.last_result['mae'],
+                                  RayTuneSearchEngine._get_sorted_trials(analysis.trials,
+                                                                         metric='mae')))
 
         # assert metric name is reported
         assert 'mae' in analysis.trials[0].last_result.keys()
         # assert _get_sorted_trials get increasing result
-        assert all(sorted_results[i]<=sorted_results[i+1] for i in range(len(sorted_results)-1))
+        assert all(sorted_results[i] <= sorted_results[i+1] for i in range(len(sorted_results)-1))
         # assert _get_best_result get minimum result
-        assert RayTuneSearchEngine._get_best_result(analysis.trials, metric='mae')['mae'] == sorted_results[0]
+        assert RayTuneSearchEngine._get_best_result(analysis.trials,
+                                                    metric='mae')['mae'] == sorted_results[0]
         # assert the trail stop at once since mse has mode of 'min'
         assert analysis.trials[0].last_result['iterations_since_restore'] == 20

--- a/pyzoo/test/zoo/automl/searcher/test_ray_tune_search_engine.py
+++ b/pyzoo/test/zoo/automl/searcher/test_ray_tune_search_engine.py
@@ -93,7 +93,6 @@ def prepare_searcher(data,
                      model_create_func=modelBuilder,
                      recipe=recipe,
                      feature_transformers=feature_transformer,
-                     search_space=search_space,
                      metric=metric)
     return searcher
 

--- a/pyzoo/test/zoo/automl/searcher/test_ray_tune_search_engine.py
+++ b/pyzoo/test/zoo/automl/searcher/test_ray_tune_search_engine.py
@@ -16,6 +16,7 @@
 
 from test.zoo.pipeline.utils.test_utils import ZooTestCase
 from zoo.automl.search import SearchEngineFactory
+from zoo.automl.search.ray_tune_search_engine import RayTuneSearchEngine
 from zoo.automl.model import PytorchModelBuilder
 from zoo.zouwu.model.VanillaLSTM_pytorch import model_creator as LSTM_model_creator
 import torch
@@ -175,29 +176,50 @@ class TestRayTuneSearchEngine(ZooTestCase):
                                     metric='mse',
                                     recipe=SimpleRecipe(stop_metric=float('inf'))) # stop at once
         analysis = searcher.run()
+        sorted_results = list(map(lambda x:x.last_result['mse'],
+                                 RayTuneSearchEngine._get_sorted_trials(analysis.trials,metric='mse')))
+
         # assert metric name is reported
         assert 'mse' in analysis.trials[0].last_result.keys()
+        # assert _get_sorted_trials get increasing result
+        assert all(sorted_results[i]<=sorted_results[i+1] for i in range(len(sorted_results)-1))
+        # assert _get_best_result get minimum result
+        assert RayTuneSearchEngine._get_best_result(analysis.trials, metric='mse')['mse'] == sorted_results[0]
         # assert the trail stop at once since mse has mode of 'min'
         assert analysis.trials[0].last_result['iterations_since_restore'] == 1
 
-        # test max mode metric with stop
+        # max mode metric with stop
         searcher = prepare_searcher(data=data_with_val, 
                                     name='test_searcher_metric_name',
                                     metric='r2',
                                     recipe=SimpleRecipe(stop_metric=float('-inf'))) # stop at once
         analysis = searcher.run()
+        sorted_results = list(map(lambda x:x.last_result['r2'],
+                                 RayTuneSearchEngine._get_sorted_trials(analysis.trials, metric='r2')))
+
         # assert metric name is reported
         assert 'r2' in analysis.trials[0].last_result.keys()
+        # assert _get_sorted_trials get decreasing result
+        assert all(sorted_results[i]>=sorted_results[i+1] for i in range(len(sorted_results)-1))
+        # assert _get_best_result get maximum result
+        assert RayTuneSearchEngine._get_best_result(analysis.trials, metric='r2')['r2'] == sorted_results[0]
         # assert the trail stop at once since mse has mode of 'max'
         assert analysis.trials[0].last_result['iterations_since_restore'] == 1
 
         # test min mode metric without stop
         searcher = prepare_searcher(data=data_with_val, 
                                     name='test_searcher_metric_name',
-                                    metric='mse',
+                                    metric='mae',
                                     recipe=SimpleRecipe(stop_metric=0)) # never stop by metric
         analysis = searcher.run()
+        sorted_results = list(map(lambda x:x.last_result['mae'],
+                                 RayTuneSearchEngine._get_sorted_trials(analysis.trials,metric='mae')))
+
         # assert metric name is reported
-        assert 'mse' in analysis.trials[0].last_result.keys()
+        assert 'mae' in analysis.trials[0].last_result.keys()
+        # assert _get_sorted_trials get increasing result
+        assert all(sorted_results[i]<=sorted_results[i+1] for i in range(len(sorted_results)-1))
+        # assert _get_best_result get minimum result
+        assert RayTuneSearchEngine._get_best_result(analysis.trials, metric='mae')['mae'] == sorted_results[0]
         # assert the trail stop at once since mse has mode of 'min'
         assert analysis.trials[0].last_result['iterations_since_restore'] == 20

--- a/pyzoo/test/zoo/automl/searcher/test_ray_tune_search_engine.py
+++ b/pyzoo/test/zoo/automl/searcher/test_ray_tune_search_engine.py
@@ -188,6 +188,8 @@ class TestRayTuneSearchEngine(ZooTestCase):
         assert RayTuneSearchEngine._get_best_result(analysis.trials,
                                                     metric='mse',
                                                     mode="min")['mse'] == sorted_results[0]
+        assert all(analysis.trials[i].last_result['mse'] >=
+                   analysis.trials[i].last_result['best_mse'] for i in range(len(sorted_results)))
         # assert the trail stop at once since mse has mode of 'min'
         assert analysis.trials[0].last_result['iterations_since_restore'] == 1
 
@@ -210,6 +212,8 @@ class TestRayTuneSearchEngine(ZooTestCase):
         assert RayTuneSearchEngine._get_best_result(analysis.trials,
                                                     metric='r2',
                                                     mode="max")['r2'] == sorted_results[0]
+        assert all(analysis.trials[i].last_result['r2'] <=
+                   analysis.trials[i].last_result['best_r2'] for i in range(len(sorted_results)))
         # assert the trail stop at once since mse has mode of 'max'
         assert analysis.trials[0].last_result['iterations_since_restore'] == 1
 
@@ -232,5 +236,7 @@ class TestRayTuneSearchEngine(ZooTestCase):
         assert RayTuneSearchEngine._get_best_result(analysis.trials,
                                                     metric='mae',
                                                     mode="min")['mae'] == sorted_results[0]
+        assert all(analysis.trials[i].last_result['mae'] >=
+                   analysis.trials[i].last_result['best_mae'] for i in range(len(sorted_results)))
         # assert the trail stop at once since mse has mode of 'min'
         assert analysis.trials[0].last_result['iterations_since_restore'] == 20

--- a/pyzoo/zoo/automl/common/parameters.py
+++ b/pyzoo/zoo/automl/common/parameters.py
@@ -19,4 +19,4 @@ DEFAULT_PPL_DIR = "./saved_pipeline"
 DEFAULT_CONFIG_DIR = "./saved_configs"
 
 # reward metric in tune reporter
-REWARD_METRIC = "reward_metric"
+# REWARD_METRIC = "reward_metric"

--- a/pyzoo/zoo/automl/common/parameters.py
+++ b/pyzoo/zoo/automl/common/parameters.py
@@ -17,6 +17,3 @@
 # where pipeline saves file by default
 DEFAULT_PPL_DIR = "./saved_pipeline"
 DEFAULT_CONFIG_DIR = "./saved_configs"
-
-# reward metric in tune reporter
-# REWARD_METRIC = "reward_metric"

--- a/pyzoo/zoo/automl/logger/tensorboardxlogger.py
+++ b/pyzoo/zoo/automl/logger/tensorboardxlogger.py
@@ -64,7 +64,7 @@ class TensorboardXLogger():
         else:
             self._file_writer = SummaryWriter(logdir=self.logs_dir)
 
-    def run(self, config, metric):
+    def run(self, config, metric, logo_str="AutoML"):
         '''
         Write log files(event files)
 
@@ -98,7 +98,7 @@ class TensorboardXLogger():
             new_config[key] = {}
             for k, value in config[key].items():
                 if value is not None:
-                    new_config[key]['AutoTS/' + k] = value
+                    new_config[key][f'{logo_str}/' + k] = value
 
         new_metric = {}
         for key in metric.keys():
@@ -107,7 +107,7 @@ class TensorboardXLogger():
                 if not isinstance(value, list):
                     value = [value]
                 if type(value[-1]) in VALID_SUMMARY_TYPES and not np.isnan(value[-1]):
-                    new_metric[key]['AutoTS/' + k] = value
+                    new_metric[key][f'{logo_str}/' + k] = value
 
         # hparams log write
         for key in new_metric.keys():

--- a/pyzoo/zoo/automl/logger/tensorboardxlogger.py
+++ b/pyzoo/zoo/automl/logger/tensorboardxlogger.py
@@ -47,7 +47,7 @@ VALID_SUMMARY_TYPES = (int, float, np.float32, np.float64, np.int32)
 
 
 class TensorboardXLogger():
-    def __init__(self, logs_dir="", writer=None):
+    def __init__(self, logs_dir="", writer=None, name="AutoML"):
         '''
         Initialize a tensorboard logger
 
@@ -58,13 +58,14 @@ class TensorboardXLogger():
         :param writer: shared tensorboardx SummaryWriter, default to None.
         '''
         self.logs_dir = logs_dir
+        self.name = name
         self._file_writer = None
         if writer:
             self._file_writer = writer
         else:
             self._file_writer = SummaryWriter(logdir=self.logs_dir)
 
-    def run(self, config, metric, logo_str="AutoML"):
+    def run(self, config, metric):
         '''
         Write log files(event files)
 
@@ -98,7 +99,7 @@ class TensorboardXLogger():
             new_config[key] = {}
             for k, value in config[key].items():
                 if value is not None:
-                    new_config[key][f'{logo_str}/' + k] = value
+                    new_config[key][f'{self.name}/' + k] = value
 
         new_metric = {}
         for key in metric.keys():
@@ -107,7 +108,7 @@ class TensorboardXLogger():
                 if not isinstance(value, list):
                     value = [value]
                 if type(value[-1]) in VALID_SUMMARY_TYPES and not np.isnan(value[-1]):
-                    new_metric[key][f'{logo_str}/' + k] = value
+                    new_metric[key][f'{self.name}/' + k] = value
 
         # hparams log write
         for key in new_metric.keys():

--- a/pyzoo/zoo/automl/regression/base_predictor.py
+++ b/pyzoo/zoo/automl/regression/base_predictor.py
@@ -111,6 +111,7 @@ class BasePredictor(object):
         else:
             upload_dir = None
 
+        self.metric = metric
         self.pipeline = self._hp_search(
             input_df,
             validation_df=validation_df,
@@ -201,7 +202,7 @@ class BasePredictor(object):
 
     def _make_pipeline(self, analysis, feature_transformers, model,
                        remote_dir):
-        metric = "reward_metric"
+        metric = self.metric
         best_config = analysis.get_best_config(metric=metric, mode="max")
         best_logdir = analysis.get_best_logdir(metric=metric, mode="max")
         print("best log dir is ", best_logdir)

--- a/pyzoo/zoo/automl/regression/base_predictor.py
+++ b/pyzoo/zoo/automl/regression/base_predictor.py
@@ -203,10 +203,11 @@ class BasePredictor(object):
     def _make_pipeline(self, analysis, feature_transformers, model,
                        remote_dir):
         metric = self.metric
-        best_config = analysis.get_best_config(metric=metric, mode="max")
-        best_logdir = analysis.get_best_logdir(metric=metric, mode="max")
+        mode = Evaluator.get_metric_mode(metric)
+        best_config = analysis.get_best_config(metric=metric, mode=mode)
+        best_logdir = analysis.get_best_logdir(metric=metric, mode=mode)
         print("best log dir is ", best_logdir)
-        dataframe = analysis.dataframe(metric=metric, mode="max")
+        dataframe = analysis.dataframe(metric=metric, mode=mode)
         # print(dataframe)
         model_path = os.path.join(best_logdir, dataframe["checkpoint"].iloc[0])
         config = convert_bayes_configs(best_config).copy()

--- a/pyzoo/zoo/automl/search/ray_tune_search_engine.py
+++ b/pyzoo/zoo/automl/search/ray_tune_search_engine.py
@@ -143,12 +143,12 @@ class RayTuneSearchEngine(SearchEngine):
                 self._stop = stop
 
             def __call__(self, trial_id, result):
-                if self._metric in result.keys():
+                if self._metric in self._stop.keys():
                     if self._mode == "max" and result[self._metric] >= self._stop[self._metric]:
                         return True
                     if self._mode == "min" and result[self._metric] <= self._stop[self._metric]:
                         return True
-                if "training_iteration" in result.keys():
+                if "training_iteration" in self._stop.keys():
                     if result["training_iteration"] >= self._stop["training_iteration"]:
                         return True
                 return False

--- a/pyzoo/zoo/automl/search/ray_tune_search_engine.py
+++ b/pyzoo/zoo/automl/search/ray_tune_search_engine.py
@@ -257,7 +257,7 @@ class RayTuneSearchEngine(SearchEngine):
     @staticmethod
     def _get_best_trial(trial_list, metric):
         """Retrieve the best trial."""
-        mode = Evaluator.get_metric_mode(metric) == "max" else "min"
+        mode = Evaluator.get_metric_mode(metric)
         if mode == "max":
             return max(trial_list, key=lambda trial: trial.last_result.get(metric, 0))
         else:

--- a/pyzoo/zoo/automl/search/ray_tune_search_engine.py
+++ b/pyzoo/zoo/automl/search/ray_tune_search_engine.py
@@ -437,7 +437,7 @@ class RayTuneSearchEngine(SearchEngine):
                 if mode == "max":
                     has_best_reward = best_reward is None or reward > best_reward
                 else:
-                    has_best_reward = best_reward is None or reward > best_reward
+                    has_best_reward = best_reward is None or reward < best_reward
 
                 if has_best_reward:
                     best_reward = reward

--- a/pyzoo/zoo/automl/search/ray_tune_search_engine.py
+++ b/pyzoo/zoo/automl/search/ray_tune_search_engine.py
@@ -119,7 +119,7 @@ class RayTuneSearchEngine(SearchEngine):
                 validation_data = {"x": data["val_x"], "y": data["val_y"]}
             else:
                 validation_data = None
-        
+
         # metric and metric's mode
         self.metric = metric
         self.mode = Evaluator.get_metric_mode(metric)
@@ -134,7 +134,7 @@ class RayTuneSearchEngine(SearchEngine):
         if "reward_metric" in stop.keys():
             stop[self.metric] = stop["reward_metric"]
             del stop["reward_metric"]
-        
+
         # stopper
         class TrailStopper(Stopper):
             def __init__(self, stop, metric, mode):
@@ -152,7 +152,7 @@ class RayTuneSearchEngine(SearchEngine):
                     if result["training_iteration"] >= self._stop["training_iteration"]:
                         return True
                 return False
-            
+
             def stop_all(self):
                 return False
 
@@ -434,7 +434,9 @@ class RayTuneSearchEngine(SearchEngine):
                 report_dict = {"training_iteration": i,
                                metric: metric_value,
                                "checkpoint": checkpoint_filename,
-                               "best_" + metric: best_reward_m if Evaluator.get_metric_mode(metric) == "max" else -best_reward_m}
+                               "best_" + metric: best_reward_m
+                               if Evaluator.get_metric_mode(metric) == "max"
+                               else -best_reward_m}
                 tune.report(**report_dict)
 
         return train_func

--- a/pyzoo/zoo/automl/search/ray_tune_search_engine.py
+++ b/pyzoo/zoo/automl/search/ray_tune_search_engine.py
@@ -413,7 +413,7 @@ class RayTuneSearchEngine(SearchEngine):
                 report_dict = {"training_iteration": i,
                                metric: metric_value,
                                "checkpoint": checkpoint_filename,
-                               "Best " + metric: best_reward_m if Evaluator.get_metric_mode(metric) == "max" else -best_reward_m}
+                               "best_" + metric: best_reward_m if Evaluator.get_metric_mode(metric) == "max" else -best_reward_m}
                 tune.report(**report_dict)
 
         return train_func

--- a/pyzoo/zoo/automl/search/ray_tune_search_engine.py
+++ b/pyzoo/zoo/automl/search/ray_tune_search_engine.py
@@ -260,7 +260,9 @@ class RayTuneSearchEngine(SearchEngine):
         # catch the ImportError Since it has been processed in TensorboardXLogger
         tf_config, tf_metric = self._log_adapt(analysis)
 
-        self.logger = TensorboardXLogger(os.path.join(self.logs_dir, self.name+"_leaderboard"))
+        self.logger = TensorboardXLogger(logs_dir=os.path.join(self.logs_dir,
+                                                               self.name+"_leaderboard"),
+                                         name=self.name)
         self.logger.run(tf_config, tf_metric)
         self.logger.close()
 

--- a/pyzoo/zoo/automl/search/ray_tune_search_engine.py
+++ b/pyzoo/zoo/automl/search/ray_tune_search_engine.py
@@ -51,7 +51,7 @@ class RayTuneSearchEngine(SearchEngine):
         self.pipeline = None
         self.train_func = None
         self.trainable_class = None
-        self.resources_per_trail = resources_per_trial
+        self.resources_per_trial = resources_per_trial
         self.trials = None
         self.remote_dir = remote_dir
         self.name = name
@@ -258,7 +258,7 @@ class RayTuneSearchEngine(SearchEngine):
             search_alg=self._search_alg,
             num_samples=self.num_samples,
             scheduler=self._scheduler,
-            resources_per_trial=self.resources_per_trail,
+            resources_per_trial=self.resources_per_trial,
             verbose=1,
             reuse_actors=True
         )

--- a/pyzoo/zoo/automl/search/ray_tune_search_engine.py
+++ b/pyzoo/zoo/automl/search/ray_tune_search_engine.py
@@ -257,14 +257,18 @@ class RayTuneSearchEngine(SearchEngine):
     @staticmethod
     def _get_best_trial(trial_list, metric):
         """Retrieve the best trial."""
-        return max(trial_list, key=lambda trial: trial.last_result.get(metric, 0))
+        mode = Evaluator.get_metric_mode(metric) == "max" else "min"
+        if mode == "max":
+            return max(trial_list, key=lambda trial: trial.last_result.get(metric, 0))
+        else:
+            return min(trial_list, key=lambda trial: trial.last_result.get(metric, 0))
 
     @staticmethod
     def _get_sorted_trials(trial_list, metric):
         return sorted(
             trial_list,
             key=lambda trial: trial.last_result.get(metric, 0),
-            reverse=True)
+            reverse=True if Evaluator.get_metric_mode(metric) == "max" else False)
 
     @staticmethod
     def _get_best_result(trial_list, metric):

--- a/pyzoo/zoo/automl/search/ray_tune_search_engine.py
+++ b/pyzoo/zoo/automl/search/ray_tune_search_engine.py
@@ -143,7 +143,7 @@ class RayTuneSearchEngine(SearchEngine):
         stop.setdefault("training_iteration", 1)
 
         # stopper
-        class TrailStopper(Stopper):
+        class TrialStopper(Stopper):
             def __init__(self, stop, metric, mode):
                 self._mode = mode
                 self._metric = metric
@@ -163,7 +163,7 @@ class RayTuneSearchEngine(SearchEngine):
             def stop_all(self):
                 return False
 
-        self.stopper = TrailStopper(stop=stop, metric=self.metric, mode=self.mode)
+        self.stopper = TrialStopper(stop=stop, metric=self.metric, mode=self.mode)
 
         if search_space is None:
             search_space = recipe.search_space()


### PR DESCRIPTION
Changes in this PR:

- pyzoo/test/zoo/automl/searcher/test_ray_tune_search_engine.py:
1. Test if specified metric name is used in results
2. Test if metrics' mode (max/min) is correctly handled in `stop`, `_get_sorted_trials ` and `_get_best_result`

- pyzoo/zoo/automl/common/parameters.py:
1. No need for fixed `REWARD_METRIC`

- pyzoo/zoo/automl/logger/tensorboardxlogger.py:
1. Add a `logo_str` param to decoupling AutoTS and AutoML

- pyzoo/zoo/automl/regression/base_predictor.py:
1. Change all the mode parameters from "max" to specified metric's mode

- pyzoo/zoo/automl/search/ray_tune_search_engine.py:
1. Change all the metric name from "reward_metric" to specified metric name
2. Change `tune.track` to `tune.report`
3. Make sure the `best.ckpt` is saved for the iteration with best metric
4. Implement an internal customized stopper to handle the max/min mode