### PR TITLE
Add Random Seed for Generating ARIMA Unittest Data

### DIFF
--- a/pyzoo/test/zoo/chronos/autots/model/test_auto_arima.py
+++ b/pyzoo/test/zoo/chronos/autots/model/test_auto_arima.py
@@ -24,6 +24,7 @@ from zoo.orca.automl import hp
 
 
 def get_data():
+    np.random.seed(0)
     seq_len = 400
     data = np.random.rand(seq_len)
     horizon = np.random.randint(2, 50)

--- a/pyzoo/test/zoo/chronos/model/test_arima.py
+++ b/pyzoo/test/zoo/chronos/model/test_arima.py
@@ -27,6 +27,7 @@ import pandas as pd
 class TestARIMAModel(ZooTestCase):
 
     def setup_method(self, method):
+        np.random.seed(0)
         self.seq_len = 400
         self.config = {
             "p": np.random.randint(0, 4),


### PR DESCRIPTION
Add Random Seed for Generating ARIMA Unittest Data.

Work-around solution to irregular random data that leads to LU Decomposition Error as in #4170.