### PR TITLE
update 0.10.0 release download links for doc websites(readthedocs and github.io)

### DIFF
--- a/docs/docs/release-docs.md
+++ b/docs/docs/release-docs.md
@@ -1,22 +1,8 @@
 
 ---
+## **Release 0.10.0**
+[Analytics-Zoo 0.10.0 Docs](https://analytics-zoo.github.io/0.10.0)
 ## **Release 0.9.0**
 [Analytics-Zoo 0.9.0 Docs](https://analytics-zoo.github.io/0.9.0)
-## **Release 0.8.1**
-[Analytics-Zoo 0.8.1 Docs](https://analytics-zoo.github.io/0.8.1)
-## **Release 0.7.0**
-[Analytics-Zoo 0.7.0 Docs](https://analytics-zoo.github.io/0.7.0)
-## **Release 0.6.0**
-[Analytics-Zoo 0.6.0 Docs](https://analytics-zoo.github.io/0.6.0)
-## **Release 0.5.1**
-[Analytics-Zoo 0.5.1 Docs](https://analytics-zoo.github.io/0.5.1)
-## **Release 0.4.0**
-[Analytics-Zoo 0.4.0 Docs](https://analytics-zoo.github.io/0.4.0)
-## **Release 0.3.0**
-[Analytics-Zoo 0.3.0 Docs](https://analytics-zoo.github.io/0.3.0)
-## **Release 0.2.0**
-[Analytics-Zoo 0.2.0 Docs](https://analytics-zoo.github.io/0.2.0)
-## **Release 0.1.0**
-[Analytics-Zoo 0.1.0 Docs](https://analytics-zoo.github.io/0.1.0)
 
 

--- a/docs/docs/release-download.md
+++ b/docs/docs/release-download.md
@@ -1,3 +1,14 @@
+## **Release 0.11.0 nightly build**
+
+| | BigDL 0.12.2 | 
+| ------------- | --------- |
+| Spark 2.1.1   | [download](https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.1.1/0.11.0-SNAPSHOT/)|
+| Spark 2.2.1   | [download](https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.2.1/0.11.0-SNAPSHOT/)|
+| Spark 2.3.1   | [download](https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.3.1/0.11.0-SNAPSHOT/)|
+| Spark 2.4.3   | [download](https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.4.3/0.11.0-SNAPSHOT/)|
+| Spark 3.0.0   | [download](https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_3.0.0/0.11.0-SNAPSHOT/)|
+
+---
 ## **Release 0.10.0**
 
 | | BigDL 0.12.2 | 

--- a/docs/docs/release-download.md
+++ b/docs/docs/release-download.md
@@ -1,12 +1,12 @@
-## **Release 0.10.0 nightly build**
+## **Release 0.10.0**
 
 | | BigDL 0.12.2 | 
 | ------------- | --------- |
-| Spark 2.1.1   | [download](https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.1.1/0.10.0-SNAPSHOT/)|
-| Spark 2.2.1   | [download](https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.2.1/0.10.0-SNAPSHOT/)|
-| Spark 2.3.1   | [download](https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.3.1/0.10.0-SNAPSHOT/)|
-| Spark 2.4.3   | [download](https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.4.3/0.10.0-SNAPSHOT/)|
-| Spark 3.0.0   | [download](https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_3.0.0/0.10.0-SNAPSHOT/)|
+| Spark 2.1.1   | [download](https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.1.1/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.1.1-0.10.0-cluster-serving-all.zip)|
+| Spark 2.2.1   | [download](https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.2.1/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.2.1-0.10.0-cluster-serving-all.zip)|
+| Spark 2.3.1   | [download](https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.3.1/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.3.1-0.10.0-cluster-serving-all.zip)|
+| Spark 2.4.3   | [download](https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.4.3/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.4.3-0.10.0-cluster-serving-all.zip)|
+| Spark 3.0.0   | [download](https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_3.0.0/0.10.0/analytics-zoo-bigdl_0.12.2-spark_3.0.0-0.10.0-cluster-serving-all.zip)|
 
 ---
 ## **Release 0.9.0**

--- a/docs/docs/release-download.md
+++ b/docs/docs/release-download.md
@@ -2,11 +2,11 @@
 
 | | BigDL 0.12.2 | 
 | ------------- | --------- |
-| Spark 2.1.1   | [download](https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.1.1/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.1.1-0.10.0-cluster-serving-all.zip)|
-| Spark 2.2.1   | [download](https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.2.1/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.2.1-0.10.0-cluster-serving-all.zip)|
-| Spark 2.3.1   | [download](https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.3.1/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.3.1-0.10.0-cluster-serving-all.zip)|
-| Spark 2.4.3   | [download](https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.4.3/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.4.3-0.10.0-cluster-serving-all.zip)|
-| Spark 3.0.0   | [download](https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_3.0.0/0.10.0/analytics-zoo-bigdl_0.12.2-spark_3.0.0-0.10.0-cluster-serving-all.zip)|
+| Spark 2.1.1   | [download](https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.1.1/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.1.1-0.10.0-dist-all.zip)|
+| Spark 2.2.1   | [download](https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.2.1/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.2.1-0.10.0-dist-all.zip)|
+| Spark 2.3.1   | [download](https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.3.1/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.3.1-0.10.0-dist-all.zip)|
+| Spark 2.4.3   | [download](https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.4.3/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.4.3-0.10.0-dist-all.zip)|
+| Spark 3.0.0   | [download](https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_3.0.0/0.10.0/analytics-zoo-bigdl_0.12.2-spark_3.0.0-0.10.0-dist-all.zip)|
 
 ---
 ## **Release 0.9.0**

--- a/docs/readthedocs/source/doc/release.md
+++ b/docs/readthedocs/source/doc/release.md
@@ -1,5 +1,36 @@
 # Release Download
 
+- **Release 0.11.0 nightly build**
+<table border="1"
+cellpadding="10"
+>
+    <tr>
+        <td></td>
+        <td>BigDL 0.12.2</td>
+    </tr>
+    <tr>
+        <td>Spark 2.1.1 </td>
+        <td><a href="https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.1.1/0.11.0-SNAPSHOT/">download</a></td>
+    </tr>
+    <tr>
+       <td>Spark 2.2.1 </td>
+       <td><a href="https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.2.1/0.11.0-SNAPSHOT/">download</a></td>    
+   </tr>
+    <tr>
+       <td>Spark 2.3.1 </td>
+       <td><a href="https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.3.1/0.11.0-SNAPSHOT/">download</a></td> 
+    </tr>
+    <tr>
+       <td>Spark 2.4.3 </td>
+       <td><a href="https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.4.3/0.11.0-SNAPSHOT/">download</a></td> 
+    </tr>
+    <tr>
+       <td>Spark 3.0.0 </td>
+       <td><a href="https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_3.0.0/0.11.0-SNAPSHOT/">download</a></td> 
+    </tr>
+</table>
+<br>
+
 - **Release 0.10.0**
 <table border="1"
 cellpadding="10"

--- a/docs/readthedocs/source/doc/release.md
+++ b/docs/readthedocs/source/doc/release.md
@@ -10,23 +10,23 @@ cellpadding="10"
     </tr>
     <tr>
         <td>Spark 2.1.1 </td>
-        <td><a href="https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.1.1/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.1.1-0.10.0-cluster-serving-all.zip">download</a></td>
+        <td><a href="https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.1.1/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.1.1-0.10.0-dist-all.zip">download</a></td>
     </tr>
     <tr>
        <td>Spark 2.2.1 </td>
-       <td><a href="https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.2.1/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.2.1-0.10.0-cluster-serving-all.zip">download</a></td>    
+       <td><a href="https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.2.1/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.2.1-0.10.0-dist-all.zip">download</a></td>    
    </tr>
     <tr>
        <td>Spark 2.3.1 </td>
-       <td><a href="https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.3.1/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.3.1-0.10.0-cluster-serving-all.zip">download</a></td> 
+       <td><a href="https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.3.1/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.3.1-0.10.0-dist-all.zip">download</a></td> 
     </tr>
     <tr>
        <td>Spark 2.4.3 </td>
-       <td><a href="https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.4.3/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.4.3-0.10.0-cluster-serving-all.zip">download</a></td> 
+       <td><a href="https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.4.3/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.4.3-0.10.0-dist-all.zip">download</a></td> 
     </tr>
     <tr>
        <td>Spark 3.0.0 </td>
-       <td><a href="https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_3.0.0/0.10.0/analytics-zoo-bigdl_0.12.2-spark_3.0.0-0.10.0-cluster-serving-all.zip">download</a></td> 
+       <td><a href="https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_3.0.0/0.10.0/analytics-zoo-bigdl_0.12.2-spark_3.0.0-0.10.0-dist-all.zip">download</a></td> 
     </tr>
 </table>
 <br>

--- a/docs/readthedocs/source/doc/release.md
+++ b/docs/readthedocs/source/doc/release.md
@@ -1,6 +1,6 @@
 # Release Download
 
-- **Release 0.10.0 nightly build**
+- **Release 0.10.0**
 <table border="1"
 cellpadding="10"
 >
@@ -10,23 +10,23 @@ cellpadding="10"
     </tr>
     <tr>
         <td>Spark 2.1.1 </td>
-        <td><a href="https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.1.1/0.10.0-SNAPSHOT/">download</a></td>
+        <td><a href="https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.1.1/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.1.1-0.10.0-cluster-serving-all.zip">download</a></td>
     </tr>
     <tr>
        <td>Spark 2.2.1 </td>
-       <td><a href="https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.2.1/0.10.0-SNAPSHOT/">download</a></td>    
+       <td><a href="https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.2.1/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.2.1-0.10.0-cluster-serving-all.zip">download</a></td>    
    </tr>
     <tr>
        <td>Spark 2.3.1 </td>
-       <td><a href="https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.3.1/0.10.0-SNAPSHOT/">download</a></td> 
+       <td><a href="https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.3.1/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.3.1-0.10.0-cluster-serving-all.zip">download</a></td> 
     </tr>
     <tr>
        <td>Spark 2.4.3 </td>
-       <td><a href="https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.4.3/0.10.0-SNAPSHOT/">download</a></td> 
+       <td><a href="https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_2.4.3/0.10.0/analytics-zoo-bigdl_0.12.2-spark_2.4.3-0.10.0-cluster-serving-all.zip">download</a></td> 
     </tr>
     <tr>
        <td>Spark 3.0.0 </td>
-       <td><a href="https://oss.sonatype.org/content/repositories/snapshots/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_3.0.0/0.10.0-SNAPSHOT/">download</a></td> 
+       <td><a href="https://repo1.maven.org/maven2/com/intel/analytics/zoo/analytics-zoo-bigdl_0.12.2-spark_3.0.0/0.10.0/analytics-zoo-bigdl_0.12.2-spark_3.0.0-0.10.0-cluster-serving-all.zip">download</a></td> 
     </tr>
 </table>
 <br>


### PR DESCRIPTION
update 0.10.0 release download links in 
1.  readthedocs website: update docs/readthedocs/source/doc/release.md
2. github.io: update /docs/docs/release-download.md and  /docs/docs/release-docs.md

PS: This PR also need be backport to branch 0.10.0