### PR TITLE
Support customized metric function in AutoEstimtor and AutoXGBoost

### DIFF
--- a/pyzoo/test/zoo/orca/automl/xgboost/test_xgbregressor.py
+++ b/pyzoo/test/zoo/orca/automl/xgboost/test_xgbregressor.py
@@ -90,6 +90,18 @@ class TestXgbregressor(ZooTestCase):
                 validation_data=[(self.val_x, self.val_y)],
                 metric="wrong_metric")
 
+        # metric func
+        def pyrmsle(y_true, y_pred):
+            y_pred[y_pred < -1] = -1 + 1e-6
+            elements = np.power(np.log1p(y_true) - np.log1p(y_pred), 2)
+            return float(np.sqrt(np.sum(elements) / len(y_true)))
+
+        result = self.model.fit_eval(
+            data=(self.x, self.y),
+            validation_data=[(self.val_x, self.val_y)],
+            metric_func=pyrmsle)
+        assert "pyrmsle" in result
+
     def test_data_creator(self):
         def get_x_y(size, config):
             values = np.random.randn(size, 4)

--- a/pyzoo/zoo/orca/automl/auto_estimator.py
+++ b/pyzoo/zoo/orca/automl/auto_estimator.py
@@ -116,6 +116,7 @@ class AutoEstimator:
             epochs=1,
             validation_data=None,
             metric=None,
+            metric_func=None,
             metric_mode=None,
             metric_threshold=None,
             n_sampling=1,
@@ -141,7 +142,11 @@ class AutoEstimator:
             optimized to the metric_threshold or it has been trained for {epochs} epochs.
         :param validation_data: Validation data. Validation data type should be the same as data.
         :param metric: String. The evaluation metric name to optimize, e.g. "mse"
+        :param metric_func: Customized evaluation metric function. Defaults to be None.
+            The signature should be func(y_true, y_pred), where y_true and y_pred are numpy ndarray.
+            The function should return a float value as evaluation result.
         :param metric_mode: One of ["min", "max"]. "max" means greater metric value is better.
+            You have to specify metric_mode if you use a customized metric function.
             You don't have to specify metric_mode if you use the built-in metric in
             zoo.automl.common.metrics.Evaluator.
         :param metric_threshold: a trial will be terminated when metric threshold is met


### PR DESCRIPTION
### What's in this PR
User customized metric function support for `AutoEstimator.from_keras`, `AutoEstimator.from_torch`, `AutoXGBClassifier`, `AutoXGBRegressor`

### API Change
Support input function for `metric` in `AutoEstimator.fit()`, `AutoXGBClassifier.fit()`, `AutoXGBRegressor.fit()`

### Usage Example
```python
# user customized metric function
def pyrmsle(y_true, y_pred):
    y_pred[y_pred < -1] = -1 + 1e-6
    elements = np.power(np.log1p(y_true) - np.log1p(y_pred), 2)
    return float(np.sqrt(np.sum(elements) / len(y_true)))

auto_est = AutoEstimator.from_keras(model_creator=model_creator)
# user should pass their metric function to metric and specify metric_mode
auto_est.fit(data=data,
             validation_data=validation_data,
             search_space=search_space,
             n_sampling=4,
             epochs=1,
             metric=pyrmsle,
             metric_mode="min")
auto_est.get_best_model()
```
