### PR TITLE
Support numPartition < num workers for RayXShards

### DIFF
--- a/pyzoo/test/zoo/orca/data/test_ray_xshards.py
+++ b/pyzoo/test/zoo/orca/data/test_ray_xshards.py
@@ -68,7 +68,7 @@ def test_assign_partitions_to_actors(orca_context_fixture):
 
     actor_num = 3
     actors = [Add1Actor.remote() for i in range(actor_num)]
-    parts_list, _ = ray_xshards.assign_partitions_to_actors(actors)
+    parts_list, _, _ = ray_xshards.assign_partitions_to_actors(actors)
 
     assert len(parts_list) == actor_num
 
@@ -78,6 +78,20 @@ def test_assign_partitions_to_actors(orca_context_fixture):
             assert len(parts_list[counter]) == div + 1
         else:
             assert len(parts_list[counter]) == div
+
+
+def test_less_partition_than_actors(orca_context_fixture):
+    ray_xshards, _ = get_ray_xshards()
+    part_num = ray_xshards.num_partitions()
+
+    actor_num = 6
+    actors = [Add1Actor.remote() for i in range(actor_num)]
+    parts_list, _, assigned_actors = ray_xshards.assign_partitions_to_actors(actors)
+
+    assert len(parts_list) == len(assigned_actors) == part_num
+
+    for counter in range(len(assigned_actors)):
+        assert len(parts_list[counter]) == 1
 
 
 def test_transform_shards_with_actors(orca_context_fixture):

--- a/pyzoo/test/zoo/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
+++ b/pyzoo/test/zoo/orca/learn/ray/pytorch/test_estimator_pytorch_backend.py
@@ -225,6 +225,24 @@ class TestPyTorchEstimator(TestCase):
                            feature_cols=["feature"],
                            label_cols=["label"])
 
+    def test_partition_num_less_than_workers(self):
+        sc = init_nncontext()
+        rdd = sc.range(200, numSlices=1)
+        df = rdd.map(lambda x: (np.random.randn(50).astype(np.float).tolist(),
+                                [int(np.random.randint(0, 2, size=()))])
+                     ).toDF(["feature", "label"])
+
+        estimator = get_estimator(workers_per_node=2)
+        assert df.rdd.getNumPartitions() < estimator.estimator.num_workers
+
+        estimator.fit(df, batch_size=4, epochs=2,
+                      feature_cols=["feature"],
+                      label_cols=["label"])
+        estimator.evaluate(df, batch_size=4,
+                           feature_cols=["feature"],
+                           label_cols=["label"])
+        estimator.predict(df, feature_cols=["feature"]).collect()
+
     def test_dataframe_predict(self):
 
         sc = init_nncontext()

--- a/pyzoo/test/zoo/orca/learn/ray/tf/test_tf_ray_estimator.py
+++ b/pyzoo/test/zoo/orca/learn/ray/tf/test_tf_ray_estimator.py
@@ -436,6 +436,33 @@ class TestTFRayEstimator(TestCase):
                          label_cols=["label"])
         trainer.predict(df, feature_cols=["feature"]).collect()
 
+    def test_partition_num_less_than_workers(self):
+        sc = init_nncontext()
+        rdd = sc.range(200, numSlices=1)
+        assert rdd.getNumPartitions() == 1
+        from pyspark.sql import SparkSession
+        spark = SparkSession(sc)
+        from pyspark.ml.linalg import DenseVector
+        df = rdd.map(lambda x: (DenseVector(np.random.randn(1,).astype(np.float)),
+                                int(np.random.randint(0, 1, size=())))).toDF(["feature", "label"])
+
+        config = {
+            "lr": 0.8
+        }
+        trainer = Estimator.from_keras(
+            model_creator=model_creator,
+            verbose=True,
+            config=config,
+            workers_per_node=2)
+        assert df.rdd.getNumPartitions() < trainer.num_workers
+
+        trainer.fit(df, epochs=1, batch_size=4, steps_per_epoch=25,
+                    feature_cols=["feature"],
+                    label_cols=["label"])
+        trainer.evaluate(df, batch_size=4, num_steps=25, feature_cols=["feature"],
+                         label_cols=["label"])
+        trainer.predict(df, feature_cols=["feature"]).collect()
+
     def test_dataframe_predict(self):
         sc = init_nncontext()
         rdd = sc.parallelize(range(20))

--- a/pyzoo/zoo/orca/data/ray_xshards.py
+++ b/pyzoo/zoo/orca/data/ray_xshards.py
@@ -175,12 +175,13 @@ class RayXShards(XShards):
         actor, and you may need to use ray.get(partition_ref) on actor to retrieve
         the actor partition objects.
         """
-        assigned_partitions, actor_ips = self.assign_partitions_to_actors(actors)
+        assigned_partitions, actor_ips, assigned_actors = self.assign_partitions_to_actors(actors)
         assigned_partition_refs = [(part_ids, self._get_multiple_partition_refs(part_ids))
                                    for part_ids in assigned_partitions]
-        new_part_id_refs = {part_id: func(actor, part_ref)
-                            for actor, (part_ids, part_refs) in zip(actors, assigned_partition_refs)
-                            for part_id, part_ref in zip(part_ids, part_refs)}
+        new_part_id_refs = {
+            part_id: func(actor, part_ref)
+            for actor, (part_ids, part_refs) in zip(assigned_actors, assigned_partition_refs)
+            for part_id, part_ref in zip(part_ids, part_refs)}
 
         actor_ip2part_id = defaultdict(list)
         for actor_ip, part_ids in zip(actor_ips, assigned_partitions):
@@ -201,7 +202,10 @@ class RayXShards(XShards):
         :param return_refs: Whether to return ray objects refs or ray objects. If True, return a
         list of ray object refs, otherwise return a list of ray objects. Defaults to be False,
         """
-        assigned_partitions, _ = self.assign_partitions_to_actors(actors)
+        assert self.num_partitions() >= len(actors), \
+            f"Get number of partitions ({self.num_partitions()}) smaller than " \
+            f"number of actors ({len(actors)}). Make sure repartition works."
+        assigned_partitions, _, _ = self.assign_partitions_to_actors(actors)
         result_refs = []
         for actor, part_ids in zip(actors, assigned_partitions):
             assigned_partition_refs = self._get_multiple_partition_refs(part_ids)
@@ -216,7 +220,10 @@ class RayXShards(XShards):
                                       return_refs=False):
         assert self.num_partitions() == xshards.num_partitions(),\
             "the rdds to be zipped must have the same number of partitions"
-        assigned_partitions, _ = self.assign_partitions_to_actors(actors)
+        assert self.num_partitions() >= len(actors), \
+            f"Get number of partitions ({self.num_partitions()}) smaller than " \
+            f"number of actors ({len(actors)}). Make sure repartition works."
+        assigned_partitions, _, _ = self.assign_partitions_to_actors(actors)
         result_refs = []
         for actor, part_ids in zip(actors, assigned_partitions):
             assigned_partition_refs = self._get_multiple_partition_refs(part_ids)
@@ -232,8 +239,10 @@ class RayXShards(XShards):
     def assign_partitions_to_actors(self, actors):
         num_parts = self.num_partitions()
         if num_parts < len(actors):
-            raise ValueError(f"this rdd has {num_parts} partitions, which is smaller"
-                             f"than actor number ({len(actors)} actors).")
+            logger.warning(f"this rdd has {num_parts} partitions, which is smaller "
+                           f"than actor number ({len(actors)} actors). That could cause "
+                           f"unbalancing workload on different actors. We recommend you to "
+                           f"repartition the rdd for better performance.")
 
         avg_part_num = num_parts // len(actors)
         remainder = num_parts % len(actors)
@@ -293,7 +302,20 @@ class RayXShards(XShards):
                     current_assignments.append(part_idx)
                     remainder -= 1
                     break
-        return actor2assignments, actor_ips
+
+        if num_parts < len(actors):
+            # filter assigned actors
+            assigned_actors = []
+            assigned_actor2assignments = []
+            assigned_actor_ips = []
+            for actor, assignment, ip in zip(actors, actor2assignments, actor_ips):
+                if assignment:
+                    assigned_actors.append(actor)
+                    assigned_actor2assignments.append(assignment)
+                    assigned_actor_ips.append(ip)
+            return assigned_actor2assignments, assigned_actor_ips, assigned_actors
+        else:
+            return actor2assignments, actor_ips, actors
 
     @staticmethod
     def from_partition_refs(ip2part_id, part_id2ref):

--- a/pyzoo/zoo/orca/data/ray_xshards.py
+++ b/pyzoo/zoo/orca/data/ray_xshards.py
@@ -204,7 +204,7 @@ class RayXShards(XShards):
         """
         assert self.num_partitions() >= len(actors), \
             f"Get number of partitions ({self.num_partitions()}) smaller than " \
-            f"number of actors ({len(actors)}). Make sure repartition works."
+            f"number of actors ({len(actors)}). Please submit an issue to analytics zoo."
         assigned_partitions, _, _ = self.assign_partitions_to_actors(actors)
         result_refs = []
         for actor, part_ids in zip(actors, assigned_partitions):
@@ -222,7 +222,7 @@ class RayXShards(XShards):
             "the rdds to be zipped must have the same number of partitions"
         assert self.num_partitions() >= len(actors), \
             f"Get number of partitions ({self.num_partitions()}) smaller than " \
-            f"number of actors ({len(actors)}). Make sure repartition works."
+            f"number of actors ({len(actors)}). Please submit an issue to analytics zoo."
         assigned_partitions, _, _ = self.assign_partitions_to_actors(actors)
         result_refs = []
         for actor, part_ids in zip(actors, assigned_partitions):

--- a/pyzoo/zoo/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/pyzoo/zoo/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -201,7 +201,8 @@ class PyTorchRayEstimator:
                                              validation_data=None,
                                              feature_cols=feature_cols,
                                              label_cols=label_cols,
-                                             mode="fit")
+                                             mode="fit",
+                                             num_workers=self.num_workers)
 
         if isinstance(data, SparkXShards):
             if data._get_class_name() == 'pandas.core.frame.DataFrame':
@@ -281,7 +282,8 @@ class PyTorchRayEstimator:
                                              validation_data=None,
                                              feature_cols=feature_cols,
                                              label_cols=label_cols,
-                                             mode="evaluate")
+                                             mode="evaluate",
+                                             num_workers=self.num_workers)
         if isinstance(data, SparkXShards):
             if data._get_class_name() == 'pandas.core.frame.DataFrame':
                 data = process_xshards_of_pandas_dataframe(data, feature_cols, label_cols)

--- a/pyzoo/zoo/orca/learn/tf2/estimator.py
+++ b/pyzoo/zoo/orca/learn/tf2/estimator.py
@@ -208,7 +208,8 @@ class TensorFlow2Estimator(OrcaRayEstimator):
         from zoo.orca.data import SparkXShards
         data, validation_data = maybe_dataframe_to_xshards(data, validation_data,
                                                            feature_cols, label_cols,
-                                                           mode="fit")
+                                                           mode="fit",
+                                                           num_workers=self.num_workers)
 
         if isinstance(data, SparkXShards):
             if data._get_class_name() == 'pandas.core.frame.DataFrame':
@@ -291,7 +292,8 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                                              validation_data=None,
                                              feature_cols=feature_cols,
                                              label_cols=label_cols,
-                                             mode="evaluate")
+                                             mode="evaluate",
+                                             num_workers=self.num_workers)
 
         if isinstance(data, SparkXShards):
             if data._get_class_name() == 'pandas.core.frame.DataFrame':

--- a/pyzoo/zoo/orca/learn/tf2/estimator.py
+++ b/pyzoo/zoo/orca/learn/tf2/estimator.py
@@ -26,6 +26,7 @@ from zoo.orca.learn.ray_estimator import Estimator as OrcaRayEstimator
 from zoo.orca.learn.utils import maybe_dataframe_to_xshards, dataframe_to_xshards, \
     convert_predict_xshards_to_dataframe, update_predict_xshards, \
     process_xshards_of_pandas_dataframe
+from zoo.orca.data.utils import process_spark_xshards
 from zoo.ray import RayContext
 
 logger = logging.getLogger(__name__)
@@ -76,14 +77,6 @@ def data_length(data):
         return x.shape[0]
     else:
         return x[0].shape[0]
-
-
-def process_spark_xshards(spark_xshards, num_workers):
-    data = spark_xshards
-    if data.num_partitions() != num_workers:
-        data = data.repartition(num_workers)
-    ray_xshards = RayXShards.from_spark_xshards(data)
-    return ray_xshards
 
 
 class TensorFlow2Estimator(OrcaRayEstimator):
@@ -222,7 +215,6 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                 data, validation_data = process_xshards_of_pandas_dataframe(data, feature_cols,
                                                                             label_cols,
                                                                             validation_data, "fit")
-
             ray_xshards = process_spark_xshards(data, self.num_workers)
 
             if validation_data is None:

--- a/pyzoo/zoo/orca/learn/utils.py
+++ b/pyzoo/zoo/orca/learn/utils.py
@@ -278,7 +278,8 @@ def _dataframe_to_xshards(data, feature_cols, label_cols=None):
     return SparkXShards(shard_rdd)
 
 
-def dataframe_to_xshards(data, validation_data, feature_cols, label_cols, mode="fit"):
+def dataframe_to_xshards(data, validation_data, feature_cols, label_cols, mode="fit",
+                         num_workers=None):
     from pyspark.sql import DataFrame
     valid_mode = {"fit", "evaluate", "predict"}
     assert mode in valid_mode, f"invalid mode {mode} " \
@@ -291,6 +292,9 @@ def dataframe_to_xshards(data, validation_data, feature_cols, label_cols, mode="
     if mode != "predict":
         assert label_cols is not None, \
             "label_cols must be provided if data is a spark dataframe"
+        # avoid empty partition for worker
+        if data.rdd.getNumPartitions() < num_workers:
+            data = data.repartition(num_workers)
 
     data = _dataframe_to_xshards(data, feature_cols, label_cols)
     if validation_data is not None:
@@ -299,13 +303,15 @@ def dataframe_to_xshards(data, validation_data, feature_cols, label_cols, mode="
     return data, validation_data
 
 
-def maybe_dataframe_to_xshards(data, validation_data, feature_cols, label_cols, mode="fit"):
+def maybe_dataframe_to_xshards(data, validation_data, feature_cols, label_cols, mode="fit",
+                               num_workers=None):
     from pyspark.sql import DataFrame
     if isinstance(data, DataFrame):
         data, validation_data = dataframe_to_xshards(data, validation_data,
                                                      feature_cols=feature_cols,
                                                      label_cols=label_cols,
-                                                     mode=mode)
+                                                     mode=mode,
+                                                     num_workers=num_workers)
     return data, validation_data
 
 


### PR DESCRIPTION
- [x] In fit and evaluate, repartition before converting to `SparkXShards`, details in #4176 
- [x] Support predict, details in #4203 

This PR also removes `process_spark_xshards` in tf2 estimator and use `zoo.orca.data.utils.process_spark_xshards` for both pytorch estimator and tf2 estimator.