### PR TITLE
Refine automl numpy metrics

### DIFF
--- a/pyzoo/test/zoo/zouwu/model/test_Seq2Seq.py
+++ b/pyzoo/test/zoo/zouwu/model/test_Seq2Seq.py
@@ -91,9 +91,8 @@ class TestSeq2Seq(ZooTestCase):
         model.fit_eval(x_train, y_train, **model_config)
         y_pred = model.predict(x_test)
         rmse, smape = model.evaluate(x=x_test, y=y_test, metric=["rmse", "smape"])
-        assert rmse.shape == smape.shape
-        assert rmse.shape == (future_seq_len, output_dim)
-
+        assert rmse is not None
+        assert smape is not None
         assert model.past_seq_len == past_seq_len
         assert model.future_seq_len == future_seq_len
         assert model.feature_num == input_dim

--- a/pyzoo/test/zoo/zouwu/model/test_VanillaLSTM.py
+++ b/pyzoo/test/zoo/zouwu/model/test_VanillaLSTM.py
@@ -49,7 +49,7 @@ class TestVanillaLSTM(TestCase):
         config = {"batch_size": 128}
         self.model.fit_eval(self.train_data[0], self.train_data[1], self.val_data, **config)
         mse, smape = self.model.evaluate(self.val_data[0], self.val_data[1],
-                                         metrics=["mse", "smape"])
+                                         metrics=["mse", "smape"], multioutput="raw_values")
         assert len(mse) == self.val_data[1].shape[-1]
         assert len(smape) == self.val_data[1].shape[-1]
 

--- a/pyzoo/test/zoo/zouwu/pipeline/test_time_sequence.py
+++ b/pyzoo/test/zoo/zouwu/pipeline/test_time_sequence.py
@@ -128,7 +128,7 @@ class TestTimeSequencePipeline(ZooTestCase):
         future_seq_len = np.random.randint(2, 6)
         train_df, test_df, tsp, test_sample_num = self.get_input_tsp(future_seq_len, target_col)
         pipeline = tsp.fit(train_df, test_df)
-        mse, rs = pipeline.evaluate(test_df, metrics=metrics)
+        mse, rs = pipeline.evaluate(test_df, metrics=metrics, multioutput='raw_values')
         assert len(mse) == future_seq_len
         assert len(rs) == future_seq_len
         y_pred = pipeline.predict(test_df)

--- a/pyzoo/zoo/automl/common/metrics.py
+++ b/pyzoo/zoo/automl/common/metrics.py
@@ -66,14 +66,6 @@ def _standardize_input(y_true, y_pred, multioutput):
     if y_true.shape[1] != y_pred.shape[1]:
         raise ValueError("y_true and y_pred have different number of output "
                          "({0}!={1})".format(y_true.shape[1], y_pred.shape[1]))
-    allowed_multioutput_str = ('raw_values', 'uniform_average',
-                               'variance_weighted')
-    if isinstance(multioutput, str):
-        if multioutput not in allowed_multioutput_str:
-            raise ValueError("Allowed 'multioutput' string values are {}. "
-                             "You provided multioutput={!r}"
-                             .format(allowed_multioutput_str, multioutput))
-
     return y_true, y_pred, original_shape
 
 
@@ -349,7 +341,6 @@ class Evaluator(object):
     }
 
     max_mode_metrics = ('r2', 'accuracy')
-    available_multioutput = ('raw_values', 'uniform_average')
 
     @staticmethod
     def evaluate(metric, y_true, y_pred, multioutput='uniform_average'):
@@ -364,9 +355,13 @@ class Evaluator(object):
 
     @staticmethod
     def check_multioutput(multioutput):
-        if multioutput not in Evaluator.available_multioutput:
-            raise ValueError(f"multioutput {multioutput} is not supported. "
-                             f"Please choose from {Evaluator.available_multioutput}")
+        allowed_multioutput_str = ('raw_values', 'uniform_average',
+                                   'variance_weighted')
+        if isinstance(multioutput, str):
+            if multioutput not in allowed_multioutput_str:
+                raise ValueError("Allowed 'multioutput' string values are {}. "
+                                 "You provided multioutput={!r}"
+                                 .format(allowed_multioutput_str, multioutput))
 
     @staticmethod
     def get_metric_mode(metric):

--- a/pyzoo/zoo/automl/model/base_keras_model.py
+++ b/pyzoo/zoo/automl/model/base_keras_model.py
@@ -98,16 +98,19 @@ class KerasBaseModel(BaseModel):
             result = hist.history.get('val_' + metric_name)[-1]
         return result
 
-    def evaluate(self, x, y, metrics=['mse']):
+    def evaluate(self, x, y, metrics=['mse'], multioutput="raw_values"):
         """
         Evaluate on x, y
         :param x: input
         :param y: target
         :param metrics: a list of metrics in string format
+        :param multioutput: string, one of ["raw_values", "uniform_average"]
         :return: a list of metric evaluation results
         """
         y_pred = self.predict(x)
-        return [Evaluator.evaluate(m, y, y_pred) for m in metrics]
+        eval_result = [Evaluator.evaluate(m, y_true=y, y_pred=y_pred, multioutput=multioutput)
+                       for m in metrics]
+        return eval_result
 
     def predict(self, x):
         """

--- a/pyzoo/zoo/zouwu/pipeline/time_sequence.py
+++ b/pyzoo/zoo/zouwu/pipeline/time_sequence.py
@@ -137,7 +137,7 @@ class TimeSequencePipeline(Pipeline):
     def evaluate(self,
                  input_df,
                  metrics=["mse"],
-                 multioutput='raw_values'
+                 multioutput='uniform_average'
                  ):
         """
         evaluate the pipeline


### PR DESCRIPTION
This PR includes:

- add check `multioutput`
- unify default values of `multioutput` as 'uniform_average'
- enhance output for metric `rmse`