### PR TITLE
Add Python api docs for Auto ML and Chronos Forecasters

### DIFF
--- a/docs/readthedocs/requirements-doc.txt
+++ b/docs/readthedocs/requirements-doc.txt
@@ -20,3 +20,4 @@ commonmark==0.8.1
 recommonmark==0.5.0
 readthedocs-sphinx-ext<2.2
 sphinx_rtd_theme==0.5.2
+scikit-learn==0.22.2.post1

--- a/docs/readthedocs/source/conf.py
+++ b/docs/readthedocs/source/conf.py
@@ -208,3 +208,5 @@ epub_title = project
 
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ['search.html']
+
+autoclass_content = 'both'

--- a/docs/readthedocs/source/conf.py
+++ b/docs/readthedocs/source/conf.py
@@ -210,3 +210,4 @@ epub_title = project
 epub_exclude_files = ['search.html']
 
 autoclass_content = 'both'
+autodoc_member_order = 'bysource'

--- a/docs/readthedocs/source/doc/Chronos/Overview/chronos.md
+++ b/docs/readthedocs/source/doc/Chronos/Overview/chronos.md
@@ -145,7 +145,7 @@ Chronos also provides a set of standalone time series forecaster, which are base
 * LSTMForecaster
 * MTNetForecaster
 * TCMFForecaster
-* SEQ2SEQForecaster
+* Seq2SeqForecaster
 * TCNForecaster
 
 View [Network Traffic Prediction](https://github.com/intel-analytics/analytics-zoo/blob/master/pyzoo/zoo/chronos/use-case/network_traffic/network_traffic_model_forecasting.ipynb) and [Datacenter AIOps](https://github.com/intel-analytics/analytics-zoo/tree/master/pyzoo/zoo/chronos/use-case/AIOps) notebooks for some examples.
@@ -194,7 +194,7 @@ TCMFForecaster wraps a model architecture that follows implementation of the pap
 
 View High-dimensional Electricity Data Forecasting [example](https://github.com/intel-analytics/analytics-zoo/blob/master/pyzoo/zoo/chronos/examples/tcmf/run_electricity.py) and [TCMFForecaster API Doc](../../PythonAPI/Chronos/forecasters.html#chronos-model-forecast-tcmf-forecaster) for more details.
 
-##### **4.2.4 SEQ2SEQForecaster**
+##### **4.2.4 Seq2SeqForecaster**
 
 Seq2SeqForecaster wraps a sequence to sequence model based on LSTM, and is suitable for multivariant & multistep time series forecasting.
 

--- a/docs/readthedocs/source/doc/Chronos/Overview/chronos.md
+++ b/docs/readthedocs/source/doc/Chronos/Overview/chronos.md
@@ -179,16 +179,28 @@ Next, create an appropriate Forecaster to fit, evaluate or predict on the input 
 
 LSTMForecaster wraps a vanilla LSTM model, and is suitable for univariate time series forecasting.
 
-View Network Traffic Prediction [notebook](https://github.com/intel-analytics/analytics-zoo/blob/master/pyzoo/zoo/chronos/use-case/network_traffic/network_traffic_model_forecasting.ipynb) and [LSTMForecaster API Doc]() for more details.
+View Network Traffic Prediction [notebook](https://github.com/intel-analytics/analytics-zoo/blob/master/pyzoo/zoo/chronos/use-case/network_traffic/network_traffic_model_forecasting.ipynb) and [LSTMForecaster API Doc](../../PythonAPI/Chronos/forecasters.html#chronos-model-forecast-lstm-forecaster) for more details.
 
 ##### **4.2.2 MTNetForecaster**
 
 MTNetForecaster wraps a MTNet model. The model architecture mostly follows the [MTNet paper](https://arxiv.org/abs/1809.02105) with slight modifications, and is suitable for multivariate time series forecasting.
 
-View Network Traffic Prediction [notebook](https://github.com/intel-analytics/analytics-zoo/blob/master/pyzoo/zoo/chronos/use-case/network_traffic/network_traffic_model_forecasting.ipynb) and [MTNetForecaster API Doc]() for more details.
+View Network Traffic Prediction [notebook](https://github.com/intel-analytics/analytics-zoo/blob/master/pyzoo/zoo/chronos/use-case/network_traffic/network_traffic_model_forecasting.ipynb) and [MTNetForecaster API Doc](../../PythonAPI/Chronos/forecasters.html#chronos-model-forecast-mtnet-forecaster) for more details.
 
 ##### **4.2.3 TCMFForecaster**
 
 TCMFForecaster wraps a model architecture that follows implementation of the paper [DeepGLO paper](https://arxiv.org/abs/1905.03806) with slight modifications. It is especially suitable for extremely high dimensional (up-to millions) multivariate time series forecasting.
 
-View High-dimensional Electricity Data Forecasting [example](https://github.com/intel-analytics/analytics-zoo/blob/master/pyzoo/zoo/chronos/examples/tcmf/run_electricity.py) and [TCMFForecaster API Doc]() for more details.
+View High-dimensional Electricity Data Forecasting [example](https://github.com/intel-analytics/analytics-zoo/blob/master/pyzoo/zoo/chronos/examples/tcmf/run_electricity.py) and [TCMFForecaster API Doc](../../PythonAPI/Chronos/forecasters.html#chronos-model-forecast-tcmf-forecaster) for more details.
+
+##### **4.2.4 SEQ2SEQForecaster**
+
+Seq2SeqForecaster wraps a sequence to sequence model based on LSTM, and is suitable for multivariant & multistep time series forecasting.
+
+View [SEQ2SEQForecaster API Doc](../../PythonAPI/Chronos/forecasters.html#chronos-model-forecast-seq2seq-forecaster) for more details.
+
+##### **4.2.5 TCNForecaster**
+
+Temporal Convolutional Networks (TCN) is a neural network that use convolutional architecture rather than recurrent networks. It supports multi-step and multi-variant cases. Causal Convolutions enables large scale parallel computing which makes TCN has less inference time than RNN based model such as LSTM.
+
+View Network Traffic multivariate multistep Prediction [example](https://github.com/intel-analytics/analytics-zoo/blob/master/pyzoo/zoo/chronos/examples/tcmf/run_electricity.py) and [TCNForecaster API Doc](../../PythonAPI/Chronos/forecasters.html#chronos-model-forecast-tcn-forecaster) for more details.

--- a/docs/readthedocs/source/doc/Chronos/Overview/chronos.md
+++ b/docs/readthedocs/source/doc/Chronos/Overview/chronos.md
@@ -142,10 +142,11 @@ loaded_ppl.save(another_file)
 
 Chronos also provides a set of standalone time series forecaster, which are based on deep learning models (without AutoML support), including
 
-* TCNForecaster
 * LSTMForecaster
 * MTNetForecaster
 * TCMFForecaster
+* SEQ2SEQForecaster
+* TCNForecaster
 
 View [Network Traffic Prediction](https://github.com/intel-analytics/analytics-zoo/blob/master/pyzoo/zoo/chronos/use-case/network_traffic/network_traffic_model_forecasting.ipynb) and [Datacenter AIOps](https://github.com/intel-analytics/analytics-zoo/tree/master/pyzoo/zoo/chronos/use-case/AIOps) notebooks for some examples.
 
@@ -203,4 +204,4 @@ View [SEQ2SEQForecaster API Doc](../../PythonAPI/Chronos/forecasters.html#chrono
 
 Temporal Convolutional Networks (TCN) is a neural network that use convolutional architecture rather than recurrent networks. It supports multi-step and multi-variant cases. Causal Convolutions enables large scale parallel computing which makes TCN has less inference time than RNN based model such as LSTM.
 
-View Network Traffic multivariate multistep Prediction [example](https://github.com/intel-analytics/analytics-zoo/blob/master/pyzoo/zoo/chronos/examples/tcmf/run_electricity.py) and [TCNForecaster API Doc](../../PythonAPI/Chronos/forecasters.html#chronos-model-forecast-tcn-forecaster) for more details.
+View Network Traffic multivariate multistep Prediction [notebook](https://github.com/intel-analytics/analytics-zoo/blob/master/pyzoo/zoo/chronos/use-case/network_traffic/network_traffic_multivariate_multistep_tcnforecaster.ipynb) and [TCNForecaster API Doc](../../PythonAPI/Chronos/forecasters.html#chronos-model-forecast-tcn-forecaster) for more details.

--- a/docs/readthedocs/source/doc/Chronos/Overview/chronos.md
+++ b/docs/readthedocs/source/doc/Chronos/Overview/chronos.md
@@ -198,7 +198,7 @@ View High-dimensional Electricity Data Forecasting [example](https://github.com/
 
 Seq2SeqForecaster wraps a sequence to sequence model based on LSTM, and is suitable for multivariant & multistep time series forecasting.
 
-View [SEQ2SEQForecaster API Doc](../../PythonAPI/Chronos/forecasters.html#chronos-model-forecast-seq2seq-forecaster) for more details.
+View [Seq2SeqForecaster API Doc](../../PythonAPI/Chronos/forecasters.html#chronos-model-forecast-seq2seq-forecaster) for more details.
 
 ##### **4.2.5 TCNForecaster**
 

--- a/docs/readthedocs/source/doc/PythonAPI/AutoML/automl.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/AutoML/automl.rst
@@ -4,10 +4,11 @@ AutoML API
 orca.automl.auto_estimator
 ---------------------------
 
-A general Estimator support automatic model tuning. It allows user to fit and search the best hyperparameter for their model.
+A general estimator supports automatic model tuning. It allows users to fit and search the best hyperparameter for their model.
 
 .. automodule:: zoo.orca.automl.auto_estimator
     :members:
     :undoc-members:
     :show-inheritance:
+    :no-special-members: __init__
 

--- a/docs/readthedocs/source/doc/PythonAPI/AutoML/automl.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/AutoML/automl.rst
@@ -8,6 +8,5 @@ A general estimator supports automatic model tuning. It allows users to fit and 
 
 .. automodule:: zoo.orca.automl.auto_estimator
     :members:
-    :undoc-members:
     :show-inheritance:
 

--- a/docs/readthedocs/source/doc/PythonAPI/AutoML/automl.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/AutoML/automl.rst
@@ -11,6 +11,3 @@ A general estimator supports automatic model tuning. It allows users to fit and 
     :undoc-members:
     :show-inheritance:
 
-    .. autoclass:: zoo.orca.automl.auto_estimator.AutoEstimator
-        :exclude-members: __init__
-

--- a/docs/readthedocs/source/doc/PythonAPI/AutoML/automl.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/AutoML/automl.rst
@@ -10,5 +10,7 @@ A general estimator supports automatic model tuning. It allows users to fit and 
     :members:
     :undoc-members:
     :show-inheritance:
-    :exclude-members: __init__
+
+    .. autoclass:: zoo.orca.automl.auto_estimator.AutoEstimator
+        :exclude-members: __init__
 

--- a/docs/readthedocs/source/doc/PythonAPI/AutoML/automl.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/AutoML/automl.rst
@@ -7,7 +7,7 @@ orca.automl.auto_estimator
 A general Estimator support automatic model tuning. It allows user to fit and search the best hyperparameter for their model.
 
 .. automodule:: zoo.orca.automl.auto_estimator
-    :members:
+    :members: __init__, fit, from_torch, from_keras, get_best_model
     :undoc-members:
     :show-inheritance:
 

--- a/docs/readthedocs/source/doc/PythonAPI/AutoML/automl.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/AutoML/automl.rst
@@ -7,7 +7,7 @@ orca.automl.auto_estimator
 A general Estimator support automatic model tuning. It allows user to fit and search the best hyperparameter for their model.
 
 .. automodule:: zoo.orca.automl.auto_estimator
-    :members: __init__, fit, from_torch, from_keras, get_best_model
+    :members:
     :undoc-members:
     :show-inheritance:
 

--- a/docs/readthedocs/source/doc/PythonAPI/AutoML/automl.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/AutoML/automl.rst
@@ -1,5 +1,5 @@
 AutoML API
-=========
+===========
 
 orca.automl.auto_estimator
 ---------------------------

--- a/docs/readthedocs/source/doc/PythonAPI/AutoML/automl.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/AutoML/automl.rst
@@ -4,6 +4,8 @@ AutoML API
 orca.automl.auto_estimator
 ---------------------------
 
+A general Estimator support automatic model tuning. It allows user to fit and search the best hyperparameter for their model.
+
 .. automodule:: zoo.orca.automl.auto_estimator
     :members:
     :undoc-members:

--- a/docs/readthedocs/source/doc/PythonAPI/AutoML/automl.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/AutoML/automl.rst
@@ -1,0 +1,11 @@
+AutoML API
+=========
+
+orca.automl.auto_estimator
+---------------------------
+
+.. automodule:: zoo.orca.automl.auto_estimator
+    :members:
+    :undoc-members:
+    :show-inheritance:
+

--- a/docs/readthedocs/source/doc/PythonAPI/AutoML/automl.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/AutoML/automl.rst
@@ -10,5 +10,5 @@ A general estimator supports automatic model tuning. It allows users to fit and 
     :members:
     :undoc-members:
     :show-inheritance:
-    :no-special-members: __init__
+    :exclude-members: __init__
 

--- a/docs/readthedocs/source/doc/PythonAPI/Chronos/forecasters.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Chronos/forecasters.rst
@@ -49,8 +49,7 @@ TCMFForecaster supports distributed training and inference. It is based on Orca 
 **Remarks**:
 
 * You can refer to `TCMFForecaster installation <https://github.com/intel-analytics/analytics-zoo/blob/master/docs/docs/Chronos/tutorials/TCMFForecaster.md/#step-0-prepare-environment>`__ to install required packages.
-* Your operating system (OS) is required to be one of the following 64-bit systems:
-**Ubuntu 16.04 or later** and **macOS 10.12.6 or later**.
+* Your operating system (OS) is required to be one of the following 64-bit systems: **Ubuntu 16.04 or later** and **macOS 10.12.6 or later**.
 
 .. automodule:: zoo.chronos.model.forecast.tcmf_forecaster
     :members:
@@ -63,7 +62,7 @@ chronos.model.forecast.mtnet_forecaster
 
 MTNet is a memory-network based solution for multivariate time-series forecasting. In a specific task of multivariate time-series forecasting, we have several variables observed in time series and we want to forecast some or all of the variables' value in a future time stamp.
 
-MTNet is proposed by paper`A Memory-Network Based Solution for Multivariate Time-Series Forecasting <https://arxiv.org/abs/1809.02105>`__. MTNetForecaster is derived from tfpark.KerasMode, and can use all methods of KerasModel. Refer to `tfpark.KerasModel API Doc <https://github.com/intel-analytics/analytics-zoo/blob/master/docs/docs/APIGuide/TFPark/model.md>`__ for details.
+MTNet is proposed by paper `A Memory-Network Based Solution for Multivariate Time-Series Forecasting <https://arxiv.org/abs/1809.02105>`__. MTNetForecaster is derived from tfpark.KerasMode, and can use all methods of KerasModel. Refer to `tfpark.KerasModel API Doc <https://github.com/intel-analytics/analytics-zoo/blob/master/docs/docs/APIGuide/TFPark/model.md>`__ for details.
 
 For the detailed algorithm description, please refer to `here <https://github.com/intel-analytics/analytics-zoo/blob/master/docs/docs/Chronos/Algorithm/MTNetAlgorithm.md>`__.
 

--- a/docs/readthedocs/source/doc/PythonAPI/Chronos/forecasters.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Chronos/forecasters.rst
@@ -4,7 +4,7 @@ Chronos Forecasters API
 chronos.model.forecast.lstm_forecaster
 ----------------------------------------
 
-Long short-term memory(LSTM) is a special type of recurrent neural network(RNN). We implement the basic version of LSTM - VanillaLSTM for this forecaster for time-series forecasting task. It has two LSTM layers, two dropout layer and a dense layer. LSTMForecaster is derived from tfpark.KerasMode, and can use all methods of KerasModel. Refer to `tfpark.KerasModel API Doc <https://github.com/intel-analytics/analytics-zoo/blob/master/docs/docs/APIGuide/TFPark/model.md>`__ for details.
+Long short-term memory(LSTM) is a special type of recurrent neural network(RNN). We implement the basic version of LSTM - VanillaLSTM for this forecaster for time-series forecasting task. It has two LSTM layers, two dropout layer and a dense layer.
 
 For the detailed algorithm description, please refer to `here <https://github.com/intel-analytics/analytics-zoo/blob/master/docs/docs/Chronos/Algorithm/LSTMAlgorithm.md>`__.
 

--- a/docs/readthedocs/source/doc/PythonAPI/Chronos/forecasters.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Chronos/forecasters.rst
@@ -1,55 +1,55 @@
-Zouwu Forecasters API
+Chronos Forecasters API
 =====================
 
-zouwu.model.forecast.lstm_forecaster
+chronos.model.forecast.lstm_forecaster
 ----------------------------------------
 
-.. automodule:: zoo.zouwu.model.forecast.lstm_forecaster
+.. automodule:: zoo.chronos.model.forecast.lstm_forecaster
     :members:
     :undoc-members:
     :show-inheritance:
 
 
-zouwu.model.forecast.seq2seq_forecaster
+chronos.model.forecast.seq2seq_forecaster
 ----------------------------------------
 
-.. automodule:: zoo.zouwu.model.forecast.seq2seq_forecaster
+.. automodule:: zoo.chronos.model.forecast.seq2seq_forecaster
     :members:
     :undoc-members:
     :show-inheritance:
 
 
-zouwu.model.forecast.tcn_forecaster
+chronos.model.forecast.tcn_forecaster
 ----------------------------------------
 
-.. automodule:: zoo.zouwu.model.forecast.tcn_forecaster
+.. automodule:: zoo.chronos.model.forecast.tcn_forecaster
     :members:
     :undoc-members:
     :show-inheritance:
 
 
-zouwu.model.forecast.tcmf_forecaster
+chronos.model.forecast.tcmf_forecaster
 ----------------------------------------
 
-.. automodule:: zoo.zouwu.model.forecast.tcmf_forecaster
+.. automodule:: zoo.chronos.model.forecast.tcmf_forecaster
     :members:
     :undoc-members:
     :show-inheritance:
 
 
-zouwu.model.forecast.mtnet_forecaster
+chronos.model.forecast.mtnet_forecaster
 ----------------------------------------
 
-.. automodule:: zoo.zouwu.model.forecast.mtnet_forecaster
+.. automodule:: zoo.chronos.model.forecast.mtnet_forecaster
     :members:
     :undoc-members:
     :show-inheritance:
 
 
-zouwu.model.forecast.tfpark_forecaster
+chronos.model.forecast.tfpark_forecaster
 ----------------------------------------
 
-.. automodule:: zoo.zouwu.model.forecast.tfpark_forecaster
+.. automodule:: zoo.chronos.model.forecast.tfpark_forecaster
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/readthedocs/source/doc/PythonAPI/Chronos/forecasters.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Chronos/forecasters.rst
@@ -4,6 +4,10 @@ Chronos Forecasters API
 chronos.model.forecast.lstm_forecaster
 ----------------------------------------
 
+Long short-term memory(LSTM) is a special type of recurrent neural network(RNN). We implement the basic version of LSTM - VanillaLSTM for this forecaster for time-series forecasting task. It has two LSTM layers, two dropout layer and a dense layer. LSTMForecaster is derived from tfpark.KerasMode, and can use all methods of KerasModel. Refer to `tfpark.KerasModel API Doc <https://github.com/intel-analytics/analytics-zoo/blob/master/docs/docs/APIGuide/TFPark/model.md>`__ for details.
+
+For the detailed algorithm description, please refer to `here <https://github.com/intel-analytics/analytics-zoo/blob/master/docs/docs/Chronos/Algorithm/LSTMAlgorithm.md>`__.
+
 .. automodule:: zoo.chronos.model.forecast.lstm_forecaster
     :members:
     :undoc-members:
@@ -12,6 +16,8 @@ chronos.model.forecast.lstm_forecaster
 
 chronos.model.forecast.seq2seq_forecaster
 ----------------------------------------
+
+Seq2SeqForecaster wraps a sequence to sequence model based on LSTM, and is suitable for multivariant & multistep time series forecasting.
 
 .. automodule:: zoo.chronos.model.forecast.seq2seq_forecaster
     :members:
@@ -22,6 +28,8 @@ chronos.model.forecast.seq2seq_forecaster
 chronos.model.forecast.tcn_forecaster
 ----------------------------------------
 
+Temporal Convolutional Networks (TCN) is a neural network that use convolutional architecture rather than recurrent networks. It supports multi-step and multi-variant cases. Causal Convolutions enables large scale parallel computing which makes TCN has less inference time than RNN based model such as LSTM.
+
 .. automodule:: zoo.chronos.model.forecast.tcn_forecaster
     :members:
     :undoc-members:
@@ -31,6 +39,19 @@ chronos.model.forecast.tcn_forecaster
 chronos.model.forecast.tcmf_forecaster
 ----------------------------------------
 
+Analytics Zoo Chronos TCMFForecaster provides an efficient way to forecast high dimensional time series.
+
+TCMFForecaster is based on DeepGLO algorithm, which is a deep forecasting model which thinks globally and acts locally.
+You can refer to `the deepglo paper <https://arxiv.org/abs/1905.03806>`__ for more details.
+
+TCMFForecaster supports distributed training and inference. It is based on Orca PyTorch Estimator, which is an estimator to do PyTorch training/evaluation/prediction on Spark in a distributed fashion. Also you can choose to enable distributed training and inference or not.
+
+**Remarks**:
+
+* You can refer to `TCMFForecaster installation <https://github.com/intel-analytics/analytics-zoo/blob/master/docs/docs/Chronos/tutorials/TCMFForecaster.md/#step-0-prepare-environment>`__ to install required packages.
+* Your operating system (OS) is required to be one of the following 64-bit systems:
+**Ubuntu 16.04 or later** and **macOS 10.12.6 or later**.
+
 .. automodule:: zoo.chronos.model.forecast.tcmf_forecaster
     :members:
     :undoc-members:
@@ -39,6 +60,12 @@ chronos.model.forecast.tcmf_forecaster
 
 chronos.model.forecast.mtnet_forecaster
 ----------------------------------------
+
+MTNet is a memory-network based solution for multivariate time-series forecasting. In a specific task of multivariate time-series forecasting, we have several variables observed in time series and we want to forecast some or all of the variables' value in a future time stamp.
+
+MTNet is proposed by paper`A Memory-Network Based Solution for Multivariate Time-Series Forecasting <https://arxiv.org/abs/1809.02105>`__. MTNetForecaster is derived from tfpark.KerasMode, and can use all methods of KerasModel. Refer to `tfpark.KerasModel API Doc <https://github.com/intel-analytics/analytics-zoo/blob/master/docs/docs/APIGuide/TFPark/model.md>`__ for details.
+
+For the detailed algorithm description, please refer to `here <https://github.com/intel-analytics/analytics-zoo/blob/master/docs/docs/Chronos/Algorithm/MTNetAlgorithm.md>`__.
 
 .. automodule:: zoo.chronos.model.forecast.mtnet_forecaster
     :members:

--- a/docs/readthedocs/source/doc/PythonAPI/Friesian/feature.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Friesian/feature.rst
@@ -1,5 +1,5 @@
 Friesian Feature API
-=========
+=====================
 
 friesian.feature.table
 ---------------------------

--- a/docs/readthedocs/source/doc/PythonAPI/Zouwu/forecasters.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Zouwu/forecasters.rst
@@ -1,5 +1,5 @@
 Zouwu Forecasters API
-=========
+=====================
 
 zouwu.model.forecast.lstm_forecaster
 ---------------------------

--- a/docs/readthedocs/source/doc/PythonAPI/Zouwu/forecasters.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Zouwu/forecasters.rst
@@ -2,7 +2,7 @@ Zouwu Forecasters API
 =====================
 
 zouwu.model.forecast.lstm_forecaster
----------------------------
+----------------------------------------
 
 .. automodule:: zoo.zouwu.model.forecast.lstm_forecaster
     :members:
@@ -10,38 +10,5 @@ zouwu.model.forecast.lstm_forecaster
     :show-inheritance:
 
 
-zouwu.model.forecast.seq2seq_forecaster
----------------------------
 
-.. automodule:: zoo.zouwu.model.forecast.seq2seq_forecaster
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-
-zouwu.model.forecast.tcn_forecaster
----------------------------
-
-.. automodule:: zoo.zouwu.model.forecast.tcn_forecaster
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-
-zouwu.model.forecast.tcmf_forecaster
----------------------------
-
-.. automodule:: zoo.zouwu.model.forecast.tcmf_forecaster
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-
-zouwu.model.forecast.mtnet_forecaster
----------------------------
-
-.. automodule:: zoo.zouwu.model.forecast.mtnet_forecaster
-    :members:
-    :undoc-members:
-    :show-inheritance:
 

--- a/docs/readthedocs/source/doc/PythonAPI/Zouwu/forecasters.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Zouwu/forecasters.rst
@@ -1,0 +1,47 @@
+Zouwu Forecasters API
+=========
+
+zouwu.model.forecast.lstm_forecaster
+---------------------------
+
+.. automodule:: zoo.zouwu.model.forecast.lstm_forecaster
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+zouwu.model.forecast.seq2seq_forecaster
+---------------------------
+
+.. automodule:: zoo.zouwu.model.forecast.seq2seq_forecaster
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+zouwu.model.forecast.tcn_forecaster
+---------------------------
+
+.. automodule:: zoo.zouwu.model.forecast.tcn_forecaster
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+zouwu.model.forecast.tcmf_forecaster
+---------------------------
+
+.. automodule:: zoo.zouwu.model.forecast.tcmf_forecaster
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+zouwu.model.forecast.mtnet_forecaster
+---------------------------
+
+.. automodule:: zoo.zouwu.model.forecast.mtnet_forecaster
+    :members:
+    :undoc-members:
+    :show-inheritance:
+

--- a/docs/readthedocs/source/doc/PythonAPI/Zouwu/forecasters.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Zouwu/forecasters.rst
@@ -10,5 +10,40 @@ zouwu.model.forecast.lstm_forecaster
     :show-inheritance:
 
 
+zouwu.model.forecast.seq2seq_forecaster
+----------------------------------------
+
+.. automodule:: zoo.zouwu.model.forecast.seq2seq_forecaster
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+zouwu.model.forecast.tcn_forecaster
+----------------------------------------
+
+.. automodule:: zoo.zouwu.model.forecast.tcn_forecaster
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+zouwu.model.forecast.tcmf_forecaster
+----------------------------------------
+
+.. automodule:: zoo.zouwu.model.forecast.tcmf_forecaster
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+zouwu.model.forecast.mtnet_forecaster
+----------------------------------------
+
+.. automodule:: zoo.zouwu.model.forecast.mtnet_forecaster
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 

--- a/docs/readthedocs/source/doc/PythonAPI/Zouwu/forecasters.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Zouwu/forecasters.rst
@@ -46,4 +46,10 @@ zouwu.model.forecast.mtnet_forecaster
     :show-inheritance:
 
 
+zouwu.model.forecast.tfpark_forecaster
+----------------------------------------
 
+.. automodule:: zoo.zouwu.model.forecast.tfpark_forecaster
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/readthedocs/source/index.rst
+++ b/docs/readthedocs/source/index.rst
@@ -71,7 +71,7 @@ Analytics Zoo Documentation
    doc/PythonAPI/Orca/orca.rst
    doc/PythonAPI/AutoML/automl.rst
    doc/PythonAPI/Friesian/feature.rst
-   doc/PythonAPI/Zouwu/forecasters.rst
+   doc/PythonAPI/Chronos/forecasters.rst
    
 .. toctree::
    :maxdepth: 1

--- a/docs/readthedocs/source/index.rst
+++ b/docs/readthedocs/source/index.rst
@@ -69,7 +69,9 @@ Analytics Zoo Documentation
    :caption: Python API
    
    doc/PythonAPI/Orca/orca.rst
+   doc/PythonAPI/AutoML/automl.rst
    doc/PythonAPI/Friesian/feature.rst
+   doc/PythonAPI/Zouwu/forecasters.rst
    
 .. toctree::
    :maxdepth: 1

--- a/pyzoo/zoo/chronos/model/forecast/lstm_forecaster.py
+++ b/pyzoo/zoo/chronos/model/forecast/lstm_forecaster.py
@@ -20,7 +20,15 @@ from zoo.chronos.model.forecast.tfpark_forecaster import TFParkForecaster
 
 class LSTMForecaster(TFParkForecaster):
     """
-    Vanilla LSTM Forecaster
+    Example:
+        >>> #The dataset is split into x_train, x_val, x_test, y_train, y_val, y_test
+        >>> model = LSTMForecaster(target_dim=1, feature_dim=x_train.shape[-1])
+        >>> model.fit(x_train,
+                  y_train,
+                  validation_data=(x_val, y_val),
+                  batch_size=8,
+                  distributed=False)
+        >>> predict_result = model.predict(x_test)
     """
 
     def __init__(self,

--- a/pyzoo/zoo/chronos/model/forecast/mtnet_forecaster.py
+++ b/pyzoo/zoo/chronos/model/forecast/mtnet_forecaster.py
@@ -84,7 +84,7 @@ class MTNetForecaster(TFParkForecaster):
         """
         build a MTNet model in tf.keras
 
-       :return: a tf.keras MTNet model
+        :return: a tf.keras MTNet model
         """
         # TODO change this function call after MTNet fixes
         self.internal = MTNetKerasModel(
@@ -98,6 +98,7 @@ class MTNetForecaster(TFParkForecaster):
         This should be called before train_x, validation_x, and test_x
 
         :param x: the original samples from rolling
+
         :return: a tuple (long_term_x, short_term_x) which are long term and short term history respectively
         """
         return self.internal._reshape_input_x(x)

--- a/pyzoo/zoo/chronos/model/forecast/mtnet_forecaster.py
+++ b/pyzoo/zoo/chronos/model/forecast/mtnet_forecaster.py
@@ -114,6 +114,7 @@ class MTNetForecaster(TFParkForecaster):
 
         :param x: the original samples from rolling
 
-        :return: a tuple (long_term_x, short_term_x) which are long term and short term history respectively
+        :return: a tuple (long_term_x, short_term_x) which are long term and short term
+            history respectively
         """
         return self.internal._reshape_input_x(x)

--- a/pyzoo/zoo/chronos/model/forecast/mtnet_forecaster.py
+++ b/pyzoo/zoo/chronos/model/forecast/mtnet_forecaster.py
@@ -20,7 +20,22 @@ from zoo.chronos.model.forecast.tfpark_forecaster import TFParkForecaster
 
 class MTNetForecaster(TFParkForecaster):
     """
-    MTNet Forecast Model
+        Example:
+            >>> #The dataset is split into x_train, x_val, x_test, y_train, y_val, y_test
+            >>> model = MTNetForecaster(target_dim=1,
+                                feature_dim=x_train.shape[-1],
+                                long_series_num=6,
+                                series_length=2
+                                )
+            >>> x_train_long, x_train_short = model.preprocess_input(x_train)
+            >>> x_val_long, x_val_short = model.preprocess_input(x_val)
+            >>> x_test_long, x_test_short = model.preprocess_input(x_test)
+            >>> model.fit([x_train_long, x_train_short],
+                  y_train,
+                  validation_data=([x_val_long, x_val_short], y_val),
+                  batch_size=32,
+                  distributed=False)
+            >>> predict_result = [x_test_long, x_test_short]
     """
 
     def __init__(self,

--- a/pyzoo/zoo/chronos/model/forecast/mtnet_forecaster.py
+++ b/pyzoo/zoo/chronos/model/forecast/mtnet_forecaster.py
@@ -41,6 +41,7 @@ class MTNetForecaster(TFParkForecaster):
                  ):
         """
         Build a MTNet Forecast Model.
+
         :param target_dim: the dimension of model output
         :param feature_dim: the dimension of input feature
         :param long_series_num: the number of series for the long-term memory series
@@ -82,6 +83,7 @@ class MTNetForecaster(TFParkForecaster):
     def _build(self):
         """
         build a MTNet model in tf.keras
+
        :return: a tf.keras MTNet model
         """
         # TODO change this function call after MTNet fixes
@@ -94,8 +96,8 @@ class MTNetForecaster(TFParkForecaster):
         """
         The original rolled features needs an extra step to process.
         This should be called before train_x, validation_x, and test_x
+
         :param x: the original samples from rolling
-        :return: a tuple (long_term_x, short_term_x)
-                which are long term and short term history respectively
+        :return: a tuple (long_term_x, short_term_x) which are long term and short term history respectively
         """
         return self.internal._reshape_input_x(x)

--- a/pyzoo/zoo/chronos/model/forecast/seq2seq_forecaster.py
+++ b/pyzoo/zoo/chronos/model/forecast/seq2seq_forecaster.py
@@ -107,7 +107,7 @@ class Seq2SeqForecaster(Forecaster):
         :param metric: The metric for training data.
         :param batch_size: Number of batch size you want to train.
 
-        :return:
+        :return: Evaluation results on validation data.
         """
         if validation_data is None:
             validation_data = (x, y)
@@ -125,7 +125,7 @@ class Seq2SeqForecaster(Forecaster):
 
         :param x: A numpy array with shape (num_samples, lookback, feature_dim).
 
-        :return:
+        :return: A numpy array with shape (num_samples, lookback, feature_dim).
         """
         if not self.internal.model_built:
             raise RuntimeError("You must call fit or restore first before calling predict!")
@@ -139,7 +139,7 @@ class Seq2SeqForecaster(Forecaster):
         :param dirname: The directory to save onnx model file. This value defaults
                to None for no saving file.
 
-        :return:
+        :return: A numpy array with shape (num_samples, lookback, feature_dim).
         """
         if not self.internal.model_built:
             raise RuntimeError("You must call fit or restore first before calling predict!")
@@ -156,7 +156,7 @@ class Seq2SeqForecaster(Forecaster):
                String in ['raw_values', 'uniform_average']. The value defaults to
                'raw_values'.
 
-        :return:
+        :return: A list of evaluation results. Each item represents a metric.
         """
         if not self.internal.model_built:
             raise RuntimeError("You must call fit or restore first before calling evaluate!")
@@ -178,7 +178,7 @@ class Seq2SeqForecaster(Forecaster):
                String in ['raw_values', 'uniform_average']. The value defaults to
                'raw_values'.
 
-        :return:
+        :return: A list of evaluation results. Each item represents a metric.
         """
         if not self.internal.model_built:
             raise RuntimeError("You must call fit or restore first before calling evaluate!")

--- a/pyzoo/zoo/chronos/model/forecast/seq2seq_forecaster.py
+++ b/pyzoo/zoo/chronos/model/forecast/seq2seq_forecaster.py
@@ -22,7 +22,19 @@ import os
 
 
 class Seq2SeqForecaster(Forecaster):
-
+    """
+        Example:
+            >>> #The dataset is split into x_train, x_val, x_test, y_train, y_val, y_test
+            >>> forecaster = Seq2SeqForecaster(future_seq_len=5,
+                                       input_feature_num=3,
+                                       output_feature_num=2,
+                                       lstm_layer_num=2)
+            >>> train_mse = forecaster.fit(x_train, x_val, epochs=10)
+            >>> test_pred = forecaster.predict(x_test)
+            >>> test_mse = forecaster.evaluate(x_test, y_test)
+            >>> forecaster.save({ckpt_name})
+            >>> forecaster.restore({ckpt_name})
+    """
     def __init__(self,
                  input_feature_num,
                  future_seq_len,

--- a/pyzoo/zoo/chronos/model/forecast/seq2seq_forecaster.py
+++ b/pyzoo/zoo/chronos/model/forecast/seq2seq_forecaster.py
@@ -94,6 +94,8 @@ class Seq2SeqForecaster(Forecaster):
         :param epochs: Number of epochs you want to train.
         :param metric: The metric for training data.
         :param batch_size: Number of batch size you want to train.
+
+        :return:
         """
         if validation_data is None:
             validation_data = (x, y)
@@ -110,6 +112,8 @@ class Seq2SeqForecaster(Forecaster):
         Predict using a trained forecaster.
 
         :param x: A numpy array with shape (num_samples, lookback, feature_dim).
+
+        :return:
         """
         if not self.internal.model_built:
             raise RuntimeError("You must call fit or restore first before calling predict!")
@@ -122,6 +126,8 @@ class Seq2SeqForecaster(Forecaster):
         :param x: A numpy array with shape (num_samples, lookback, feature_dim).
         :param dirname: The directory to save onnx model file. This value defaults
                to None for no saving file.
+
+        :return:
         """
         if not self.internal.model_built:
             raise RuntimeError("You must call fit or restore first before calling predict!")
@@ -137,6 +143,8 @@ class Seq2SeqForecaster(Forecaster):
         :param multioutput: Defines aggregating of multiple output values.
                String in ['raw_values', 'uniform_average']. The value defaults to
                'raw_values'.
+
+        :return:
         """
         if not self.internal.model_built:
             raise RuntimeError("You must call fit or restore first before calling evaluate!")
@@ -157,6 +165,8 @@ class Seq2SeqForecaster(Forecaster):
         :param multioutput: Defines aggregating of multiple output values.
                String in ['raw_values', 'uniform_average']. The value defaults to
                'raw_values'.
+
+        :return:
         """
         if not self.internal.model_built:
             raise RuntimeError("You must call fit or restore first before calling evaluate!")

--- a/pyzoo/zoo/chronos/model/forecast/tcmf_forecaster.py
+++ b/pyzoo/zoo/chronos/model/forecast/tcmf_forecaster.py
@@ -116,7 +116,7 @@ class TCMFForecaster(Forecaster):
             alt_iters=10,
             num_workers=None):
         """
-        fit the model on x from scratch
+        Fit the model on x from scratch
 
         :param x: the input for fit. Only dict of ndarray and SparkXShards of dict of ndarray
             are supported. Example: {'id': id_arr, 'y': data_ndarray}, and data_ndarray
@@ -183,7 +183,7 @@ class TCMFForecaster(Forecaster):
 
     def fit_incremental(self, x_incr, covariates_incr=None, dti_incr=None):
         """
-        incrementally fit the model. Note that we only incrementally fit X_seq (TCN in global model)
+        Incrementally fit the model. Note that we only incrementally fit X_seq (TCN in global model)
 
         :param x_incr: incremental data to be fitted. It should be of the same format as input x in
             fit, which is a dict of ndarray or SparkXShards of dict of ndarray.
@@ -212,7 +212,7 @@ class TCMFForecaster(Forecaster):
                  num_workers=None,
                  ):
         """
-        evaluate the model
+        Evaluate the model
 
         :param target_value: target value for evaluation. We interpret its second dimension of
                as the horizon length for evaluation.
@@ -245,7 +245,7 @@ class TCMFForecaster(Forecaster):
                 num_workers=None,
                 ):
         """
-        predict
+        Predict using a trained forecaster.
 
         :param horizon: horizon length to look forward.
         :param future_covariates: covariates corresponding to future horizon steps data to predict.

--- a/pyzoo/zoo/chronos/model/forecast/tcmf_forecaster.py
+++ b/pyzoo/zoo/chronos/model/forecast/tcmf_forecaster.py
@@ -21,6 +21,7 @@ from zoo.chronos.model.forecast.abstract import Forecaster
 
 
 class TCMFForecaster(Forecaster):
+
     def __init__(self,
                  vbsize=128,
                  hbsize=256,
@@ -35,7 +36,7 @@ class TCMFForecaster(Forecaster):
                  use_time=True,
                  svd=True,):
         """
-        Initialize
+        Build a TCMF Forecast Model.
 
         :param vbsize: int, default is 128.
             Vertical batch size, which is the number of cells per batch.

--- a/pyzoo/zoo/chronos/model/forecast/tcmf_forecaster.py
+++ b/pyzoo/zoo/chronos/model/forecast/tcmf_forecaster.py
@@ -36,6 +36,7 @@ class TCMFForecaster(Forecaster):
                  svd=True,):
         """
         Initialize
+
         :param vbsize: int, default is 128.
             Vertical batch size, which is the number of cells per batch.
         :param hbsize: int, default is 256.
@@ -92,6 +93,7 @@ class TCMFForecaster(Forecaster):
             num_workers=None):
         """
         fit the model on x from scratch
+
         :param x: the input for fit. Only dict of ndarray and SparkXShards of dict of ndarray
             are supported. Example: {'id': id_arr, 'y': data_ndarray}, and data_ndarray is of shape
             (n, T), where n is the number f target time series and T is the number of time steps.
@@ -121,7 +123,7 @@ class TCMFForecaster(Forecaster):
         :param alt_iters: int, default is 10.
             Number of iterations while alternate training.
         :param num_workers: the number of workers you want to use for fit. If None, it defaults to
-        num_ray_nodes in the created RayContext or 1 if there is no active RayContext.
+            num_ray_nodes in the created RayContext or 1 if there is no active RayContext.
         :return: None
         """
         if self.internal is None:
@@ -158,12 +160,13 @@ class TCMFForecaster(Forecaster):
     def fit_incremental(self, x_incr, covariates_incr=None, dti_incr=None):
         """
         incrementally fit the model. Note that we only incrementally fit X_seq (TCN in global model)
+
         :param x_incr: incremental data to be fitted. It should be of the same format as input x in
-         fit, which is a dict of ndarray or SparkXShards of dict of ndarray.
-        Example: {'id': id_arr, 'y': incr_ndarray}, and incr_ndarray is of shape (n, T_incr), where
-        n is the number of target time series, T_incr is the number of time steps incremented. You
-        can choose not to input 'id' in x_incr, but if you do, the elements of id in x_incr should
-        be the same as id in x of fit.
+            fit, which is a dict of ndarray or SparkXShards of dict of ndarray.
+            Example: {'id': id_arr, 'y': incr_ndarray}, and incr_ndarray is of shape (n, T_incr), where
+            n is the number of target time series, T_incr is the number of time steps incremented. You
+            can choose not to input 'id' in x_incr, but if you do, the elements of id in x_incr should
+            be the same as id in x of fit.
         :param covariates_incr: covariates corresponding to x_incr. 2-D ndarray or None.
             The shape of ndarray should be (r, T_incr), where r is the number of covariates.
             Global covariates for all time series. If None, only default time coveriates will be
@@ -187,8 +190,9 @@ class TCMFForecaster(Forecaster):
                  ):
         """
         evaluate the model
+
         :param target_value: target value for evaluation. We interpret its second dimension of
-        as the horizon length for evaluation.
+               as the horizon length for evaluation.
         :param metric: the metrics. A list of metric names.
         :param target_covariates: covariates corresponding to target_value.
             2-D ndarray or None.
@@ -201,7 +205,8 @@ class TCMFForecaster(Forecaster):
             If None, use default fixed frequency DatetimeIndex generated with the last date of x in
             fit and freq.
         :param num_workers: the number of workers to use in evaluate. If None, it defaults to
-        num_ray_nodes in the created RayContext or 1 if there is no active RayContext.
+            num_ray_nodes in the created RayContext or 1 if there is no active RayContext.
+
         :return:
         """
         return self.internal.evaluate(y=target_value,
@@ -218,6 +223,7 @@ class TCMFForecaster(Forecaster):
                 ):
         """
         predict
+
         :param horizon: horizon length to look forward.
         :param future_covariates: covariates corresponding to future horizon steps data to predict.
             2-D ndarray or None.
@@ -230,7 +236,7 @@ class TCMFForecaster(Forecaster):
             If None, use default fixed frequency DatetimeIndex generated with the last date of x in
             fit and freq.
         :param num_workers: the number of workers to use in predict. If None, it defaults to
-        num_ray_nodes in the created RayContext or 1 if there is no active RayContext.
+            num_ray_nodes in the created RayContext or 1 if there is no active RayContext.
         :return:
         """
         if self.internal is None:

--- a/pyzoo/zoo/chronos/model/forecast/tcmf_forecaster.py
+++ b/pyzoo/zoo/chronos/model/forecast/tcmf_forecaster.py
@@ -124,7 +124,6 @@ class TCMFForecaster(Forecaster):
             Number of iterations while alternate training.
         :param num_workers: the number of workers you want to use for fit. If None, it defaults to
             num_ray_nodes in the created RayContext or 1 if there is no active RayContext.
-        :return: None
         """
         if self.internal is None:
             if isinstance(x, SparkXShards):
@@ -175,7 +174,6 @@ class TCMFForecaster(Forecaster):
         :param dti_incr: dti corresponding to the x_incr. DatetimeIndex or None.
             If None, use default fixed frequency DatetimeIndex generated with the last date of x in
             fit and freq.
-        :return: None.
         """
         self.internal.fit_incremental(x_incr,
                                       covariates_incr=covariates_incr,
@@ -237,6 +235,7 @@ class TCMFForecaster(Forecaster):
             fit and freq.
         :param num_workers: the number of workers to use in predict. If None, it defaults to
             num_ray_nodes in the created RayContext or 1 if there is no active RayContext.
+
         :return:
         """
         if self.internal is None:
@@ -248,24 +247,46 @@ class TCMFForecaster(Forecaster):
                                          num_workers=num_workers)
 
     def save(self, path):
+        """
+        Save the forecaster.
+
+        :param path: Path to target saved file.
+        """
         if self.internal is None:
             raise Exception("You should run fit before calling save()")
         else:
             self.internal.save(path)
 
     def is_xshards_distributed(self):
+        """
+        Check whether model is distributed by input xshards.
+
+        :return: True if the model is distributed by input xshards
+        """
         if self.internal is None:
-            raise ValueError("You should run fit before calling is_xshards_distributed()")
+            raise ValueError(
+                "You should run fit before calling is_xshards_distributed()")
         else:
             return self.internal.is_xshards_distributed()
 
     @classmethod
     def load(cls, path, is_xshards_distributed=False, minPartitions=None):
+        """
+        Load a saved model.
+
+        :param path: The location you want to save the forecaster.
+        :param is_xshards_distributed: Whether the model is distributed trained with input of dict of SparkXshards.
+        :param minPartitions: The minimum partitions for the XShards.
+
+        :return: the model loaded
+        """
         loaded_model = TCMFForecaster()
         if is_xshards_distributed:
-            loaded_model.internal = TCMFXshardsModelWrapper(loaded_model.config)
+            loaded_model.internal = TCMFXshardsModelWrapper(
+                loaded_model.config)
             loaded_model.internal.load(path, minPartitions=minPartitions)
         else:
-            loaded_model.internal = TCMFNdarrayModelWrapper(loaded_model.config)
+            loaded_model.internal = TCMFNdarrayModelWrapper(
+                loaded_model.config)
             loaded_model.internal.load(path)
         return loaded_model

--- a/pyzoo/zoo/chronos/model/forecast/tcn_forecaster.py
+++ b/pyzoo/zoo/chronos/model/forecast/tcn_forecaster.py
@@ -19,7 +19,23 @@ from zoo.chronos.model.tcn import TCNPytorch
 
 
 class TCNForecaster(Forecaster):
-
+    """
+        Example:
+            >>> #The dataset is split into x_train, x_val, x_test, y_train, y_val, y_test
+            >>> forecaster = TCNForecaster(past_seq_len=24,
+                                   future_seq_len=5,
+                                   input_feature_num=1,
+                                   output_feature_num=1,
+                                   kernel_size=4,
+                                   num_channels=[16, 16],
+                                   loss="mae",
+                                   lr=0.01)
+            >>> train_loss = forecaster.fit(x_train, x_val, epochs=3)
+            >>> test_pred = forecaster.predict(x_test)
+            >>> test_mse = forecaster.evaluate(x_test, y_test)
+            >>> forecaster.save({ckpt_name})
+            >>> forecaster.restore({ckpt_name})
+    """
     def __init__(self,
                  past_seq_len,
                  future_seq_len,

--- a/pyzoo/zoo/chronos/model/forecast/tcn_forecaster.py
+++ b/pyzoo/zoo/chronos/model/forecast/tcn_forecaster.py
@@ -79,6 +79,8 @@ class TCNForecaster(Forecaster):
         :param epochs: Number of epochs you want to train.
         :param metric: The metric for training data.
         :param batch_size: Number of batch size you want to train.
+
+        :return:
         """
         if validation_data is None:
             validation_data = (x, y)
@@ -113,6 +115,8 @@ class TCNForecaster(Forecaster):
         Predict using a trained forecaster.
 
         :param x: A numpy array with shape (num_samples, lookback, feature_dim).
+
+        :return:
         """
         if not self.internal.model_built:
             raise RuntimeError("You must call fit or restore first before calling predict!")
@@ -125,6 +129,8 @@ class TCNForecaster(Forecaster):
         :param x: A numpy array with shape (num_samples, lookback, feature_dim).
         :param dirname: The directory to save onnx model file. This value defaults
                to None for no saving file.
+
+        :return:
         """
         if not self.internal.model_built:
             raise RuntimeError("You must call fit or restore first before calling predict!")
@@ -140,6 +146,8 @@ class TCNForecaster(Forecaster):
         :param multioutput: Defines aggregating of multiple output values.
                String in ['raw_values', 'uniform_average']. The value defaults to
                'raw_values'.
+
+        :return:
         """
         if not self.internal.model_built:
             raise RuntimeError("You must call fit or restore first before calling evaluate!")
@@ -160,6 +168,8 @@ class TCNForecaster(Forecaster):
         :param multioutput: Defines aggregating of multiple output values.
                String in ['raw_values', 'uniform_average']. The value defaults to
                'raw_values'.
+
+        :return:
         """
         if not self.internal.model_built:
             raise RuntimeError("You must call fit or restore first before calling evaluate!")

--- a/pyzoo/zoo/chronos/model/forecast/tcn_forecaster.py
+++ b/pyzoo/zoo/chronos/model/forecast/tcn_forecaster.py
@@ -96,7 +96,7 @@ class TCNForecaster(Forecaster):
         :param metric: The metric for training data.
         :param batch_size: Number of batch size you want to train.
 
-        :return:
+        :return: Evaluation results on validation data.
         """
         if validation_data is None:
             validation_data = (x, y)
@@ -132,7 +132,7 @@ class TCNForecaster(Forecaster):
 
         :param x: A numpy array with shape (num_samples, lookback, feature_dim).
 
-        :return:
+        :return: A numpy array with shape (num_samples, lookback, feature_dim).
         """
         if not self.internal.model_built:
             raise RuntimeError("You must call fit or restore first before calling predict!")
@@ -146,7 +146,7 @@ class TCNForecaster(Forecaster):
         :param dirname: The directory to save onnx model file. This value defaults
                to None for no saving file.
 
-        :return:
+        :return: A numpy array with shape (num_samples, lookback, feature_dim).
         """
         if not self.internal.model_built:
             raise RuntimeError("You must call fit or restore first before calling predict!")
@@ -163,7 +163,7 @@ class TCNForecaster(Forecaster):
                String in ['raw_values', 'uniform_average']. The value defaults to
                'raw_values'.
 
-        :return:
+        :return: A list of evaluation results. Each item represents a metric.
         """
         if not self.internal.model_built:
             raise RuntimeError("You must call fit or restore first before calling evaluate!")
@@ -185,7 +185,7 @@ class TCNForecaster(Forecaster):
                String in ['raw_values', 'uniform_average']. The value defaults to
                'raw_values'.
 
-        :return:
+        :return: A list of evaluation results. Each item represents a metric.
         """
         if not self.internal.model_built:
             raise RuntimeError("You must call fit or restore first before calling evaluate!")

--- a/pyzoo/zoo/chronos/model/forecast/tfpark_forecaster.py
+++ b/pyzoo/zoo/chronos/model/forecast/tfpark_forecaster.py
@@ -27,7 +27,7 @@ class TFParkForecaster(TFParkKerasModel, Forecaster, metaclass=ABCMeta):
 
     def __init__(self):
         """
-        Initializer.
+        Build a tf.keras model.
         Turns the tf.keras model returned from _build into a tfpark.KerasModel
         """
         self.model = self._build()

--- a/pyzoo/zoo/chronos/model/forecast/tfpark_forecaster.py
+++ b/pyzoo/zoo/chronos/model/forecast/tfpark_forecaster.py
@@ -38,6 +38,7 @@ class TFParkForecaster(TFParkKerasModel, Forecaster, metaclass=ABCMeta):
     def _build(self):
         """
         Build a tf.keras model.
-       :return: a tf.keras model (compiled)
+
+        :return: a tf.keras model (compiled)
         """
         pass

--- a/pyzoo/zoo/orca/automl/auto_estimator.py
+++ b/pyzoo/zoo/orca/automl/auto_estimator.py
@@ -41,15 +41,6 @@ class AutoEstimator:
                  resources_per_trial=None,
                  remote_dir=None,
                  name=None):
-        """
-        Create an AutoEstimator.
-
-        :param model_builder: A ModelBuilder instance, from which we will
-            build the target model for hyperparameter optimization.
-        :param logs_dir: local dir to save training results, defaults to /tmp/auto_estimator_logs
-        :param resources_per_trial: Dict. resources for each trial. e.g. {"cpu": 2}.
-        :param name: AutoEstimator name.
-        """
         self.model_builder = model_builder
         self.searcher = SearchEngineFactory.create_engine(
             backend="ray",

--- a/pyzoo/zoo/orca/automl/auto_estimator.py
+++ b/pyzoo/zoo/orca/automl/auto_estimator.py
@@ -167,7 +167,8 @@ class AutoEstimator:
     def get_best_model(self):
         """
         Return the best model found by the AutoEstimator
-        :return the best model instance
+
+        :return: the best model instance
         """
         best_trial = self.searcher.get_best_trials(k=1)[0]
         best_model_path = best_trial.model_path

--- a/pyzoo/zoo/orca/automl/auto_estimator.py
+++ b/pyzoo/zoo/orca/automl/auto_estimator.py
@@ -21,17 +21,17 @@ class AutoEstimator:
     """
     Example:
         >>> auto_est = AutoEstimator.from_torch(model_creator=model_creator,
-                                            optimizer=get_optimizer,
-                                            loss=nn.BCELoss(),
-                                            logs_dir="/tmp/zoo_automl_logs",
-                                            resources_per_trial={"cpu": 2},
-                                            name="test_fit")
+                                                optimizer=get_optimizer,
+                                                loss=nn.BCELoss(),
+                                                logs_dir="/tmp/zoo_automl_logs",
+                                                resources_per_trial={"cpu": 2},
+                                                name="test_fit")
         >>> auto_est.fit(data=data,
-                     validation_data=validation_data,
-                     search_space=create_linear_search_space(),
-                     n_sampling=4,
-                     epochs=1,
-                     metric="accuracy")
+                         validation_data=validation_data,
+                         search_space=create_linear_search_space(),
+                         n_sampling=4,
+                         epochs=1,
+                         metric="accuracy")
         >>> best_model = auto_est.get_best_model()
     """
 

--- a/pyzoo/zoo/orca/automl/auto_estimator.py
+++ b/pyzoo/zoo/orca/automl/auto_estimator.py
@@ -121,12 +121,12 @@ class AutoEstimator:
 
         :param data: train data.
             If the AutoEstimator is created with from_torch, data can be a tuple of
-                ndarrays or a function that takes a config dictionary as parameter
-                and returns a PyTorch DataLoader.
+            ndarrays or a function that takes a config dictionary as parameter
+            and returns a PyTorch DataLoader.
             If the AutoEstimator is created with from_keras, data can be a tuple of
-                ndarrays.
+            ndarrays.
             If data is a tuple of ndarrays, it should be in the form of (x, y),
-                where x is training input data and y is training target data.
+            where x is training input data and y is training target data.
         :param epochs: Max number of epochs to train in each trial. Defaults to 1.
             If you have also set metric_threshold, a trial will stop if either it has been
             optimized to the metric_threshold or it has been trained for {epochs} epochs.

--- a/pyzoo/zoo/orca/automl/auto_estimator.py
+++ b/pyzoo/zoo/orca/automl/auto_estimator.py
@@ -18,6 +18,23 @@ from zoo.automl.search import SearchEngineFactory
 
 
 class AutoEstimator:
+    """
+    Example:
+        >>> auto_est = AutoEstimator.from_torch(model_creator=model_creator,
+                                            optimizer=get_optimizer,
+                                            loss=nn.BCELoss(),
+                                            logs_dir="/tmp/zoo_automl_logs",
+                                            resources_per_trial={"cpu": 2},
+                                            name="test_fit")
+        >>> auto_est.fit(data=data,
+                     validation_data=validation_data,
+                     search_space=create_linear_search_space(),
+                     n_sampling=4,
+                     epochs=1,
+                     metric="accuracy")
+        >>> best_model = auto_est.get_best_model()
+    """
+
     def __init__(self,
                  model_builder,
                  logs_dir="/tmp/auto_estimator_logs",
@@ -34,11 +51,12 @@ class AutoEstimator:
         :param name: AutoEstimator name.
         """
         self.model_builder = model_builder
-        self.searcher = SearchEngineFactory.create_engine(backend="ray",
-                                                          logs_dir=logs_dir,
-                                                          resources_per_trial=resources_per_trial,
-                                                          remote_dir=remote_dir,
-                                                          name=name)
+        self.searcher = SearchEngineFactory.create_engine(
+            backend="ray",
+            logs_dir=logs_dir,
+            resources_per_trial=resources_per_trial,
+            remote_dir=remote_dir,
+            name=name)
         self._fitted = False
 
     @staticmethod
@@ -148,7 +166,8 @@ class AutoEstimator:
         :param scheduler_params: parameters for scheduler
         """
         if self._fitted:
-            raise RuntimeError("This AutoEstimator has already been fitted and cannot fit again.")
+            raise RuntimeError(
+                "This AutoEstimator has already been fitted and cannot fit again.")
         self.searcher.compile(data=data,
                               model_builder=self.model_builder,
                               validation_data=validation_data,

--- a/pyzoo/zoo/orca/learn/pytorch/estimator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/estimator.py
@@ -142,9 +142,9 @@ class PyTorchRayEstimator(OrcaRayEstimator):
             feature_cols=None, label_cols=None):
         """
         Trains a PyTorch model given training data for several epochs.
-
         Calls `TrainingOperator.train_epoch()` on N parallel workers simultaneously
         underneath the hood.
+
         :param data: An instance of SparkXShards, a Spark DataFrame or a function that
                takes config and batch_size as argument and returns a PyTorch DataLoader for
                training.
@@ -165,7 +165,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
         :param feature_cols: feature column names if data is Spark DataFrame.
         :param label_cols: label column names if data is Spark DataFrame.
 
-        :return A list of dictionary of metrics for every training epoch. If reduce_results is
+        :return: A list of dictionary of metrics for every training epoch. If reduce_results is
                 False, this will return a nested list of metric dictionaries whose length will be
                 equal to the total number of workers.
                 You can also provide custom metrics by passing in a custom training_operator_cls
@@ -185,7 +185,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
         :param profile: Boolean. Whether to return time stats for the training procedure.
                Default is False.
         :param feature_cols: feature column names if data is a Spark DataFrame.
-        :return A SparkXShards that contains the predictions with key "prediction" in each shard
+        :return: A SparkXShards that contains the predictions with key "prediction" in each shard
         """
         return self.estimator.predict(data, batch_size=batch_size,
                                       feature_cols=feature_cols,
@@ -197,9 +197,9 @@ class PyTorchRayEstimator(OrcaRayEstimator):
         Evaluates a PyTorch model given validation data.
         Note that only accuracy for classification with zero-based label is supported by
         default. You can override validate_batch in TrainingOperator for other metrics.
-
         Calls `TrainingOperator.validate()` on N parallel workers simultaneously
         underneath the hood.
+
         :param data: An instance of SparkXShards, a Spark DataFrame or a function that
                takes config and batch_size as argument and returns a PyTorch DataLoader for
                validation.
@@ -216,7 +216,7 @@ class PyTorchRayEstimator(OrcaRayEstimator):
         :param feature_cols: feature column names if train data is Spark DataFrame.
         :param label_cols: label column names if train data is Spark DataFrame.
 
-        :return A dictionary of metrics for the given data, including validation accuracy and loss.
+        :return: A dictionary of metrics for the given data, including validation accuracy and loss.
                 You can also provide custom metrics by passing in a custom training_operator_cls
                 when creating the Estimator.
         """

--- a/pyzoo/zoo/orca/learn/tf/estimator.py
+++ b/pyzoo/zoo/orca/learn/tf/estimator.py
@@ -964,7 +964,7 @@ class KerasEstimator(Estimator):
                tuple]
         :param batch_size: batch size per thread.
         :param feature_cols: feature_cols: feature column names if train data is Spark DataFrame or
-        XShards of Pandas DataFrame.
+               XShards of Pandas DataFrame.
         :param label_cols: label column names if train data is Spark DataFrame or XShards
                of Pandas DataFrame.
         :param auto_shard_files: whether to automatically detect if the dataset is file-based and


### PR DESCRIPTION
- Add two sections **AutoML API** and **ChronosForecasters API** in  readthedocs
- Make sure all parameters and return values has a description
- Add a code example for each class
- Add an intro for each class

You can preview the doc [here](https://yuyin-analytics-zoo.readthedocs.io/en/latest/doc/PythonAPI/AutoML/automl.html)