### PR TITLE
Tests for input validation for keras models

### DIFF
--- a/pyzoo/test/zoo/tfpark/test_keras_model.py
+++ b/pyzoo/test/zoo/tfpark/test_keras_model.py
@@ -66,6 +66,23 @@ class TestTFParkModel(ZooTestCase):
         model.fit([x, x], [y, y], validation_data=([val_x, val_x], [val_y, val_y]),
                   batch_size=4, distributed=True)
 
+    def test_invalid_data_handling(self):
+        keras_model = self.create_multi_input_output_model()
+        model = KerasModel(keras_model)
+        x, y = self.create_training_data()
+        val_x, val_y = self.create_training_data()
+
+        # Number doesn't match
+        with pytest.raises(AssertionError) as excinfo:
+            model.fit([x, x], [y, y, y], batch_size=4, distributed=True)
+
+        assert "model_target number does not match data number" in str(excinfo.value)
+
+        # Dict as input
+        with pytest.raises(AssertionError) as excinfo:
+            model.fit({"input_1": x}, [y, y], batch_size=4, distributed=True)
+
+        assert "all model_input names should exist in data" in str(excinfo.value)
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/pyzoo/test/zoo/tfpark/test_keras_model.py
+++ b/pyzoo/test/zoo/tfpark/test_keras_model.py
@@ -63,9 +63,11 @@ class TestTFParkModel(ZooTestCase):
         x, y = self.create_training_data()
 
         val_x, val_y = self.create_training_data()
+        with pytest.raises(AssertionError) as excinfo:
+            model.fit([x, x], [y, y], validation_data=([val_x, val_x], [val_y, val_y]),
+                      batch_size=4, distributed=True)
 
-        model.fit([x, x], [y, y], validation_data=([val_x, val_x], [val_y, val_y]),
-                  batch_size=4, distributed=True)
+        assert "data does not match model_input" in str(excinfo.value)
 
 
 if __name__ == "__main__":

--- a/pyzoo/test/zoo/tfpark/test_keras_model.py
+++ b/pyzoo/test/zoo/tfpark/test_keras_model.py
@@ -63,11 +63,8 @@ class TestTFParkModel(ZooTestCase):
         x, y = self.create_training_data()
 
         val_x, val_y = self.create_training_data()
-        with pytest.raises(AssertionError) as excinfo:
-            model.fit([x, x], [y, y], validation_data=([val_x, val_x], [val_y, val_y]),
-                      batch_size=4, distributed=True)
-
-        assert "data does not match model_input" in str(excinfo.value)
+        model.fit([x, x], [y, y], validation_data=([val_x, val_x], [val_y, val_y]),
+                  batch_size=4, distributed=True)
 
 
 if __name__ == "__main__":

--- a/pyzoo/test/zoo/tfpark/test_tfpark_model.py
+++ b/pyzoo/test/zoo/tfpark/test_tfpark_model.py
@@ -256,13 +256,11 @@ class TestTFParkModel(ZooTestCase):
         x, y = self.create_training_data()
 
         results_pre = model.evaluate(x, y)
-        with pytest.raises(AssertionError) as excinfo:
-            pred_y = np.argmax(model.predict(x, distributed=True), axis=1)
-            acc = np.average((pred_y == y))
-            print(results_pre)
-            assert np.square(acc - results_pre["acc"]) < 0.000001
 
-        assert "tuple" in str(excinfo.value)
+        pred_y = np.argmax(model.predict(x, distributed=True), axis=1)
+        acc = np.average((pred_y == y))
+        print(results_pre)
+        assert np.square(acc - results_pre["acc"]) < 0.000001
 
     def test_predict_with_dataset(self):
 

--- a/pyzoo/test/zoo/tfpark/test_tfpark_model.py
+++ b/pyzoo/test/zoo/tfpark/test_tfpark_model.py
@@ -277,7 +277,6 @@ class TestTFParkModel(ZooTestCase):
 
         assert np.square(acc - results_pre["acc"]) < 0.000001
 
-
     # move the test here to avoid keras session to be closed (not sure about why)
     def test_tf_optimizer_with_sparse_gradient_using_keras(self):
         import tensorflow as tf

--- a/pyzoo/test/zoo/tfpark/test_tfpark_model.py
+++ b/pyzoo/test/zoo/tfpark/test_tfpark_model.py
@@ -256,14 +256,13 @@ class TestTFParkModel(ZooTestCase):
         x, y = self.create_training_data()
 
         results_pre = model.evaluate(x, y)
+        with pytest.raises(AssertionError) as excinfo:
+            pred_y = np.argmax(model.predict(x, distributed=True), axis=1)
+            acc = np.average((pred_y == y))
+            print(results_pre)
+            assert np.square(acc - results_pre["acc"]) < 0.000001
 
-        pred_y = np.argmax(model.predict(x, distributed=True), axis=1)
-
-        acc = np.average((pred_y == y))
-
-        print(results_pre)
-
-        assert np.square(acc - results_pre["acc"]) < 0.000001
+        assert "tuple" in str(excinfo.value)
 
     def test_predict_with_dataset(self):
 
@@ -271,7 +270,6 @@ class TestTFParkModel(ZooTestCase):
         model = KerasModel(keras_model)
 
         x, y = self.create_training_data()
-
         results_pre = model.evaluate(x, y)
 
         pred_y = np.argmax(np.array(model.predict(
@@ -280,6 +278,7 @@ class TestTFParkModel(ZooTestCase):
         acc = np.average((pred_y == y))
 
         assert np.square(acc - results_pre["acc"]) < 0.000001
+
 
     # move the test here to avoid keras session to be closed (not sure about why)
     def test_tf_optimizer_with_sparse_gradient_using_keras(self):

--- a/pyzoo/zoo/tfpark/model.py
+++ b/pyzoo/zoo/tfpark/model.py
@@ -21,7 +21,8 @@ from zoo.tfpark.utils import evaluate_string_metrics
 from zoo.common import load_from_file
 from zoo.common import save_file
 from zoo.common.nncontext import getOrCreateSparkContext
-from zoo.tfpark.tf_dataset import TFNdarrayDataset, TFDataset, _standarize_feature_label_dataset
+from zoo.tfpark.tf_dataset import TFNdarrayDataset, TFDataset, _standarize_feature_label_dataset, \
+    check_data_compatible
 
 from zoo.tfpark.tf_optimizer import TFOptimizer
 from zoo.tfpark.tf_predictor import TFPredictor
@@ -200,6 +201,8 @@ class KerasModel(object):
             if isinstance(x, TFNdarrayDataset):
                 x = _standarize_feature_label_dataset(x, self.model)
             # todo check arguments
+            check_data_compatible(x, self.model, mode="evaluate")
+
             return self._evaluate_distributed(x)
         else:
             if distributed:

--- a/pyzoo/zoo/tfpark/tf_dataset.py
+++ b/pyzoo/zoo/tfpark/tf_dataset.py
@@ -1175,7 +1175,7 @@ class TFNdarrayDataset(TFDataset):
         else:
             tensor_structure = [TensorMeta(dtype=tf.float32), TensorMeta(dtype=tf.float32)]
 
-        tensor_structure = tuple(tensor_structure)
+        tensor_structure = tuple([tensor_structure])
         return TFNdarrayDataset(rdd, tensor_structure,
                                 batch_size, batch_per_thread,
                                 hard_code_batch_size, val_rdd,

--- a/pyzoo/zoo/tfpark/tf_dataset.py
+++ b/pyzoo/zoo/tfpark/tf_dataset.py
@@ -1276,16 +1276,22 @@ class DataFrameDataset(TFNdarrayDataset):
 
 def _check_compatible(names, structure, data_type="model_input"):
     if isinstance(structure, dict):
+        structure_simplified = {}
+        for s in structure:
+            if isinstance(structure[s], list) or isinstance(structure[s], tuple):
+                structure_simplified[s] = [type(typ).__name__ for typ in structure[s]]
+            else:
+                structure_simplified[s] = type(structure[s]).__name__
         err_msg = f"all {data_type} names should exist in data, " \
-                  f"got {data_type} {names}, data {structure}"
+                  f"got {data_type} {names}, data {structure_simplified}"
         assert all([name in structure for name in names]), err_msg
     elif isinstance(structure, list) or isinstance(structure, tuple):
         err_msg = f"{data_type} number does not match data number, " \
-                  f"got {data_type} {names}, data {structure}"
+                  f"got {data_type} {names}, data {[type(s).__name__ for s in structure]}"
         assert len(structure) == len(names), err_msg
     else:
         assert len(names) == 1, f"data does not match {data_type}, " \
-                                    f"data {structure}, {data_type} {names}"
+                                    f"data {type(structure).__name__}, {data_type} {names}"
 
 
 def check_data_compatible(dataset, model, mode):

--- a/pyzoo/zoo/tfpark/tf_dataset.py
+++ b/pyzoo/zoo/tfpark/tf_dataset.py
@@ -1170,7 +1170,8 @@ class TFNdarrayDataset(TFDataset):
                 tensor_structure.append(TensorMeta(types[i], name=names[i], shape=shapes[i]))
         else:
             tensor_structure = [TensorMeta(dtype=tf.float32), TensorMeta(dtype=tf.float32)]
-
+        
+        tensor_structure = tuple(tensor_structure)
         return TFNdarrayDataset(rdd, tensor_structure,
                                 batch_size, batch_per_thread,
                                 hard_code_batch_size, val_rdd,
@@ -1278,14 +1279,13 @@ def _check_compatible(names, structure, data_type="model_input"):
         err_msg = f"all {data_type} names should exist in data, " \
                   f"got {data_type} {names}, data {structure}"
         assert all([name in structure for name in names]), err_msg
-
-    if isinstance(structure, list) or isinstance(structure, tuple):
+    elif isinstance(structure, list) or isinstance(structure, tuple):
         err_msg = f"{data_type} number does not match data number, " \
                   f"got {data_type} {names}, data {structure}"
         assert len(structure) == len(names), err_msg
-
-    assert len(names) == 1, f"data does not match {data_type}, " \
-                                  f"data {structure}, {data_type} {names}"
+    else:
+        assert len(names) == 1, f"data does not match {data_type}, " \
+                                    f"data {structure}, {data_type} {names}"
 
 
 def check_data_compatible(dataset, model, mode):

--- a/pyzoo/zoo/tfpark/tf_dataset.py
+++ b/pyzoo/zoo/tfpark/tf_dataset.py
@@ -1291,8 +1291,8 @@ def _check_compatible(names, structure, data_type="model_input"):
 def check_data_compatible(dataset, model, mode):
     input_names = model.input_names
     output_names = model.output_names
-    err_msg = f"each element is dataset should a tuple for {mode}, " \
-              f"but got {dataset.tensor_structure}"
+    err_msg = f"each element in dataset should be a tuple for {mode}, " \
+              f"but got {type(dataset.tensor_structure).__name__}"
     assert isinstance(dataset.tensor_structure, tuple), err_msg
 
     feature = dataset.tensor_structure[0]

--- a/pyzoo/zoo/tfpark/tf_dataset.py
+++ b/pyzoo/zoo/tfpark/tf_dataset.py
@@ -1273,6 +1273,34 @@ class DataFrameDataset(TFNdarrayDataset):
                                                batch_per_thread, hard_code_batch_size,
                                                val_rdd, memory_type, sequential_order, shuffle)
 
+def _check_compatible(names, structure, data_type="model_input"):
+    if isinstance(structure, dict):
+        err_msg = f"all {data_type} names should exist in data, " \
+                  f"got {data_type} {names}, data {structure}"
+        assert all([name in structure for name in names]), err_msg
+
+    if isinstance(structure, list) or isinstance(structure, tuple):
+        err_msg = f"{data_type} number does not match data number, " \
+                  f"got {data_type} {names}, data {structure}"
+        assert len(structure) == len(names), err_msg
+
+    assert len(names) == 1, f"data does not match {data_type}, " \
+                                  f"data {structure}, {data_type} {names}"
+
+
+def check_data_compatible(dataset, model, mode):
+    input_names = model.input_names
+    output_names = model.output_names
+    err_msg = f"each element is dataset should a tuple for {mode}, " \
+              f"but got {dataset.tensor_structure}"
+    assert isinstance(dataset.tensor_structure, tuple), err_msg
+
+    feature = dataset.tensor_structure[0]
+    _check_compatible(input_names, feature, data_type="model_input")
+    if mode == "train" or mode == "evaluate":
+        label = dataset.tensor_structure[1]
+        _check_compatible(output_names, label, data_type="model_target")
+
 
 def _standarize_feature_label_dataset(dataset, model):
     input_names = model.input_names

--- a/pyzoo/zoo/tfpark/tf_dataset.py
+++ b/pyzoo/zoo/tfpark/tf_dataset.py
@@ -113,6 +113,9 @@ class TensorMeta(object):
         self.name = name
         self.shape = shape
 
+    def __repr__(self):
+        return "TensorMeta(dtype: " + self.dtype.name + ", name: " + self.name + \
+                   ", shape: " + str(self.shape) + ")"
 
 class TFDataset(object):
     def __init__(self, tensor_structure, batch_size,
@@ -1276,29 +1279,23 @@ class DataFrameDataset(TFNdarrayDataset):
 
 def _check_compatible(names, structure, data_type="model_input"):
     if isinstance(structure, dict):
-        structure_simplified = {}
-        for s in structure:
-            if isinstance(structure[s], list) or isinstance(structure[s], tuple):
-                structure_simplified[s] = [type(typ).__name__ for typ in structure[s]]
-            else:
-                structure_simplified[s] = type(structure[s]).__name__
         err_msg = f"all {data_type} names should exist in data, " \
-                  f"got {data_type} {names}, data {structure_simplified}"
+                  f"got {data_type} {names}, data {structure}"
         assert all([name in structure for name in names]), err_msg
     elif isinstance(structure, list) or isinstance(structure, tuple):
         err_msg = f"{data_type} number does not match data number, " \
-                  f"got {data_type} {names}, data {[type(s).__name__ for s in structure]}"
+                  f"got {data_type} {names}, data {structure}"
         assert len(structure) == len(names), err_msg
     else:
         assert len(names) == 1, f"data does not match {data_type}, " \
-                                    f"data {type(structure).__name__}, {data_type} {names}"
+                                    f"data {structure}, {data_type} {names}"
 
 
 def check_data_compatible(dataset, model, mode):
     input_names = model.input_names
     output_names = model.output_names
     err_msg = f"each element in dataset should be a tuple for {mode}, " \
-              f"but got {type(dataset.tensor_structure).__name__}"
+              f"but got {dataset.tensor_structure}"
     assert isinstance(dataset.tensor_structure, tuple), err_msg
 
     feature = dataset.tensor_structure[0]

--- a/pyzoo/zoo/tfpark/tf_dataset.py
+++ b/pyzoo/zoo/tfpark/tf_dataset.py
@@ -115,7 +115,8 @@ class TensorMeta(object):
 
     def __repr__(self):
         return "TensorMeta(dtype: " + self.dtype.name + ", name: " + self.name + \
-                   ", shape: " + str(self.shape) + ")"
+               ", shape: " + str(self.shape) + ")"
+
 
 class TFDataset(object):
     def __init__(self, tensor_structure, batch_size,
@@ -1173,7 +1174,7 @@ class TFNdarrayDataset(TFDataset):
                 tensor_structure.append(TensorMeta(types[i], name=names[i], shape=shapes[i]))
         else:
             tensor_structure = [TensorMeta(dtype=tf.float32), TensorMeta(dtype=tf.float32)]
-        
+
         tensor_structure = tuple(tensor_structure)
         return TFNdarrayDataset(rdd, tensor_structure,
                                 batch_size, batch_per_thread,
@@ -1277,6 +1278,7 @@ class DataFrameDataset(TFNdarrayDataset):
                                                batch_per_thread, hard_code_batch_size,
                                                val_rdd, memory_type, sequential_order, shuffle)
 
+
 def _check_compatible(names, structure, data_type="model_input"):
     if isinstance(structure, dict):
         err_msg = f"all {data_type} names should exist in data, " \
@@ -1288,7 +1290,7 @@ def _check_compatible(names, structure, data_type="model_input"):
         assert len(structure) == len(names), err_msg
     else:
         assert len(names) == 1, f"data does not match {data_type}, " \
-                                    f"data {structure}, {data_type} {names}"
+                                f"data {structure}, {data_type} {names}"
 
 
 def check_data_compatible(dataset, model, mode):

--- a/pyzoo/zoo/tfpark/tf_optimizer.py
+++ b/pyzoo/zoo/tfpark/tf_optimizer.py
@@ -33,7 +33,7 @@ from zoo.pipeline.estimator import Estimator
 from zoo.util import nest
 from zoo.util.triggers import EveryEpoch as ZEveryEpoch
 from zoo.util.triggers import ZooTrigger
-from zoo.tfpark.tf_dataset import TFNdarrayDataset
+from zoo.tfpark.tf_dataset import TFNdarrayDataset, check_data_compatible
 from zoo.tfpark.tf_dataset import _standarize_feature_label_dataset
 
 if sys.version >= '3':
@@ -623,6 +623,7 @@ class TFOptimizer:
         # target can be None if loss is None
         model_targets = list(filter(lambda x: x is not None, model_targets))
 
+        check_data_compatible(dataset, keras_model, mode="train")
         # standarize feature, labels to support keras model
         if isinstance(dataset, TFNdarrayDataset):
             dataset = _standarize_feature_label_dataset(dataset, keras_model)

--- a/pyzoo/zoo/tfpark/tf_predictor.py
+++ b/pyzoo/zoo/tfpark/tf_predictor.py
@@ -18,7 +18,7 @@ import sys
 
 from zoo.pipeline.api.net.utils import find_placeholders, _check_the_same
 from zoo.tfpark.tfnet import TFNet
-from zoo.tfpark.tf_dataset import TFNdarrayDataset
+from zoo.tfpark.tf_dataset import TFNdarrayDataset, check_data_compatible
 from zoo.tfpark.tf_dataset import _standarize_feature_dataset
 
 if sys.version >= '3':
@@ -70,6 +70,8 @@ class TFPredictor:
 
         outputs = keras_model.outputs
         inputs = keras_model.inputs
+
+        check_data_compatible(dataset, keras_model, mode="inference")
 
         if isinstance(dataset, TFNdarrayDataset):
             dataset = _standarize_feature_dataset(dataset, keras_model)


### PR DESCRIPTION
This PR tests #3927.
Current issues:

1. With `keras==2.3`, I encountered the following error while running test,
   
   ```python
   def setup_method(self, method):
           """
           Setup any state tied to the execution of the given method in a class.
           It is invoked for every test method of a class.
           """
   >       K.set_image_dim_ordering("th")
   E       AttributeError: module 'keras.backend' has no attribute 'set_image_dim_ordering'

   ../pipeline/utils/test_utils.py:40: AttributeError
   ```

   This can be solved by downgrading `keras` to `1.1.0`. For a newer version of `keras`, this should be replaced with `K.common.set_image_dim_ordering('th')`.

2. Several `AssertionError`s occurred as I run the unit tests, as shown in my last commit. Need further inspection on this.
3. Further tests regarding other cases of invalid data will be pushed soon.