### PR TITLE
disable exception jep

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/common/PythonInterpreter.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/common/PythonInterpreter.scala
@@ -96,7 +96,7 @@ object PythonInterpreter {
     } catch {
       case t: Throwable =>
         // Don't use logger here, or spark local will stuck when catch an exception.
-        println("Warn: " + ExceptionUtils.getStackTrace(t))
+        // println("Warn: " + ExceptionUtils.getStackTrace(t))
         throw new JepException(t)
     }
   }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
@@ -469,6 +469,7 @@ class PythonFeatureSet[T: ClassTag](
                   e.getMessage().contains("is not defined")) {
                   PythonInterpreter.exec(getIteratorCode)
                   PythonInterpreter.exec(nextCode)
+                  FeatureSet.logger.debug("The data has been iterated. Start the next epoch...")
                 } else {
                   throw e
                 }


### PR DESCRIPTION
disable message like:
```
2021-04-23 01:43:37 INFO  DistriOptimizer$:651 - Cache thread models... done
2021-04-23 01:43:37 INFO  DistriOptimizer$:161 - Count dataset
[Stage 7:>                                                          (0 + 1) / 1]Warn: jep.JepException: <class 'StopIteration'>
	at jep.Jep.exec(Native Method)
	at jep.Jep.exec(Jep.java:478)
	at com.intel.analytics.zoo.common.PythonInterpreter$$anonfun$1.apply$mcV$sp(PythonInterpreter.scala:108)
	at com.intel.analytics.zoo.common.PythonInterpreter$$anonfun$1.apply(PythonInterpreter.scala:107)
	at com.intel.analytics.zoo.common.PythonInterpreter$$anonfun$1.apply(PythonInterpreter.scala:107)
	at scala.concurrent.impl.Future$PromiseCompletingRunnable.liftedTree1$1(Future.scala:24)
	at scala.concurrent.impl.Future$PromiseCompletingRunnable.run(Future.scala:24)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```