### PR TITLE
add support of multi-model

### DIFF
--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/FrontEndApp.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/FrontEndApp.scala
@@ -326,11 +326,11 @@ object FrontEndApp extends Supportive with EncryptSupportive {
                     }
                     servable match {
                       case _: ClusterServingServable =>
-                        val result = timing("cluster serving predict")(predictRequestTimer, modelInferenceTimersMap(modelName)(modelVersion)) {
+                        val result = timing("cluster serving predict")(predictRequestTimer) {
                           val instances = timing("json deserialization")() {
                             JsonUtil.fromJson(classOf[Instances], content)
                           }
-                          val outputs = timing("cluster serving predict total")() {
+                          val outputs = timing("model predict total")(modelInferenceTimersMap(modelName)(modelVersion)) {
                             servable.predict(instances)
                           }
                           Predictions(outputs)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/FrontEndApp.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/FrontEndApp.scala
@@ -326,7 +326,7 @@ object FrontEndApp extends Supportive with EncryptSupportive {
                     }
                     servable match {
                       case _: ClusterServingServable =>
-                        val result = timing("cluster serving predict")(overallRequestTimer, predictRequestTimer) {
+                        val result = timing("cluster serving predict")(overallRequestTimer, predictRequestTimer, modelInferenceTimersMap(modelName)(modelVersion)) {
                           val instances = timing("json deserialization")() {
                             JsonUtil.fromJson(classOf[Instances], content)
                           }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/FrontEndApp.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/FrontEndApp.scala
@@ -326,7 +326,7 @@ object FrontEndApp extends Supportive with EncryptSupportive {
                     }
                     servable match {
                       case _: ClusterServingServable =>
-                        val result = timing("cluster serving predict")(overallRequestTimer, predictRequestTimer, modelInferenceTimersMap(modelName)(modelVersion)) {
+                        val result = timing("cluster serving predict")(predictRequestTimer, modelInferenceTimersMap(modelName)(modelVersion)) {
                           val instances = timing("json deserialization")() {
                             JsonUtil.fromJson(classOf[Instances], content)
                           }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/FrontEndApp.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/FrontEndApp.scala
@@ -280,7 +280,8 @@ object FrontEndApp extends Supportive with EncryptSupportive {
           concat(
             (get & path(Segment)) {
               (modelName) => {
-                timing("get model infos with model name")(overallRequestTimer, servablesRetriveTimer) {
+                timing("get model infos with model name")(overallRequestTimer,
+                  servablesRetriveTimer) {
                   try {
                     val servables = servableManager.retriveServables(modelName)
                     val metaData = servables.map(e => e.getMetaData)
@@ -299,7 +300,8 @@ object FrontEndApp extends Supportive with EncryptSupportive {
               }
             } ~ (get & path(Segment / "versions" / Segment)) {
               (modelName, modelVersion) => {
-                timing("get model info with model name and model version")(overallRequestTimer, servableRetriveTimer) {
+                timing("get model info with model name and model version")(overallRequestTimer,
+                  servableRetriveTimer) {
                   try {
                     val servables = servableManager.retriveServable(modelName, modelVersion)
                     val metaData = servables.getMetaData
@@ -316,7 +318,8 @@ object FrontEndApp extends Supportive with EncryptSupportive {
                   }
                 }
               }
-            } ~ (post & path(Segment / "versions" / Segment / "predict") & extract(_.request.entity.contentType) & entity(as[String])) {
+            } ~ (post & path(Segment / "versions" / Segment / "predict")
+              & extract(_.request.entity.contentType) & entity(as[String])) {
               (modelName, modelVersion, contentType, content) => {
                 timing("backend inference timing")(overallRequestTimer, backendInferenceTimer) {
                   try {
@@ -330,7 +333,8 @@ object FrontEndApp extends Supportive with EncryptSupportive {
                           val instances = timing("json deserialization")() {
                             JsonUtil.fromJson(classOf[Instances], content)
                           }
-                          val outputs = timing("model predict total")(modelInferenceTimersMap(modelName)(modelVersion)) {
+                          val outputs = timing("model predict total")(modelInferenceTimersMap
+                          (modelName)(modelVersion)) {
                             servable.predict(instances)
                           }
                           Predictions(outputs)
@@ -481,7 +485,8 @@ case class FrontEndAppArguments(
                                  redisPort: Int = 6379,
                                  redisInputQueue: String = Conventions.SERVING_STREAM_DEFAULT_NAME,
                                  redisOutputQueue: String =
-                                 Conventions.RESULT_PREFIX + Conventions.SERVING_STREAM_DEFAULT_NAME + ":",
+                                 Conventions.RESULT_PREFIX + Conventions.SERVING_STREAM_DEFAULT_NAME
+                                   + ":",
                                  parallelism: Int = 1000,
                                  timeWindow: Int = 0,
                                  countWindow: Int = 0,

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/FrontEndApp.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/FrontEndApp.scala
@@ -464,7 +464,7 @@ case class FrontEndAppArguments(
                                  Conventions.RESULT_PREFIX + Conventions.SERVING_STREAM_DEFAULT_NAME + ":",
                                  parallelism: Int = 1000,
                                  timeWindow: Int = 0,
-                                 countWindow: Int = 56,
+                                 countWindow: Int = 0,
                                  tokenBucketEnabled: Boolean = false,
                                  tokensPerSecond: Int = 100,
                                  tokenAcquireTimeout: Int = 100,
@@ -474,5 +474,5 @@ case class FrontEndAppArguments(
                                  redisSecureEnabled: Boolean = false,
                                  redissTrustStorePath: String = null,
                                  redissTrustStoreToken: String = "1234qwer",
-                                 servableManagerPath: String = "/home/yansu/projects/cluster_serving.yaml"
+                                 servableManagerPath: String = "./servables-conf.yaml"
                                )

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/FrontEndApp.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/FrontEndApp.scala
@@ -258,6 +258,23 @@ object FrontEndApp extends Supportive with EncryptSupportive {
               }
             }
           }
+        }~(get & path("models")) {
+          timing("get all model infos")(overallRequestTimer, servablesRetriveTimer) {
+            try {
+              val servables = servableManager.retriveAllServables
+              val metaData = servables.map(e => e.getMetaData)
+              val json = JsonUtil.toJson(metaData)
+              complete(200, json)
+            }
+            catch {
+              case e: ModelNotFoundException =>
+                complete(404, "Model Not Found")
+              case e: ServingRuntimeException =>
+                complete(405, "Serving Runtime Error Err: " + e)
+              case e =>
+                complete(500, "Internal Error: " + e)
+            }
+          }
         } ~ pathPrefix("models") {
           concat(
             (get & path(Segment)) {
@@ -271,7 +288,7 @@ object FrontEndApp extends Supportive with EncryptSupportive {
                   }
                   catch {
                     case e: ModelNotFoundException =>
-                      complete(200, "Model Not Found")
+                      complete(404, "Model Not Found")
                     case e: ServingRuntimeException =>
                       complete(405, "Serving Runtime Error Err: " + e)
                     case e =>
@@ -290,7 +307,7 @@ object FrontEndApp extends Supportive with EncryptSupportive {
                   }
                   catch {
                     case e: ModelNotFoundException =>
-                      complete(200, "Model Not Found")
+                      complete(404, "Model Not Found")
                     case e: ServingRuntimeException =>
                       complete(405, "Serving Runtime Error Err: " + e)
                     case e =>
@@ -302,7 +319,7 @@ object FrontEndApp extends Supportive with EncryptSupportive {
               (modelName, modelVersion, contentType, content) => {
                 timing("backend inference timing")(overallRequestTimer, backendInferenceTimer) {
                   try {
-                    logger.info("model name: " + modelName + "\nmodel version: " + modelVersion)
+                    logger.info("model name: " + modelName + ", model version: " + modelVersion)
                     val servable = timing("retriving servable")() {
                       servableManager.retriveServable(modelName, modelVersion)
                     }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/domains.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/domains.scala
@@ -665,7 +665,7 @@ class ServableManager {
       }
     }
   }
-  def retriveAllServables(): List[Servable] = {
+  def retriveAllServables: List[Servable] = {
     val result = modelVersionMap.values.flatMap(
       maps => maps.values.toList
     ).toList

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/domains.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/domains.scala
@@ -781,6 +781,14 @@ class ClusterServingServable(clusterServingMetaData: ClusterServingMetaData) ext
     result
   }
 
+  override def getMetaData: ModelMetaData = {
+     ClusterServingMetaData(clusterServingMetaData.modelName, clusterServingMetaData.modelVersion,
+      clusterServingMetaData.redisHost, clusterServingMetaData.redisPort, clusterServingMetaData.redisInputQueue,
+      clusterServingMetaData.redisOutputQueue, clusterServingMetaData.timeWindow, clusterServingMetaData.countWindow,
+      clusterServingMetaData.redisSecureEnabled,
+      "*******", "*******", clusterServingMetaData.features)
+  }
+
 }
 
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/domains.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/domains.scala
@@ -665,6 +665,12 @@ class ServableManager {
       }
     }
   }
+  def retriveAllServables(): List[Servable] = {
+    val result = modelVersionMap.values.flatMap(
+      maps => maps.values.toList
+    ).toList
+    result
+  }
 
   def retriveServables(modelName: String): List[Servable] = {
     if (!modelVersionMap.contains(modelName)) {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/serializers.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/serializers.scala
@@ -66,7 +66,8 @@ class JacksonJsonSerializer extends SerializeSuported {
 object YamlUtil {
   val jacksonYamlSerializer = new JacksonYamlSerializer()
 
-  def fromYaml[T](clazz: Class[T], data: String)(implicit m: Manifest[T]): T = jacksonYamlSerializer.deSerialize[T](clazz, data)
+  def fromYaml[T](clazz: Class[T], data: String)(implicit m: Manifest[T]): T =
+    jacksonYamlSerializer.deSerialize[T](clazz, data)
 
   def toYaml(value: Object): String = jacksonYamlSerializer.serialize(value)
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/serializers.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/serializers.scala
@@ -17,11 +17,32 @@
 package com.intel.analytics.zoo.serving.http
 
 import com.fasterxml.jackson.databind._
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.scala.{DefaultScalaModule, ScalaObjectMapper}
+
 
 trait SerializeSuported {
   def serialize(src: Object): String
-  def deSerialize[T](clazz: Class[T], dest: String): T
+
+  def deSerialize[T](clazz: Class[T], data: String): T
+}
+
+class JacksonYamlSerializer extends SerializeSuported {
+  val mapper = new ObjectMapper(new YAMLFactory()) with ScalaObjectMapper
+  mapper.registerModule(DefaultScalaModule)
+  mapper.configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
+  mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+  mapper.configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false)
+  mapper.configure(SerializationFeature.INDENT_OUTPUT, true)
+  mapper
+
+  override def serialize(src: Object): String = {
+    mapper.writeValueAsString(src)
+  }
+
+  override def deSerialize[T](clazz: Class[T], data: String): T = {
+    mapper.readValue[T](data, clazz)
+  }
 }
 
 class JacksonJsonSerializer extends SerializeSuported {
@@ -42,8 +63,18 @@ class JacksonJsonSerializer extends SerializeSuported {
   }
 }
 
+object YamlUtil {
+  val jacksonYamlSerializer = new JacksonYamlSerializer()
+
+  def fromYaml[T](clazz: Class[T], data: String)(implicit m: Manifest[T]): T = jacksonYamlSerializer.deSerialize[T](clazz, data)
+
+  def toYaml(value: Object): String = jacksonYamlSerializer.serialize(value)
+}
+
 object JsonUtil {
   val jacksonJsonSerializer = new JacksonJsonSerializer()
+
   def fromJson[T](clazz: Class[T], dest: String): T = jacksonJsonSerializer.deSerialize(clazz, dest)
+
   def toJson(value: Object): String = jacksonJsonSerializer.serialize(value)
 }


### PR DESCRIPTION
Add support of multi-model HTTP serving.
### 1. Four routes support added:
- route GET "/models": return JSON list of all model meta info with all versions
- route GET "/models/[MODEL_NAME]": return JSON list of models with all versions with model name [MODEL_NAME]
- route GET "/models/[MODEL_NAME]/versions/[MODEL_VERSION]": return JSON of model info with name [MODEL_NAME] and version [MODEL_VERSION]
- route POST "/models/[MODEL_NAME]/versions/[MODEL_VERSION]/predict": request body should be in JSON format.  See examples below. Result is also returned in JSON format.

**Sample output format of model info:**
```
[ {
  "modelName" : "second-model",
  "modelVersion" : "1.0",
  "redisHost" : "localhost",
  "redisPort" : "6381",
  "redisInputQueue" : "serving_stream",
  "redisOutputQueue" : "cluster-serving_serving_stream:",
  "timeWindow" : 0,
  "countWindow" : 56,
  "redisSecureEnabled" : false,
  "redisTrustStorePath" : *****,
  "redisTrustStoreToken" : *****,
  "features" : null
}, {
  "modelName" : "third-model",
  "modelVersion" : "1.0",
  "redisHost" : "localhost",
  "redisPort" : "6381",
  "redisInputQueue" : "serving_stream2",
  "redisOutputQueue" : "cluster-serving_serving_stream2:",
  "timeWindow" : 0,
  "countWindow" : 56,
  "redisSecureEnabled" : false,
  "redisTrustStorePath" : *****,
  "redisTrustStoreToken" : *****,
  "features" : null
} ]
```
**Sample input format of predict:**
```
{
  "instances" : [ {
    "image": {
     "b64":  "/9j/4AAQSkZJRgABAQEASABIAAD/7RcEUGhvdG9za..."
     }
  } ]
}
```

A yaml config file with MetaData of models is necessary to launch the serving:
**Sample input format of yaml config file:**

```
                ---
                 modelMetaDataList:
                 - !<ClusterServingMetaData>
                    modelName: "1"
                    modelVersion:"1.0"
                    redisHost: "localhost"
                    redisPort: "6381"
                    redisInputQueue: "serving_stream2"
                    redisOutputQueue: "cluster-serving_serving_stream2:"
                 - !<InflerenceModelMetaData>
                    modelName: "1"
                    modelVersion:"1.0"
                    modelPath:"/"
                    modelType:"OpenVINO"
                    features:
                      - "image"
                      - "iamge2"
```

### 2. Corresponding timers added

- Add timers "servablesRetriveTimer" and "servablesRetriveTimer" to trigger the time of retrieving servables
- Add timer "backendInferenceTimer" to triggle the whole time to make inference backend.
- Add timer "modelInferenceTimersMap" to triggle the predict time for each model