### PR TITLE
relax the threshold to fix anomaly detection ut random fail

### DIFF
--- a/pyzoo/test/zoo/zouwu/model/anomaly/test_model_anomaly.py
+++ b/pyzoo/test/zoo/zouwu/model/anomaly/test_model_anomaly.py
@@ -128,7 +128,7 @@ class TestZouwuModelAnomaly(ZooTestCase):
 
         threshold = ThresholdEstimator().fit(y, y_test, mode="gaussian", ratio=ratio)
         from scipy.stats import norm
-        assert abs(threshold-(norm.ppf(1-ratio)*sigma+mu)) < 0.02
+        assert abs(threshold-(norm.ppf(1-ratio)*sigma+mu)) < 0.04
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
related to #3933 
It seems that we compare the estimators' value to a theoretical value. Relaxing the threshold will significantly reduce the random fail.