### PR TITLE
Always keep driver core as 0 when start ray on driver in cluster mode

### DIFF
--- a/pyzoo/zoo/orca/common.py
+++ b/pyzoo/zoo/orca/common.py
@@ -262,8 +262,6 @@ def init_orca_context(cluster_mode="local", cores=2, memory="2g", num_nodes=1,
     ray_ctx = RayContext(sc, **ray_args)
     if init_ray_on_spark:
         driver_cores = 0  # This is the default value.
-        if "driver_cores" in kwargs:
-            driver_cores = kwargs["driver_cores"]
         ray_ctx.init(driver_cores=driver_cores)
     return sc
 


### PR DESCRIPTION
If start ray on driver with more than 0 cores, the TFRunner or other actors would run on driver which is not expected.
So not pass driver cores values when calling ray_context.init()