### PR TITLE
Change return value of fit_eval and change default metric values in automl.BaseModel

### DIFF
--- a/pyzoo/test/zoo/automl/model/test_base_keras_model.py
+++ b/pyzoo/test/zoo/automl/model/test_base_keras_model.py
@@ -50,12 +50,12 @@ class TestBaseKerasModel(TestCase):
         model = modelBuilder_keras.build(config={
             "lr": 1e-2,
             "batch_size": 32,
-            "metric": "mse"
         })
         val_result = model.fit_eval(data=(self.data["x"], self.data["y"]),
                                     validation_data=(self.data["val_x"], self.data["val_y"]),
+                                    metric="mse",
                                     epochs=20)
-        assert val_result is not None
+        assert val_result.get("mse")
 
     def test_uncompiled_model(self):
         def model_creator(config):
@@ -70,10 +70,10 @@ class TestBaseKerasModel(TestCase):
             model = modelBuilder_keras.build(config={
                 "lr": 1e-2,
                 "batch_size": 32,
-                "metric": "mse"
             })
             model.fit_eval(data=(self.data["x"], self.data["y"]),
                            validation_data=(self.data["val_x"], self.data["val_y"]),
+                           metric="mse",
                            epochs=20)
 
     def test_unaligned_metric_value(self):

--- a/pyzoo/test/zoo/automl/model/test_base_keras_model.py
+++ b/pyzoo/test/zoo/automl/model/test_base_keras_model.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 from unittest import TestCase
-from zoo.automl.model.base_keras_model import KerasModelBuilder
+from zoo.automl.model.base_keras_model import KerasBaseModel, KerasModelBuilder
 import numpy as np
 import tensorflow as tf
 import pytest
@@ -42,6 +42,17 @@ def model_creator_keras(config):
     return model
 
 
+def model_creator_multiple_metrics(config):
+    """Returns a tf.keras model"""
+    model = tf.keras.models.Sequential([
+        tf.keras.layers.Dense(1)
+    ])
+    model.compile(loss="mse",
+                  optimizer='sgd',
+                  metrics=["mse", "mae"])
+    return model
+
+
 class TestBaseKerasModel(TestCase):
     data = get_data()
 
@@ -56,6 +67,29 @@ class TestBaseKerasModel(TestCase):
                                     metric="mse",
                                     epochs=20)
         assert val_result.get("mse")
+
+    def test_fit_eval_default_metric(self):
+        modelBuilder_keras = KerasModelBuilder(model_creator_keras)
+        model = modelBuilder_keras.build(config={
+            "lr": 1e-2,
+            "batch_size": 32,
+        })
+        val_result = model.fit_eval(data=(self.data["x"], self.data["y"]),
+                                    validation_data=(self.data["val_x"], self.data["val_y"]),
+                                    epochs=20)
+        hist_metric_name = tf.keras.metrics.get("mse").__name__
+        assert val_result.get(hist_metric_name)
+
+    def test_multiple_metrics_default(self):
+        modelBuilder_keras = KerasModelBuilder(model_creator_multiple_metrics)
+        model = modelBuilder_keras.build(config={
+            "lr": 1e-2,
+            "batch_size": 32,
+        })
+        with pytest.raises(ValueError):
+            model.fit_eval(data=(self.data["x"], self.data["y"]),
+                           validation_data=(self.data["val_x"], self.data["val_y"]),
+                           epochs=20)
 
     def test_uncompiled_model(self):
         def model_creator(config):

--- a/pyzoo/test/zoo/automl/model/test_base_pytorch_model.py
+++ b/pyzoo/test/zoo/automl/model/test_base_pytorch_model.py
@@ -90,7 +90,7 @@ class TestBasePytorchModel(TestCase):
         val_result = model.fit_eval(data=(self.data["x"], self.data["y"]),
                                     validation_data=(self.data["val_x"], self.data["val_y"]),
                                     epochs=20)
-        assert val_result is not None
+        assert val_result.get(metric_name)
 
     def test_evaluate(self):
         modelBuilder = PytorchModelBuilder(model_creator=model_creator_pytorch,
@@ -176,7 +176,7 @@ class TestBasePytorchModel(TestCase):
         assert model.config["train_size"] == 500
         assert model.config["valid_size"] == 100
         assert model.config["shuffle"] is True
-        assert val_result is not None
+        assert val_result.get(metric_name)
 
 
 if __name__ == "__main__":

--- a/pyzoo/test/zoo/automl/model/test_base_pytorch_model.py
+++ b/pyzoo/test/zoo/automl/model/test_base_pytorch_model.py
@@ -80,6 +80,7 @@ class TestBasePytorchModel(TestCase):
     data = get_data()
 
     def test_fit_evaluate(self):
+        metric_name = "rmse"
         modelBuilder = PytorchModelBuilder(model_creator=model_creator_pytorch,
                                            optimizer_creator=optimizer_creator,
                                            loss_creator=loss_creator)
@@ -89,6 +90,7 @@ class TestBasePytorchModel(TestCase):
         })
         val_result = model.fit_eval(data=(self.data["x"], self.data["y"]),
                                     validation_data=(self.data["val_x"], self.data["val_y"]),
+                                    metric=metric_name,
                                     epochs=20)
         assert val_result.get(metric_name)
 
@@ -102,6 +104,7 @@ class TestBasePytorchModel(TestCase):
         })
         model.fit_eval(data=(self.data["x"], self.data["y"]),
                        validation_data=(self.data["val_x"], self.data["val_y"]),
+                       metric="rmse",
                        epochs=20)
         mse_eval = model.evaluate(x=self.data["val_x"], y=self.data["val_y"])
         try:
@@ -114,6 +117,7 @@ class TestBasePytorchModel(TestCase):
         # incremental training test
         model.fit_eval(data=(self.data["x"], self.data["y"]),
                        validation_data=(self.data["val_x"], self.data["val_y"]),
+                       metric="rmse",
                        epochs=20)
         mse_eval = model.evaluate(x=self.data["val_x"], y=self.data["val_y"])
         try:
@@ -134,6 +138,7 @@ class TestBasePytorchModel(TestCase):
         })
         model.fit_eval(data=(self.data["x"], self.data["y"]),
                        validation_data=(self.data["val_x"], self.data["val_y"]),
+                       metric="rmse",
                        epochs=20)
         pred = model.predict(x=self.data["val_x"])
         pred_full_batch = model.predict(x=self.data["val_x"], batch_size=len(self.data["val_x"]))
@@ -160,6 +165,7 @@ class TestBasePytorchModel(TestCase):
             })
 
     def test_dataloader_fit_evaluate(self):
+        metric_name = "rmse"
         modelBuilder = PytorchModelBuilder(model_creator=model_creator_pytorch,
                                            optimizer_creator=optimizer_creator,
                                            loss_creator=loss_creator)
@@ -172,6 +178,7 @@ class TestBasePytorchModel(TestCase):
         })
         val_result = model.fit_eval(data=train_dataloader_creator,
                                     validation_data=valid_dataloader_creator,
+                                    metric=metric_name,
                                     epochs=20)
         assert model.config["train_size"] == 500
         assert model.config["valid_size"] == 100

--- a/pyzoo/test/zoo/chronos/autots/test_auto_ts.py
+++ b/pyzoo/test/zoo/chronos/autots/test_auto_ts.py
@@ -97,7 +97,7 @@ class TestChronosAutoTS(ZooTestCase):
         pipeline = tsp.fit(self.train_df,
                            self.validation_df,
                            recipe=MTNetGridRandomRecipe(
-                               num_rand_samples=5,
+                               num_rand_samples=1,
                                time_step=[5],
                                long_num=[2],
                                batch_size=[1024],

--- a/pyzoo/test/zoo/chronos/model/test_Seq2Seq_pytorch.py
+++ b/pyzoo/test/zoo/chronos/model/test_Seq2Seq_pytorch.py
@@ -47,7 +47,9 @@ class TestSeq2SeqPytorch(TestCase):
     def test_s2s_fit_evaluate(self):
         model = Seq2SeqPytorch()
         config = {"batch_size": 128, "teacher_forcing": False}
-        model.fit_eval((self.train_data[0], self.train_data[1]), self.val_data, **config)
+        model.fit_eval((self.train_data[0], self.train_data[1]), self.val_data,
+                       metric="mse",
+                       **config)
         mse, smape = model.evaluate(self.val_data[0],
                                     self.val_data[1],
                                     metrics=["mse", "smape"])
@@ -59,7 +61,9 @@ class TestSeq2SeqPytorch(TestCase):
     def test_s2s_teacher_forcing_fit_evaluate(self):
         model = Seq2SeqPytorch()
         config = {"batch_size": 128, "teacher_forcing": True}
-        model.fit_eval((self.train_data[0], self.train_data[1]), self.val_data, **config)
+        model.fit_eval((self.train_data[0], self.train_data[1]), self.val_data,
+                       metric="mse",
+                       **config)
         mse, smape = model.evaluate(self.val_data[0],
                                     self.val_data[1],
                                     metrics=["mse", "smape"])
@@ -71,7 +75,9 @@ class TestSeq2SeqPytorch(TestCase):
     def test_s2s_predict_save_restore(self):
         model = Seq2SeqPytorch()
         config = {"batch_size": 128}
-        model.fit_eval((self.train_data[0], self.train_data[1]), self.val_data, **config)
+        model.fit_eval((self.train_data[0], self.train_data[1]), self.val_data,
+                       metric="mse",
+                       **config)
         pred = model.predict(self.test_data[0])
         assert pred.shape == self.test_data[1].shape
         with tempfile.TemporaryDirectory() as tmp_dir_name:

--- a/pyzoo/test/zoo/chronos/model/test_tcn.py
+++ b/pyzoo/test/zoo/chronos/model/test_tcn.py
@@ -47,7 +47,9 @@ class TestTcn(TestCase):
 
     def test_fit_evaluate(self):
         config = {"batch_size": 128}
-        self.model.fit_eval((self.train_data[0], self.train_data[1]), self.val_data, **config)
+        self.model.fit_eval((self.train_data[0], self.train_data[1]), self.val_data,
+                            metric="mse",
+                            **config)
         mse, smape = self.model.evaluate(self.val_data[0],
                                          self.val_data[1],
                                          metrics=["mse", "smape"])
@@ -58,7 +60,9 @@ class TestTcn(TestCase):
 
     def test_predict_save_restore(self):
         config = {"batch_size": 128}
-        self.model.fit_eval((self.train_data[0], self.train_data[1]), self.val_data, **config)
+        self.model.fit_eval((self.train_data[0], self.train_data[1]), self.val_data,
+                            metric="mse",
+                            **config)
         pred = self.model.predict(self.test_data[0])
         assert pred.shape == self.test_data[1].shape
         with tempfile.TemporaryDirectory() as tmp_dir_name:

--- a/pyzoo/zoo/automl/model/abstract.py
+++ b/pyzoo/zoo/automl/model/abstract.py
@@ -32,7 +32,7 @@ class BaseModel(ABC):
         :param data: train data
         :param validation_data: validation data
 
-        :return:
+        :return: A Dictionary
         """
         raise NotImplementedError
 

--- a/pyzoo/zoo/automl/model/base_keras_model.py
+++ b/pyzoo/zoo/automl/model/base_keras_model.py
@@ -49,7 +49,7 @@ class KerasBaseModel(BaseModel):
             raise ValueError("You must create a compiled model in model_creator")
         self.model_built = True
 
-    def fit_eval(self, data, validation_data=None, mc=False, verbose=0, epochs=1, metric="mse",
+    def fit_eval(self, data, validation_data=None, mc=False, verbose=0, epochs=1, metric=None,
                  **config):
         """
         :param data: could be a tuple with numpy ndarray with form (x, y)
@@ -82,19 +82,27 @@ class KerasBaseModel(BaseModel):
                               verbose=verbose
                               )
 
-        # check input metric value
-        hist_metric_name = tf.keras.metrics.get(metric).__name__
         # model.metrics_names are available only after a keras model has been trained/evaluated
         compiled_metric_names = self.model.metrics_names.copy()
         compiled_metric_names.remove("loss")
-        if hist_metric_name in compiled_metric_names:
-            metric_name = hist_metric_name
-        elif metric in compiled_metric_names:
-            metric_name = metric
+        # check input metric value
+        if not metric:
+            if len(compiled_metric_names) == 1:
+                metric = compiled_metric_names[0]
+                metric_name = metric
+            else:
+                raise ValueError(f"Got multiple metrics in compile: {compiled_metric_names}. Please"
+                                 f" choose one target metric for automl optimization")
         else:
-            raise ValueError(f"Input metric in fit_eval should be one of the metrics that are used "
-                             f"to compile the model. Got metric value of {metric} and the metrics "
-                             f"in compile are {compiled_metric_names}")
+            hist_metric_name = tf.keras.metrics.get(metric).__name__
+            if hist_metric_name in compiled_metric_names:
+                metric_name = hist_metric_name
+            elif metric in compiled_metric_names:
+                metric_name = metric
+            else:
+                raise ValueError(f"Input metric in fit_eval should be one of the metrics that are "
+                                 f"used to compile the model. Got metric value of {metric} and the "
+                                 f"metrics in compile are {compiled_metric_names}")
         if validation_data is None:
             result = hist.history.get(metric_name)[-1]
         else:

--- a/pyzoo/zoo/automl/model/base_keras_model.py
+++ b/pyzoo/zoo/automl/model/base_keras_model.py
@@ -64,7 +64,8 @@ class KerasBaseModel(BaseModel):
         def update_config():
             config.setdefault("input_dim", x.shape[-1])
             config.setdefault("output_dim", y.shape[-1])
-            config.update({"metric": metric})
+            if metric:
+                config.update({"metric": metric})
 
         if not self.model_built:
             update_config()

--- a/pyzoo/zoo/automl/model/base_keras_model.py
+++ b/pyzoo/zoo/automl/model/base_keras_model.py
@@ -99,7 +99,7 @@ class KerasBaseModel(BaseModel):
             result = hist.history.get(metric_name)[-1]
         else:
             result = hist.history.get('val_' + metric_name)[-1]
-        return result
+        return {metric: result}
 
     def evaluate(self, x, y, metrics=['mse']):
         """

--- a/pyzoo/zoo/automl/model/base_pytorch_model.py
+++ b/pyzoo/zoo/automl/model/base_pytorch_model.py
@@ -151,7 +151,7 @@ class PytorchBaseModel(BaseModel):
         train_stats = {"loss": np.mean(epoch_losses), "last_loss": epoch_losses[-1]}
         val_stats = self._validate(validation_loader, metric=metric)
         self.onnx_model_built = False
-        return val_stats[metric]
+        return val_stats
 
     @staticmethod
     def to_torch(inp):

--- a/pyzoo/zoo/automl/model/base_pytorch_model.py
+++ b/pyzoo/zoo/automl/model/base_pytorch_model.py
@@ -89,7 +89,7 @@ class PytorchBaseModel(BaseModel):
                                   shuffle=True)
         return data_creator
 
-    def fit_eval(self, data, validation_data=None, mc=False, verbose=0, epochs=1, metric="mse",
+    def fit_eval(self, data, validation_data=None, mc=False, verbose=0, epochs=1, metric=None,
                  **config):
         """
         :param data: data could be a tuple with numpy ndarray with form (x, y) or a
@@ -107,6 +107,9 @@ class PytorchBaseModel(BaseModel):
         """
         # todo: support input validation data None
         assert validation_data is not None, "You must input validation data!"
+
+        if not metric:
+            raise ValueError("You must input a valid metric value for fit_eval.")
 
         # update config settings
         def update_config():

--- a/pyzoo/zoo/automl/search/ray_tune_search_engine.py
+++ b/pyzoo/zoo/automl/search/ray_tune_search_engine.py
@@ -286,7 +286,7 @@ class RayTuneSearchEngine(SearchEngine):
                                               mc=mc,
                                               metric=metric,
                                               **config)
-                reward = result
+                reward = result[metric]
                 checkpoint_filename = "best.ckpt"
 
                 # Save best reward iteration
@@ -305,9 +305,9 @@ class RayTuneSearchEngine(SearchEngine):
                         put_ckpt_hdfs(remote_dir, checkpoint_filename)
 
                 report_dict = {"training_iteration": i,
-                               metric: reward,
                                "checkpoint": checkpoint_filename,
                                "best_" + metric: best_reward}
+                report_dict.update(result)
                 tune.report(**report_dict)
 
         return train_func

--- a/pyzoo/zoo/chronos/model/MTNet_keras.py
+++ b/pyzoo/zoo/chronos/model/MTNet_keras.py
@@ -512,7 +512,7 @@ class MTNetKeras(BaseModel):
             result = hist.history.get(self.metrics[0])[-1]
         else:
             result = hist.history.get('val_' + str(self.metrics[0]))[-1]
-        return result
+        return {self.metrics[0]: result}
 
     def evaluate(self, x, y, metrics=['mse']):
         """

--- a/pyzoo/zoo/chronos/model/MTNet_keras.py
+++ b/pyzoo/zoo/chronos/model/MTNet_keras.py
@@ -262,10 +262,10 @@ class MTNetKeras(BaseModel):
         self.saved_configs = {"cnn_height", "long_num", "time_step", "ar_window",
                               "cnn_hid_size", "rnn_hid_sizes", "cnn_dropout",
                               "rnn_dropout", "lr", "batch_size",
-                              "epochs", "metrics", "mc",
+                              "epochs", "metric", "mc",
                               "feature_num", "output_dim", "loss"}
         self.model = None
-        self.metrics = None
+        self.metric = None
         self.mc = None
         self.epochs = None
 
@@ -277,7 +277,7 @@ class MTNetKeras(BaseModel):
             # assert config_names.issuperset(self.lr_decay_configs) or \
             #        config_names.issuperset(self.lr_configs)
         self.epochs = config.get("epochs")
-        self.metrics = config.get("metrics", ["mean_squared_error"])
+        self.metric = config.get("metric", "mean_squared_error")
         self.mc = config.get("mc")
         self.feature_num = config["feature_num"]
         self.output_dim = config["output_dim"]
@@ -377,7 +377,7 @@ class MTNetKeras(BaseModel):
         #                    optimizer=tf.keras.optimizers.Adam(learning_rate=lr_schedule))
 
         self.model.compile(loss=self.loss,
-                           metrics=self.metrics,
+                           metrics=[self.metric],
                            optimizer=tf.keras.optimizers.Adam(lr=self.lr))
 
         return self.model
@@ -450,17 +450,17 @@ class MTNetKeras(BaseModel):
         return [long_term, short_term], validation_data
 
     def _add_config_attributes(self, config, **new_attributes):
-        # new_attributes are among ["metrics", "epochs", "mc", "feature_num", "output_dim"]
+        # new_attributes are among ["metric", "epochs", "mc", "feature_num", "output_dim"]
         if self.config is None:
             self.config = config
         else:
             if config:
                 raise ValueError("You can only pass new configuations for 'mc', 'epochs' and "
-                                 "'metrics' during incremental fitting. "
+                                 "'metric' during incremental fitting. "
                                  "Additional configs passed are {}".format(config))
 
-        if new_attributes["metrics"] is None:
-            del new_attributes["metrics"]
+        if new_attributes["metric"] is None:
+            del new_attributes["metric"]
         self.config.update(new_attributes)
 
     def _check_input(self, x, y):
@@ -481,11 +481,11 @@ class MTNetKeras(BaseModel):
                              .format(input_output_dim, self.output_dim))
         return input_feature_num, input_output_dim
 
-    def fit_eval(self, data, validation_data=None, mc=False, metrics=None,
+    def fit_eval(self, data, validation_data=None, mc=False, metric=None,
                  epochs=10, verbose=0, **config):
         x, y = data[0], data[1]
         feature_num, output_dim = self._check_input(x, y)
-        self._add_config_attributes(config, epochs=epochs, mc=mc, metrics=metrics,
+        self._add_config_attributes(config, epochs=epochs, mc=mc, metric=metric,
                                     feature_num=feature_num, output_dim=output_dim)
         self.apply_config(config=self.config)
         processed_x, processed_validation_data = self._pre_processing(x, validation_data)
@@ -509,10 +509,10 @@ class MTNetKeras(BaseModel):
         if validation_data is None:
             # get train metrics
             # results = self.model.evaluate(x, y)
-            result = hist.history.get(self.metrics[0])[-1]
+            result = hist.history.get(self.metric)[-1]
         else:
-            result = hist.history.get('val_' + str(self.metrics[0]))[-1]
-        return {self.metrics[0]: result}
+            result = hist.history.get('val_' + str(self.metric))[-1]
+        return {self.metric: result}
 
     def evaluate(self, x, y, metrics=['mse']):
         """
@@ -559,8 +559,7 @@ class MTNetKeras(BaseModel):
                        "batch_size": self.batch_size,
                        # for fit eval
                        "epochs": self.epochs,
-                       # todo: can not serialize metrics unless all elements are str
-                       "metrics": self.metrics,
+                       "metric": self.metric,
                        "mc": self.mc,
                        "feature_num": self.feature_num,
                        "output_dim": self.output_dim,

--- a/pyzoo/zoo/chronos/model/Seq2Seq.py
+++ b/pyzoo/zoo/chronos/model/Seq2Seq.py
@@ -260,7 +260,7 @@ class LSTMSeq2Seq(BaseModel):
             result = hist.history.get(metric_name)[-1]
         else:
             result = hist.history.get('val_' + metric_name)[-1]
-        return result
+        return {self.metric: result}
 
     def evaluate(self, x, y, metric=['mse']):
         """

--- a/pyzoo/zoo/chronos/model/VanillaLSTM.py
+++ b/pyzoo/zoo/chronos/model/VanillaLSTM.py
@@ -44,7 +44,7 @@ def model_creator(config):
     model.compile(loss=config.get("loss", "mse"),
                   optimizer=getattr(tf.keras.optimizers, config.get("optim", "Adam"))
                   (learning_rate=config.get("lr", 0.001)),
-                  metrics=[config["metric"]])
+                  metrics=[config.get("metric", "mse")])
     return model
 
 

--- a/pyzoo/zoo/chronos/model/prophet.py
+++ b/pyzoo/zoo/chronos/model/prophet.py
@@ -78,7 +78,7 @@ class ProphetModel(BaseModel):
         target = data['val_y']
         self.model.fit(x)
         val_metric = self.evaluate(x=None, target=target, metrics=[self.metric])[0].item()
-        return val_metric
+        return {self.metric: val_metric}
 
     def predict(self, x=None, horizon=24):
         """

--- a/pyzoo/zoo/chronos/model/tcmf_model.py
+++ b/pyzoo/zoo/chronos/model/tcmf_model.py
@@ -96,7 +96,7 @@ class TCMF(BaseModel):
                                                max_TCN_epoch=config.get("max_TCN_epoch", 300),
                                                num_workers=num_workers,
                                                )
-        return val_loss
+        return {"val_loss": val_loss}
 
     def fit_incremental(self, x, covariates_new=None, dti_new=None):
         """

--- a/pyzoo/zoo/orca/automl/xgboost/XGBoost.py
+++ b/pyzoo/zoo/orca/automl/xgboost/XGBoost.py
@@ -127,7 +127,6 @@ class XGBoost(BaseModel):
         if not self.model_init:
             self._build(**config)
         if validation_data is not None and type(validation_data) is not list:
-<<<<<<< HEAD
             eval_set = [validation_data]
         else:
             eval_set = validation_data

--- a/pyzoo/zoo/orca/automl/xgboost/XGBoost.py
+++ b/pyzoo/zoo/orca/automl/xgboost/XGBoost.py
@@ -127,6 +127,7 @@ class XGBoost(BaseModel):
         if not self.model_init:
             self._build(**config)
         if validation_data is not None and type(validation_data) is not list:
+<<<<<<< HEAD
             eval_set = [validation_data]
         else:
             eval_set = validation_data
@@ -144,7 +145,7 @@ class XGBoost(BaseModel):
         if self.metric in XGB_METRIC_NAME:
             self.model.fit(x, y, eval_set=eval_set, eval_metric=self.metric)
             vals = self.model.evals_result_.get("validation_0").get(self.metric)
-            return vals[-1]
+            return {self.metric: vals[-1]}
         else:
             if isinstance(validation_data, list):
                 validation_data = validation_data[0]
@@ -153,7 +154,7 @@ class XGBoost(BaseModel):
                 validation_data[0],
                 validation_data[1],
                 metrics=[self.metric])[0]
-            return eval_result
+            return {self.metric: eval_result}
 
     def predict(self, x):
         """


### PR DESCRIPTION
This PR includes
- Change return value from `eval_result` value to dictionary of {`metric_name`: `eval_result`} in `fit_eval` for all `automl.BaseModel` inheritors 
- Change default `metric` value in `BaseKerasModel` from "mse" to `None`. If use leaves the `metric` in `fit_eval` as default, we will use the compiled metric name and value as evaluation result if user only used one metric to compile the model. We will raise error if user used multiple metrics in `model_creator` and didn't specify a specific target metric for `AutoEstimator` to optimize.
- Change default `metric` value in `BasePytorchModel` from "mse" to `None`.  