### PR TITLE
Add rolling feature by tsfresh in TSDataset

### DIFF
--- a/pyzoo/test/zoo/chronos/data/utils/test_roll.py
+++ b/pyzoo/test/zoo/chronos/data/utils/test_roll.py
@@ -36,6 +36,7 @@ class TestRollTimeSeries(ZooTestCase):
 
     def test_roll_timeseries_dataframe(self):
         x, y = roll_timeseries_dataframe(self.easy_data,
+                                         None,
                                          lookback=self.lookback,
                                          horizon=[1, 3],
                                          feature_col=["A"],
@@ -44,6 +45,7 @@ class TestRollTimeSeries(ZooTestCase):
         assert y.shape == (8-self.lookback, 2, 1)
 
         x, y = roll_timeseries_dataframe(self.easy_data,
+                                         None,
                                          lookback=self.lookback,
                                          horizon=4,
                                          feature_col=["A", "C"],
@@ -52,6 +54,7 @@ class TestRollTimeSeries(ZooTestCase):
         assert y.shape == (7-self.lookback, 4, 1)
 
         x, y = roll_timeseries_dataframe(self.easy_data,
+                                         None,
                                          lookback=2,
                                          horizon=0,
                                          feature_col=[],
@@ -61,6 +64,7 @@ class TestRollTimeSeries(ZooTestCase):
 
         self.easy_data["A"][0] = None
         x, y = roll_timeseries_dataframe(self.easy_data,
+                                         None,
                                          lookback=2,
                                          horizon=0,
                                          feature_col=[],
@@ -69,6 +73,7 @@ class TestRollTimeSeries(ZooTestCase):
         assert y is None
 
         x, y = roll_timeseries_dataframe(self.easy_data,
+                                         None,
                                          lookback=2,
                                          horizon=2,
                                          feature_col=["C"],

--- a/pyzoo/zoo/chronos/data/tsdataset.py
+++ b/pyzoo/zoo/chronos/data/tsdataset.py
@@ -26,6 +26,15 @@ from zoo.chronos.data.utils.scale import unscale_timeseries_numpy
 from zoo.chronos.data.utils.resample import resample_timeseries_dataframe
 from zoo.chronos.data.utils.split import split_timeseries_dataframe
 
+from tsfresh.utilities.dataframe_functions import roll_time_series
+from tsfresh.utilities.dataframe_functions import impute as impute_tsfresh
+from tsfresh import extract_features
+from tsfresh.feature_extraction import ComprehensiveFCParameters,\
+            MinimalFCParameters, EfficientFCParameters
+DEFAULT_PARAMS = {"comprehensive": ComprehensiveFCParameters(),
+                  "minimal": MinimalFCParameters(),
+                  "efficient": EfficientFCParameters()}
+
 _DEFAULT_ID_COL_NAME = "id"
 _DEFAULT_ID_PLACEHOLDER = "0"
 
@@ -42,17 +51,19 @@ class TSDataset:
         self.feature_col = schema["feature_col"]
         self.target_col = schema["target_col"]
 
-        self._check_basic_invariants()
-
-        self._id_list = list(np.unique(self.df[self.id_col]))
-        self._is_pd_datetime = pd.api.types.is_datetime64_any_dtype(self.df[self.dt_col].dtypes)
-
         self.numpy_x = None
         self.numpy_y = None
         self.roll_feature = None
         self.roll_target = None
+        self.roll_feature_df = None
+        self.roll_addional_feature = None
         self.scaler = None
         self.id_sensitive = None
+
+        self._check_basic_invariants()
+
+        self._id_list = list(np.unique(self.df[self.id_col]))
+        self._is_pd_datetime = pd.api.types.is_datetime64_any_dtype(self.df[self.dt_col].dtypes)
 
     @staticmethod
     def from_pandas(df,
@@ -250,17 +261,11 @@ class TSDataset:
                                                kind_to_fc_parameters=full_settings)
             return self
 
-        from tsfresh.feature_extraction import ComprehensiveFCParameters,\
-            MinimalFCParameters, EfficientFCParameters
-        default_params = {"comprehensive": ComprehensiveFCParameters(),
-                          "minimal": MinimalFCParameters(),
-                          "efficient": EfficientFCParameters()}
-
         if isinstance(settings, str):
             assert settings in ["comprehensive", "minimal", "efficient"], \
                 f"settings str should be one of \"comprehensive\", \"minimal\", \"efficient\"\
                     , but found {settings}."
-            default_fc_parameters = default_params[settings]
+            default_fc_parameters = DEFAULT_PARAMS[settings]
         else:
             default_fc_parameters = settings
 
@@ -274,6 +279,46 @@ class TSDataset:
         self.feature_col += addtional_feature
 
         return self
+
+    def gen_rolling_feature(self,
+                            window_size,
+                            settings="comprehensive",
+                            full_settings=None):
+        '''
+        :param window_size: int, generate feature according to the rolling result.
+        :param settings: str or dict. If a string is set, then it must be one of "comprehensive"
+               "minimal" and "efficient". If a dict is set then it should follow the instruction
+               for default_fc_parameters in tsfresh. The value is defaulted to "comprehensive".
+        :param full_settings: dict. It should follow the instruction for kind_to_fc_parameters in
+               tsfresh. The value is defaulted to None.
+
+        :return: the tsdataset instance.
+        '''
+        if isinstance(settings, str):
+            assert settings in ["comprehensive", "minimal", "efficient"], \
+                f"settings str should be one of \"comprehensive\", \"minimal\", \"efficient\"\
+                    , but found {settings}."
+            default_fc_parameters = DEFAULT_PARAMS[settings]
+        else:
+            default_fc_parameters = settings
+        
+        df_rolled = roll_time_series(self.df,
+                                     column_id=self.id_col,
+                                     column_sort=self.dt_col,
+                                     max_timeshift=window_size-1,
+                                     min_timeshift=window_size-1)
+
+        self.roll_feature_df = extract_features(df_rolled,
+                                                column_id=self.id_col,
+                                                column_sort=self.dt_col,
+                                                default_fc_parameters=default_fc_parameters)
+        impute_tsfresh(self.roll_feature_df)
+
+        self.feature_col += list(self.roll_feature_df.columns)
+        self.roll_addional_feature = list(self.roll_feature_df.columns)
+
+        return self
+
 
     def roll(self,
              lookback,
@@ -319,16 +364,26 @@ class TSDataset:
             else self.feature_col
         target_col = _to_list(target_col, "target_col") if target_col is not None \
             else self.target_col
+        if self.roll_addional_feature:
+            additional_feature_col =\
+                list(set(feature_col).intersection(set(self.roll_addional_feature)))
+            feature_col =\
+                list(set(feature_col) - set(self.roll_addional_feature))
+            self.roll_feature = feature_col + additional_feature_col
+        else:
+            additional_feature_col = None
+            self.roll_feature = feature_col
 
         num_id = len(self._id_list)
         num_feature_col = len(self.feature_col)
         num_target_col = len(self.target_col)
-        self.roll_feature = feature_col
         self.roll_target = target_col
         self.id_sensitive = id_sensitive
+        roll_feature_df = None if self.roll_feature_df is None else self.roll_feature_df[additional_feature_col]
 
         # get rolling result for each sub dataframe
         rolling_result = [roll_timeseries_dataframe(df=self.df[self.df[self.id_col] == id_name],
+                                                    roll_feature_df=roll_feature_df,
                                                     lookback=lookback,
                                                     horizon=horizon,
                                                     feature_col=feature_col,
@@ -388,12 +443,17 @@ class TSDataset:
                test set. The value is defaulted to True.
         :return: the tsdataset instance.
         '''
+        feature_col = []
+        if self.roll_addional_feature:
+            for feature in self.feature_col:
+                if not feature in self.roll_addional_feature:
+                    feature_col.append(feature)
         if fit:
-            self.df[self.target_col + self.feature_col] = \
-                scaler.fit_transform(self.df[self.target_col + self.feature_col])
+            self.df[self.target_col + feature_col] = \
+                scaler.fit_transform(self.df[self.target_col + feature_col])
         else:
-            self.df[self.target_col + self.feature_col] = \
-                scaler.transform(self.df[self.target_col + self.feature_col])
+            self.df[self.target_col + feature_col] = \
+                scaler.transform(self.df[self.target_col + feature_col])
         self.scaler = scaler
         return self
 
@@ -403,8 +463,13 @@ class TSDataset:
 
         :return: the tsdataset instance.
         '''
-        self.df[self.target_col + self.feature_col] = \
-            self.scaler.inverse_transform(self.df[self.target_col + self.feature_col])
+        feature_col = []
+        if self.roll_addional_feature:
+            for feature in self.feature_col:
+                if not feature in self.roll_addional_feature:
+                    feature_col.append(feature)
+        self.df[self.target_col + feature_col] = \
+            self.scaler.inverse_transform(self.df[self.target_col + feature_col])
         return self
 
     def _unscale_numpy(self, data):
@@ -440,6 +505,8 @@ class TSDataset:
         for target_col_name in self.target_col:
             _check_col_within(self.df, target_col_name)
         for feature_col_name in self.feature_col:
+            if self.roll_addional_feature and feature_col_name in self.roll_addional_feature:
+                continue
             _check_col_within(self.df, feature_col_name)
 
         # check no n/a in critical col

--- a/pyzoo/zoo/chronos/data/tsdataset.py
+++ b/pyzoo/zoo/chronos/data/tsdataset.py
@@ -374,10 +374,10 @@ class TSDataset:
             additional_feature_col = None
             self.roll_feature = feature_col
 
-        num_id = len(self._id_list)
-        num_feature_col = len(self.feature_col)
-        num_target_col = len(self.target_col)
         self.roll_target = target_col
+        num_id = len(self._id_list)
+        num_feature_col = len(self.roll_feature)
+        num_target_col = len(self.roll_target)
         self.id_sensitive = id_sensitive
         roll_feature_df = None if self.roll_feature_df is None else self.roll_feature_df[additional_feature_col]
 

--- a/pyzoo/zoo/chronos/data/tsdataset.py
+++ b/pyzoo/zoo/chronos/data/tsdataset.py
@@ -257,10 +257,13 @@ class TSDataset:
 
         '''
         if full_settings is not None:
-            self.df = generate_global_features(input_df=self.df,
-                                               column_id=self.id_col,
-                                               column_sort=self.dt_col,
-                                               kind_to_fc_parameters=full_settings)
+            self.df,\
+                addtional_feature =\
+                generate_global_features(input_df=self.df,
+                                        column_id=self.id_col,
+                                        column_sort=self.dt_col,
+                                        kind_to_fc_parameters=full_settings)
+            self.feature_col += addtional_feature
             return self
 
         if isinstance(settings, str):
@@ -456,8 +459,9 @@ class TSDataset:
                test set. The value is defaulted to True.
         :return: the tsdataset instance.
         '''
-        feature_col = []
+        feature_col = self.feature_col
         if self.roll_addional_feature:
+            feature_col = []
             for feature in self.feature_col:
                 if feature not in self.roll_addional_feature:
                     feature_col.append(feature)
@@ -476,8 +480,9 @@ class TSDataset:
 
         :return: the tsdataset instance.
         '''
-        feature_col = []
+        feature_col = self.feature_col
         if self.roll_addional_feature:
+            feature_col = []
             for feature in self.feature_col:
                 if feature not in self.roll_addional_feature:
                     feature_col.append(feature)

--- a/pyzoo/zoo/chronos/data/tsdataset.py
+++ b/pyzoo/zoo/chronos/data/tsdataset.py
@@ -245,6 +245,8 @@ class TSDataset:
         Generate per-time-series feature for each time series.
         This method will be implemented by tsfresh.
 
+        TODO: relationship with scale should be figured out.
+
         :param settings: str or dict. If a string is set, then it must be one of "comprehensive"
                "minimal" and "efficient". If a dict is set then it should follow the instruction
                for default_fc_parameters in tsfresh. The value is defaulted to "comprehensive".
@@ -285,6 +287,11 @@ class TSDataset:
                             settings="comprehensive",
                             full_settings=None):
         '''
+        Generate aggregation feature for each sample.
+        This method will be implemented by tsfresh.
+
+        TODO: relationship with scale should be figured out.
+
         :param window_size: int, generate feature according to the rolling result.
         :param settings: str or dict. If a string is set, then it must be one of "comprehensive"
                "minimal" and "efficient". If a dict is set then it should follow the instruction
@@ -307,11 +314,16 @@ class TSDataset:
                                      column_sort=self.dt_col,
                                      max_timeshift=window_size-1,
                                      min_timeshift=window_size-1)
-
-        self.roll_feature_df = extract_features(df_rolled,
-                                                column_id=self.id_col,
-                                                column_sort=self.dt_col,
-                                                default_fc_parameters=default_fc_parameters)
+        if not full_settings:
+            self.roll_feature_df = extract_features(df_rolled,
+                                                    column_id=self.id_col,
+                                                    column_sort=self.dt_col,
+                                                    default_fc_parameters=default_fc_parameters)
+        else:
+            self.roll_feature_df = extract_features(df_rolled,
+                                                    column_id=self.id_col,
+                                                    column_sort=self.dt_col,
+                                                    kind_to_fc_parameters=full_settings)
         impute_tsfresh(self.roll_feature_df)
 
         self.feature_col += list(self.roll_feature_df.columns)

--- a/pyzoo/zoo/chronos/data/tsdataset.py
+++ b/pyzoo/zoo/chronos/data/tsdataset.py
@@ -260,9 +260,9 @@ class TSDataset:
             self.df,\
                 addtional_feature =\
                 generate_global_features(input_df=self.df,
-                                        column_id=self.id_col,
-                                        column_sort=self.dt_col,
-                                        kind_to_fc_parameters=full_settings)
+                                         column_id=self.id_col,
+                                         column_sort=self.dt_col,
+                                         kind_to_fc_parameters=full_settings)
             self.feature_col += addtional_feature
             return self
 

--- a/pyzoo/zoo/chronos/data/tsdataset.py
+++ b/pyzoo/zoo/chronos/data/tsdataset.py
@@ -30,7 +30,7 @@ from tsfresh.utilities.dataframe_functions import roll_time_series
 from tsfresh.utilities.dataframe_functions import impute as impute_tsfresh
 from tsfresh import extract_features
 from tsfresh.feature_extraction import ComprehensiveFCParameters,\
-            MinimalFCParameters, EfficientFCParameters
+    MinimalFCParameters, EfficientFCParameters
 DEFAULT_PARAMS = {"comprehensive": ComprehensiveFCParameters(),
                   "minimal": MinimalFCParameters(),
                   "efficient": EfficientFCParameters()}
@@ -308,7 +308,7 @@ class TSDataset:
             default_fc_parameters = DEFAULT_PARAMS[settings]
         else:
             default_fc_parameters = settings
-        
+
         df_rolled = roll_time_series(self.df,
                                      column_id=self.id_col,
                                      column_sort=self.dt_col,
@@ -330,7 +330,6 @@ class TSDataset:
         self.roll_addional_feature = list(self.roll_feature_df.columns)
 
         return self
-
 
     def roll(self,
              lookback,
@@ -391,7 +390,8 @@ class TSDataset:
         num_feature_col = len(self.roll_feature)
         num_target_col = len(self.roll_target)
         self.id_sensitive = id_sensitive
-        roll_feature_df = None if self.roll_feature_df is None else self.roll_feature_df[additional_feature_col]
+        roll_feature_df = None if self.roll_feature_df is None \
+            else self.roll_feature_df[additional_feature_col]
 
         # get rolling result for each sub dataframe
         rolling_result = [roll_timeseries_dataframe(df=self.df[self.df[self.id_col] == id_name],
@@ -448,6 +448,7 @@ class TSDataset:
     def scale(self, scaler, fit=True):
         '''
         scale the time series dataset's feature column and target column.
+
         :param scaler: sklearn scaler instance, StandardScaler, MaxAbsScaler,
                MinMaxScaler and RobustScaler are supported.
         :param fit: if we need to fit the scaler. Typically, the value should
@@ -458,7 +459,7 @@ class TSDataset:
         feature_col = []
         if self.roll_addional_feature:
             for feature in self.feature_col:
-                if not feature in self.roll_addional_feature:
+                if feature not in self.roll_addional_feature:
                     feature_col.append(feature)
         if fit:
             self.df[self.target_col + feature_col] = \
@@ -478,7 +479,7 @@ class TSDataset:
         feature_col = []
         if self.roll_addional_feature:
             for feature in self.feature_col:
-                if not feature in self.roll_addional_feature:
+                if feature not in self.roll_addional_feature:
                     feature_col.append(feature)
         self.df[self.target_col + feature_col] = \
             self.scaler.inverse_transform(self.df[self.target_col + feature_col])

--- a/pyzoo/zoo/chronos/data/utils/roll.py
+++ b/pyzoo/zoo/chronos/data/utils/roll.py
@@ -26,8 +26,10 @@ def roll_timeseries_dataframe(df,
                               target_col):
     """
     roll dataframe into numpy ndarray sequence samples.
+
     :param input_df: a dataframe which has been resampled in uniform frequency.
-    :param roll_feature_df: 
+    :param roll_feature_df: an additional rolling feature dataframe that will
+           be append to final result.
     :param lookback: the length of the past sequence
     :param horizon: int or list,
            if `horizon` is an int, we will sample `horizon` step
@@ -76,7 +78,7 @@ def _append_rolling_feature_df(rolling_result,
                                          len(roll_feature_df.columns)))
     for idx in range(additional_rolling_result.shape[0]):
         for col_idx in range(additional_rolling_result.shape[2]):
-            additional_rolling_result[idx,:,col_idx] = roll_feature_df.iloc[idx, col_idx]
+            additional_rolling_result[idx, :, col_idx] = roll_feature_df.iloc[idx, col_idx]
     rolling_result = np.concatenate([rolling_result, additional_rolling_result], axis=2)
     return rolling_result
 

--- a/pyzoo/zoo/chronos/data/utils/roll.py
+++ b/pyzoo/zoo/chronos/data/utils/roll.py
@@ -19,6 +19,7 @@ import pandas as pd
 
 
 def roll_timeseries_dataframe(df,
+                              roll_feature_df,
                               lookback,
                               horizon,
                               feature_col,
@@ -26,6 +27,7 @@ def roll_timeseries_dataframe(df,
     """
     roll dataframe into numpy ndarray sequence samples.
     :param input_df: a dataframe which has been resampled in uniform frequency.
+    :param roll_feature_df: 
     :param lookback: the length of the past sequence
     :param horizon: int or list,
            if `horizon` is an int, we will sample `horizon` step
@@ -52,18 +54,35 @@ def roll_timeseries_dataframe(df,
     is_test = True if (is_horizon_int and horizon == 0) else False
     if not is_test:
         return _roll_timeseries_dataframe_train(df,
+                                                roll_feature_df,
                                                 lookback,
                                                 horizon,
                                                 feature_col,
                                                 target_col)
     else:
         return _roll_timeseries_dataframe_test(df,
+                                               roll_feature_df,
                                                lookback,
                                                feature_col,
                                                target_col)
 
 
+def _append_rolling_feature_df(rolling_result,
+                               roll_feature_df):
+    if roll_feature_df is None:
+        return rolling_result
+    additional_rolling_result = np.zeros((rolling_result.shape[0],
+                                         rolling_result.shape[1],
+                                         len(roll_feature_df.columns)))
+    for idx in range(additional_rolling_result.shape[0]):
+        for col_idx in range(additional_rolling_result.shape[2]):
+            additional_rolling_result[idx,:,col_idx] = roll_feature_df.iloc[idx, col_idx]
+    rolling_result = np.concatenate([rolling_result, additional_rolling_result], axis=2)
+    return rolling_result
+
+
 def _roll_timeseries_dataframe_test(df,
+                                    roll_feature_df,
                                     lookback,
                                     feature_col,
                                     target_col):
@@ -72,10 +91,13 @@ def _roll_timeseries_dataframe_test(df,
     output_x, mask_x = _roll_timeseries_ndarray(x, lookback)
     mask = (mask_x == 1)
 
-    return output_x[mask], None
+    x = _append_rolling_feature_df(output_x[mask], roll_feature_df)
+
+    return x, None
 
 
 def _roll_timeseries_dataframe_train(df,
+                                     roll_feature_df,
                                      lookback,
                                      horizon,
                                      feature_col,
@@ -88,7 +110,9 @@ def _roll_timeseries_dataframe_train(df,
     output_y, mask_y = _roll_timeseries_ndarray(y, horizon)
     mask = (mask_x == 1) & (mask_y == 1)
 
-    return output_x[mask], output_y[mask]
+    x = _append_rolling_feature_df(output_x[mask], roll_feature_df)
+
+    return x, output_y[mask]
 
 
 def _roll_timeseries_ndarray(data, window):


### PR DESCRIPTION
add rolling feature rather than global feature for each rolling sample. The method should be called after scale and before roll. And window_size should be the same as lookback.
```python
tsdata.gen_dt_feature()\
          .scale(scaler)\
          .gen_rolling_feature(settings="minimal", window_size=5)\
          .roll(lookback=5, horizon=4, id_sensitive=True)
```
Need huge amount of testing and code cleaning