### PR TITLE
Remove pyarrow 0.17.0 in pip dependencies

### DIFF
--- a/pyzoo/setup.py
+++ b/pyzoo/setup.py
@@ -140,7 +140,7 @@ def setup_package():
         packages=packages,
         install_requires=['pyspark==2.4.3', 'bigdl==0.12.2', 'conda-pack==0.3.1'],
         extras_require={'ray': ['ray==1.2.0', 'psutil', 'aiohttp==3.7.0',
-                                'setproctitle', 'pyarrow==0.17.0', 'hiredis==1.1.0'],
+                                'setproctitle', 'hiredis==1.1.0'],
                         'automl': ['tensorflow>=1.15.0,<2.0.0', 'h5py==2.10.0', 'hiredis==1.1.0',
                                    'ray[tune]==1.2.0', 'psutil', 'aiohttp', 'setproctitle',
                                    'pandas', 'scikit-learn>=0.20.0,<=0.22.0', 'requests']},


### PR DESCRIPTION
This is previously used to put Spark rdd into plasma.
Now out of date. Remove it from the dependencies.