### PR TITLE
Remove feature selection and use all features as default

### DIFF
--- a/pyzoo/test/zoo/automl/searcher/test_ray_tune_search_engine.py
+++ b/pyzoo/test/zoo/automl/searcher/test_ray_tune_search_engine.py
@@ -125,7 +125,9 @@ class TestRayTuneSearchEngine(ZooTestCase):
     def test_numpy_input(self):
         train_x, train_y, val_x, val_y = get_np_input()
         data_with_val = {'x': train_x, 'y': train_y, 'val_x': val_x, 'val_y': val_y}
-        searcher = prepare_searcher(data=data_with_val, name='test_ray_numpy_with_val')
+        searcher = prepare_searcher(data=data_with_val,
+                                    name='test_ray_numpy_with_val',
+                                    recipe=SimpleRecipe())
         searcher.run()
         best_trials = searcher.get_best_trials(k=1)
         assert best_trials is not None

--- a/pyzoo/test/zoo/orca/automl/autoestimator/test_autoestimator_keras.py
+++ b/pyzoo/test/zoo/orca/automl/autoestimator/test_autoestimator_keras.py
@@ -46,7 +46,7 @@ def get_train_val_data():
 
 
 class LinearRecipe(Recipe):
-    def search_space(self, all_available_features):
+    def search_space(self):
         from zoo.orca.automl import hp
         return {
             "hidden_size": hp.choice([5, 10]),

--- a/pyzoo/test/zoo/orca/automl/autoestimator/test_autoestimator_pytorch.py
+++ b/pyzoo/test/zoo/orca/automl/autoestimator/test_autoestimator_pytorch.py
@@ -77,7 +77,7 @@ def get_train_val_data():
 
 
 class LinearRecipe(Recipe):
-    def search_space(self, all_available_features):
+    def search_space(self):
         from zoo.orca.automl import hp
         return {
             "dropout": hp.uniform(0.2, 0.3),

--- a/pyzoo/test/zoo/zouwu/config/test_recipe.py
+++ b/pyzoo/test/zoo/zouwu/config/test_recipe.py
@@ -42,37 +42,27 @@ class TestTimeSequencePredictor(ZooTestCase):
 
     def test_GridRandomRecipe(self):
         recipe = GridRandomRecipe(num_rand_samples=100)
-        search_space = recipe.search_space(
-            all_available_features=[
-                "f1", "f2", "f3", "target1", "target2"])
+        search_space = recipe.search_space()
         assert search_space is not None
 
     def test_RandomRecipe(self):
         recipe = GridRandomRecipe(num_rand_samples=100)
-        search_space = recipe.search_space(
-            all_available_features=[
-                "f1", "f2", "f3", "target1", "target2"])
+        search_space = recipe.search_space()
         assert search_space is not None
 
     def test_LSTMGridRandomRecipe(self):
         recipe = LSTMGridRandomRecipe(num_rand_samples=100)
-        search_space = recipe.search_space(
-            all_available_features=[
-                "f1", "f2", "f3", "target1", "target2"])
+        search_space = recipe.search_space()
         assert search_space is not None
 
     def test_MTNetGridRandomRecipe(self):
         recipe = MTNetGridRandomRecipe()
-        search_space = recipe.search_space(
-            all_available_features=[
-                "f1", "f2", "f3", "target1", "target2"])
+        search_space = recipe.search_space()
         assert search_space is not None
 
     def test_BayesRecipe(self):
         recipe = BayesRecipe(num_samples=10)
-        search_space = recipe.search_space(
-            all_available_features=[
-                "f1", "f2", "f3", "target1", "target2"])
+        search_space = recipe.search_space()
         assert search_space is not None
         assert recipe.reward_metric is not None
 

--- a/pyzoo/zoo/automl/recipe/base.py
+++ b/pyzoo/zoo/automl/recipe/base.py
@@ -29,7 +29,7 @@ class Recipe(metaclass=ABCMeta):
         self.reward_metric = None
 
     @abstractmethod
-    def search_space(self, all_available_features):
+    def search_space(self):
         pass
 
     def runtime_params(self):

--- a/pyzoo/zoo/automl/regression/base_predictor.py
+++ b/pyzoo/zoo/automl/regression/base_predictor.py
@@ -164,15 +164,10 @@ class BasePredictor(object):
                    resources_per_trial,
                    remote_dir):
         ft = self.create_feature_transformer()
-        try:
-            feature_list = ft.get_feature_list()
-        except:
-            feature_list = None
 
         model_fn = self.make_model_fn(resources_per_trial)
 
         # prepare parameters for search engine
-        search_space = recipe.search_space(feature_list)
 
         searcher = RayTuneSearchEngine(logs_dir=self.logs_dir,
                                        resources_per_trial=resources_per_trial,

--- a/pyzoo/zoo/automl/regression/base_predictor.py
+++ b/pyzoo/zoo/automl/regression/base_predictor.py
@@ -176,7 +176,6 @@ class BasePredictor(object):
                                        )
         searcher.compile(data={'df': input_df, 'val_df': validation_df},
                          model_create_func=model_fn,
-                         search_space=search_space,
                          recipe=recipe,
                          search_alg=self.search_alg,
                          search_alg_params=self.search_alg_params,

--- a/pyzoo/zoo/automl/search/ray_tune_search_engine.py
+++ b/pyzoo/zoo/automl/search/ray_tune_search_engine.py
@@ -127,7 +127,7 @@ class RayTuneSearchEngine(SearchEngine):
         del stop['num_samples']
         self.stop_criteria = stop
         if search_space is None:
-            search_space = recipe.search_space(all_available_features=None)
+            search_space = recipe.search_space()
         self._search_alg = RayTuneSearchEngine._set_search_alg(search_alg, search_alg_params,
                                                                recipe, search_space)
         self._scheduler = RayTuneSearchEngine._set_scheduler(scheduler, scheduler_params)

--- a/pyzoo/zoo/examples/automl/plugin_model_demo.py
+++ b/pyzoo/zoo/examples/automl/plugin_model_demo.py
@@ -57,7 +57,7 @@ class SimpleRecipe(Recipe):
         self.num_samples = 2
         self.training_iteration = 20
 
-    def search_space(self, all_available_features):
+    def search_space(self):
         return {
             "lr": hp.uniform(0.01, 0.02),
             "batch_size": hp.choice([16, 32, 64])

--- a/pyzoo/zoo/examples/orca/automl/autoxgboost/AutoXGBoostRegressor.py
+++ b/pyzoo/zoo/examples/orca/automl/autoxgboost/AutoXGBoostRegressor.py
@@ -34,7 +34,7 @@ class XgbSigOptRecipe(Recipe):
 
         self.num_samples = num_rand_samples
 
-    def search_space(self, all_available_features):
+    def search_space(self):
         return dict()
 
 

--- a/pyzoo/zoo/zouwu/config/recipe.py
+++ b/pyzoo/zoo/zouwu/config/recipe.py
@@ -30,9 +30,8 @@ class SmokeRecipe(Recipe):
     def __init__(self):
         super(self.__class__, self).__init__()
 
-    def search_space(self, all_available_features):
+    def search_space(self):
         return {
-            "selected_features": json.dumps(all_available_features),
             "model": "LSTM",
             "lstm_1_units": hp.choice([32, 64]),
             "dropout_1": hp.uniform(0.2, 0.5),
@@ -54,9 +53,8 @@ class MTNetSmokeRecipe(Recipe):
     def __init__(self):
         super(self.__class__, self).__init__()
 
-    def search_space(self, all_available_features):
+    def search_space(self):
         return {
-            "selected_features": json.dumps(all_available_features),
             "model": "MTNet",
             "lr": 0.001,
             "batch_size": 16,
@@ -81,7 +79,7 @@ class TCNSmokeRecipe(Recipe):
     def __init__(self):
         super(self.__class__, self).__init__()
 
-    def search_space(self, all_available_features):
+    def search_space(self):
         return {
             "lr": 0.001,
             "batch_size": 16,
@@ -165,18 +163,8 @@ class GridRandomRecipe(Recipe):
             look_back)
         self.epochs = epochs
 
-    def search_space(self, all_available_features):
+    def search_space(self):
         return {
-            # -------- feature related parameters
-            "selected_features": hp.sample_from(lambda spec:
-                                                json.dumps(
-                                                    list(np.random.choice(
-                                                        all_available_features,
-                                                        size=np.random.randint(
-                                                            low=3,
-                                                            high=len(all_available_features)),
-                                                        replace=False)))),
-
             # -------- model selection TODO add MTNet
             "model": hp.choice(["LSTM", "Seq2seq"]),
 
@@ -242,18 +230,8 @@ class LSTMGridRandomRecipe(Recipe):
         self.batch_size = hp.grid_search(batch_size)
         self.epochs = epochs
 
-    def search_space(self, all_available_features):
+    def search_space(self):
         return {
-            # -------- feature related parameters
-            "selected_features": hp.sample_from(lambda spec:
-                                                json.dumps(
-                                                    list(np.random.choice(
-                                                        all_available_features,
-                                                        size=np.random.randint(
-                                                            low=3,
-                                                            high=len(all_available_features) + 1),
-                                                        replace=False)))),
-
             "model": "LSTM",
 
             # --------- Vanilla LSTM model parameters
@@ -312,18 +290,8 @@ class Seq2SeqRandomRecipe(Recipe):
         self.batch_size = hp.grid_search(batch_size)
         self.epochs = epochs
 
-    def search_space(self, all_available_features):
+    def search_space(self):
         return {
-            # -------- feature related parameters
-            "selected_features": hp.sample_from(lambda spec:
-                                                json.dumps(
-                                                    list(np.random.choice(
-                                                        all_available_features,
-                                                        size=np.random.randint(
-                                                            low=3,
-                                                            high=len(all_available_features) + 1),
-                                                        replace=False)))),
-
             "model": "Seq2Seq",
             "latent_dim": self.latent_dim,
             "dropout": self.dropout_config,
@@ -385,17 +353,8 @@ class MTNetGridRandomRecipe(Recipe):
             lambda spec: (
                 spec.config.long_num + 1) * spec.config.time_step)
 
-    def search_space(self, all_available_features):
+    def search_space(self):
         return {
-            "selected_features": hp.sample_from(lambda spec:
-                                                json.dumps(
-                                                    list(np.random.choice(
-                                                        all_available_features,
-                                                        size=np.random.randint(
-                                                            low=3,
-                                                            high=len(all_available_features)),
-                                                        replace=False)))),
-
             "model": "MTNet",
             "lr": self.lr,
             "batch_size": self.batch_size,
@@ -453,7 +412,7 @@ class TCNGridRandomRecipe(Recipe):
         self.kernel_size = hp.grid_search(kernel_size)
         self.dropout = hp.choice(dropout)
 
-    def search_space(self, all_available_features):
+    def search_space(self):
         return {
             "lr": self.lr,
             "batch_size": self.batch_size,
@@ -494,19 +453,9 @@ class RandomRecipe(Recipe):
         self.past_seq_config = PastSeqParamHandler.get_past_seq_config(
             look_back)
 
-    def search_space(self, all_available_features):
+    def search_space(self):
         import random
         return {
-            # -------- feature related parameters
-            "selected_features": hp.sample_from(lambda spec:
-                                                json.dumps(
-                                                    list(np.random.choice(
-                                                        all_available_features,
-                                                        size=np.random.randint(
-                                                            low=3,
-                                                            high=len(all_available_features)),
-                                                        replace=False)))),
-
             "model": hp.choice(["LSTM", "Seq2seq"]),
             # --------- Vanilla LSTM model parameters
             "lstm_1_units": hp.choice([8, 16, 32, 64, 128]),
@@ -592,11 +541,10 @@ class BayesRecipe(Recipe):
         total_space.update(self.bayes_past_seq_config)
         return total_space
 
-    def search_space(self, all_available_features):
+    def search_space(self):
         total_fixed_params = {
             "epochs": self.epochs,
             "model": "LSTM",
-            "selected_features": json.dumps(all_available_features),
             # "batch_size": 1024,
         }
         total_fixed_params.update(self.fixed_past_seq_config)
@@ -641,7 +589,7 @@ class XgbRegressorGridRandomRecipe(Recipe):
         self.subsample = subsample
         self.min_child_weight = hp.choice(min_child_weight)
 
-    def search_space(self, all_available_features):
+    def search_space(self):
         return {
             # -------- feature related parameters
             "model": "XGBRegressor",
@@ -674,7 +622,7 @@ class XgbRegressorSkOptRecipe(Recipe):
         self.lr = hp.loguniform(lr[0], lr[1])
         self.min_child_weight = hp.choice(min_child_weight)
 
-    def search_space(self, all_available_features):
+    def search_space(self):
         space = {
             "n_estimators": hp.randint(self.n_estimators_range[0],
                                        self.n_estimators_range[1]),

--- a/pyzoo/zoo/zouwu/feature/time_sequence.py
+++ b/pyzoo/zoo/zouwu/feature/time_sequence.py
@@ -554,8 +554,11 @@ class TimeSequenceFeatureTransformer(BaseFeatureTransformer):
 
     def _get_features(self, input_df, config):
         feature_matrix = self._generate_features(input_df)
-        # self.write_generate_feature_list(feature_defs)
-        feature_cols = np.asarray(json.loads(config.get("selected_features")))
+        selected_features = config.get("selected_features")
+        if selected_features:
+            feature_cols = np.asarray(json.loads(selected_features))
+        else:
+            feature_cols = self.get_feature_list()
         # we do not include target col in candidates.
         # the first column is designed to be the default position of target column.
         target_col = np.array(self.target_col)
@@ -564,7 +567,7 @@ class TimeSequenceFeatureTransformer(BaseFeatureTransformer):
         return target_feature_matrix.astype(float)
 
     def _get_optional_parameters(self):
-        return set(["past_seq_len"])
+        return {"past_seq_len", "selected_features"}
 
     def _get_required_parameters(self):
-        return set(["selected_features"])
+        return set()


### PR DESCRIPTION
User used to need including `all_available_features` in `search_space` while customizing a `recipe`. It might be a little confusing since users may only search with their customized models and don't need feature at all.

To improve usability, we remove the parameter and disable feature selection for now. And we will enable feature selection later with a better way to pass necessary parameters to search space in recipe. 