### PR TITLE
Rename experimental AutoTSTrainer to AutoTSEstimator and corr uts

### DIFF
--- a/pyzoo/test/zoo/chronos/autots/experimental/test_autotstrainer.py
+++ b/pyzoo/test/zoo/chronos/autots/experimental/test_autotstrainer.py
@@ -21,9 +21,8 @@ import torch
 import torch.nn as nn
 from torch.utils.data import TensorDataset, DataLoader
 import numpy as np
-from zoo.chronos.autots.experimental.autotstrainer import AutoTSTrainer
-from zoo.chronos.data.tsdataset import TSDataset
-from zoo.chronos.autots.experimental.tspipeline import TSPipeline
+from zoo.chronos.autots.experimental import AutoTSEstimator, TSPipeline
+from zoo.chronos.data import TSDataset
 from zoo.orca.automl import hp
 import pandas as pd
 
@@ -119,24 +118,24 @@ class TestAutoTrainer(TestCase):
             'dropout': hp.uniform(0.1, 0.2)
         }
 
-        auto_trainer = AutoTSTrainer(model=model_creator,
-                                     search_space=search_space,
-                                     past_seq_len=hp.randint(4, 6),
-                                     future_seq_len=1,
-                                     input_feature_num=input_feature_dim,
-                                     output_target_num=output_target_num,
-                                     selected_features="auto",
-                                     metric="mse",
-                                     loss=torch.nn.MSELoss(),
-                                     cpus_per_trial=2)
+        auto_estimator = AutoTSEstimator(model=model_creator,
+                                         search_space=search_space,
+                                         past_seq_len=hp.randint(4, 6),
+                                         future_seq_len=1,
+                                         input_feature_num=input_feature_dim,
+                                         output_target_num=output_target_num,
+                                         selected_features="auto",
+                                         metric="mse",
+                                         loss=torch.nn.MSELoss(),
+                                         cpus_per_trial=2)
 
-        ts_pipeline = auto_trainer.fit(data=tsdata_train,
-                                       epochs=1,
-                                       batch_size=hp.choice([32, 64]),
-                                       validation_data=tsdata_valid,
-                                       n_sampling=1)
-        best_config = auto_trainer.get_best_config()
-        best_model = auto_trainer.get_best_model()
+        ts_pipeline = auto_estimator.fit(data=tsdata_train,
+                                         epochs=1,
+                                         batch_size=hp.choice([32, 64]),
+                                         validation_data=tsdata_valid,
+                                         n_sampling=1)
+        best_config = auto_estimator.get_best_config()
+        best_model = auto_estimator.get_best_model()
         assert 4 <= best_config["past_seq_len"] <= 6
 
         assert isinstance(ts_pipeline, TSPipeline)
@@ -178,25 +177,24 @@ class TestAutoTrainer(TestCase):
             'dropout': hp.uniform(0.1, 0.2)
         }
 
-        auto_trainer = AutoTSTrainer(model=model_creator,
-                                     search_space=search_space,
-                                     past_seq_len=7,
-                                     future_seq_len=1,
-                                     input_feature_num=input_feature_dim,
-                                     output_target_num=output_feature_dim,
-                                     selected_features="auto",
-                                     metric="mse",
-                                     loss=torch.nn.MSELoss(),
-                                     cpus_per_trial=2)
+        auto_estimator = AutoTSEstimator(model=model_creator,
+                                         search_space=search_space,
+                                         past_seq_len=7,
+                                         future_seq_len=1,
+                                         input_feature_num=input_feature_dim,
+                                         output_target_num=output_feature_dim,
+                                         selected_features="auto",
+                                         metric="mse",
+                                         loss=torch.nn.MSELoss(),
+                                         cpus_per_trial=2)
 
-        auto_trainer.fit(data=get_data_creator(),
-                         epochs=1,
-                         batch_size=hp.choice([32, 64]),
-                         validation_data=get_data_creator(),
-                         n_sampling=1
-                         )
+        auto_estimator.fit(data=get_data_creator(),
+                           epochs=1,
+                           batch_size=hp.choice([32, 64]),
+                           validation_data=get_data_creator(),
+                           n_sampling=1)
 
-        config = auto_trainer.get_best_config()
+        config = auto_estimator.get_best_config()
         assert config["past_seq_len"] == 7
 
     def test_fit_lstm_feature(self):
@@ -215,25 +213,25 @@ class TestAutoTrainer(TestCase):
             'dropout': hp.uniform(0.1, 0.2)
         }
 
-        auto_trainer = AutoTSTrainer(model='lstm',
-                                     search_space=search_space,
-                                     past_seq_len=hp.randint(4, 6),
-                                     future_seq_len=1,
-                                     input_feature_num=input_feature_dim,
-                                     output_target_num=output_feature_dim,
-                                     selected_features="auto",
-                                     metric="mse",
-                                     loss=torch.nn.MSELoss(),
-                                     logs_dir="/tmp/auto_trainer",
-                                     cpus_per_trial=2,
-                                     name="auto_trainer")
-        ts_pipeline = auto_trainer.fit(data=tsdata_train,
-                                       epochs=1,
-                                       batch_size=hp.choice([32, 64]),
-                                       validation_data=tsdata_valid,
-                                       n_sampling=1)
-        best_config = auto_trainer.get_best_config()
-        best_model = auto_trainer.get_best_model()
+        auto_estimator = AutoTSEstimator(model='lstm',
+                                         search_space=search_space,
+                                         past_seq_len=hp.randint(4, 6),
+                                         future_seq_len=1,
+                                         input_feature_num=input_feature_dim,
+                                         output_target_num=output_feature_dim,
+                                         selected_features="auto",
+                                         metric="mse",
+                                         loss=torch.nn.MSELoss(),
+                                         logs_dir="/tmp/auto_trainer",
+                                         cpus_per_trial=2,
+                                         name="auto_trainer")
+        ts_pipeline = auto_estimator.fit(data=tsdata_train,
+                                         epochs=1,
+                                         batch_size=hp.choice([32, 64]),
+                                         validation_data=tsdata_valid,
+                                         n_sampling=1)
+        best_config = auto_estimator.get_best_config()
+        best_model = auto_estimator.get_best_model()
         assert 4 <= best_config["past_seq_len"] <= 6
 
         assert isinstance(ts_pipeline, TSPipeline)
@@ -282,26 +280,26 @@ class TestAutoTrainer(TestCase):
             'dropout': hp.uniform(0.1, 0.2),
             'lr': hp.loguniform(0.001, 0.01)
         }
-        auto_trainer = AutoTSTrainer(model='tcn',
-                                     search_space=search_space,
-                                     past_seq_len=hp.randint(4, 6),
-                                     future_seq_len=1,
-                                     input_feature_num=input_feature_dim,
-                                     output_target_num=output_feature_dim,
-                                     selected_features="auto",
-                                     metric="mse",
-                                     optimizer="Adam",
-                                     loss=torch.nn.MSELoss(),
-                                     logs_dir="/tmp/auto_trainer",
-                                     cpus_per_trial=2,
-                                     name="auto_trainer")
-        ts_pipeline = auto_trainer.fit(data=tsdata_train,
-                                       epochs=1,
-                                       batch_size=hp.choice([32, 64]),
-                                       validation_data=tsdata_valid,
-                                       n_sampling=1)
-        best_config = auto_trainer.get_best_config()
-        best_model = auto_trainer.get_best_model()
+        auto_estimator = AutoTSEstimator(model='tcn',
+                                         search_space=search_space,
+                                         past_seq_len=hp.randint(4, 6),
+                                         future_seq_len=1,
+                                         input_feature_num=input_feature_dim,
+                                         output_target_num=output_feature_dim,
+                                         selected_features="auto",
+                                         metric="mse",
+                                         optimizer="Adam",
+                                         loss=torch.nn.MSELoss(),
+                                         logs_dir="/tmp/auto_trainer",
+                                         cpus_per_trial=2,
+                                         name="auto_trainer")
+        ts_pipeline = auto_estimator.fit(data=tsdata_train,
+                                         epochs=1,
+                                         batch_size=hp.choice([32, 64]),
+                                         validation_data=tsdata_valid,
+                                         n_sampling=1)
+        best_config = auto_estimator.get_best_config()
+        best_model = auto_estimator.get_best_model()
         assert 4 <= best_config["past_seq_len"] <= 6
 
         assert isinstance(ts_pipeline, TSPipeline)
@@ -344,25 +342,24 @@ class TestAutoTrainer(TestCase):
             'lr': hp.choice([0.001, 0.003, 0.01]),
             'dropout': hp.uniform(0.1, 0.2)
         }
-        auto_trainer = AutoTSTrainer(model='lstm',
-                                     search_space=search_space,
-                                     past_seq_len=7,
-                                     future_seq_len=1,
-                                     input_feature_num=input_feature_dim,
-                                     output_target_num=output_feature_dim,
-                                     selected_features="auto",
-                                     metric="mse",
-                                     loss=torch.nn.MSELoss(),
-                                     logs_dir="/tmp/auto_trainer",
-                                     cpus_per_trial=2,
-                                     name="auto_trainer")
-        auto_trainer.fit(data=get_data_creator(),
-                         epochs=1,
-                         batch_size=hp.choice([32, 64]),
-                         validation_data=get_data_creator(),
-                         n_sampling=1
-                         )
-        config = auto_trainer.get_best_config()
+        auto_estimator = AutoTSEstimator(model='lstm',
+                                         search_space=search_space,
+                                         past_seq_len=7,
+                                         future_seq_len=1,
+                                         input_feature_num=input_feature_dim,
+                                         output_target_num=output_feature_dim,
+                                         selected_features="auto",
+                                         metric="mse",
+                                         loss=torch.nn.MSELoss(),
+                                         logs_dir="/tmp/auto_trainer",
+                                         cpus_per_trial=2,
+                                         name="auto_trainer")
+        auto_estimator.fit(data=get_data_creator(),
+                           epochs=1,
+                           batch_size=hp.choice([32, 64]),
+                           validation_data=get_data_creator(),
+                           n_sampling=1)
+        config = auto_estimator.get_best_config()
         assert config["past_seq_len"] == 7
 
 

--- a/pyzoo/zoo/chronos/autots/experimental/__init__.py
+++ b/pyzoo/zoo/chronos/autots/experimental/__init__.py
@@ -13,3 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from .autotsestimator import AutoTSEstimator
+from .tspipeline import TSPipeline

--- a/pyzoo/zoo/chronos/autots/experimental/autotsestimator.py
+++ b/pyzoo/zoo/chronos/autots/experimental/autotsestimator.py
@@ -23,9 +23,9 @@ from zoo.chronos.autots.model import AutoModelFactory
 from zoo.chronos.autots.experimental.tspipeline import TSPipeline
 
 
-class AutoTSTrainer:
+class AutoTSEstimator:
     """
-    Automated Trainer.
+    Automated Estimator.
     """
 
     def __init__(self,
@@ -40,12 +40,12 @@ class AutoTSTrainer:
                  output_target_num=None,
                  selected_features="all",
                  backend="torch",
-                 logs_dir="/tmp/autots_trainer",
+                 logs_dir="/tmp/autots_estimator",
                  cpus_per_trial=1,
-                 name="autots_trainer"
+                 name="autots_estimator"
                  ):
         """
-        AutoTSTrainer trains a model for time series forecasting.
+        AutoTSEstimator trains a model for time series forecasting.
         User can choose one of the built-in models, or pass in a customized pytorch or keras model
         for tuning using AutoML.
         :param model: a string or a model creation function
@@ -77,7 +77,7 @@ class AutoTSTrainer:
                if not using chronos.data.TSDataset as input data type.
         :param backend: The backend of the auto model. We only support backend as "torch" for now.
         :param logs_dir: Local directory to save logs and results.
-               It defaults to "/tmp/autots_trainer"
+               It defaults to "/tmp/autots_estimator"
         :param cpus_per_trial: Int. Number of cpus for each trial. It defaults to 1.
         :param name: name of the AutoLSTM. It defaults to "auto_lstm".
         """

--- a/pyzoo/zoo/chronos/autots/experimental/tspipeline.py
+++ b/pyzoo/zoo/chronos/autots/experimental/tspipeline.py
@@ -47,7 +47,7 @@ class TSPipeline:
 
         :param data: data can be a TSDataset or data creator(will be supported).
                The TSDataset should follow the same operations as the training
-               TSDataset used in AutoTSTrainer.fit.
+               TSDataset used in AutoTSEstimator.fit.
         :param metrics: list. The evaluation metric name to optimize. e.g. ["mse"]
         :param multioutput: Defines aggregating of multiple output values.
                String in ['raw_values', 'uniform_average']. The value defaults to
@@ -72,7 +72,7 @@ class TSPipeline:
 
         :param data: data can be a TSDataset or data creator(will be supported).
                The TSDataset should follow the same operations as the training
-               TSDataset used in AutoTSTrainer.fit.
+               TSDataset used in AutoTSEstimator.fit.
         :param batch_size: predict batch_size, the process will cost more time
                if batch_size is small while cost less memory.  The param is only
                effective when data is a TSDataset. The values defaults to 32.
@@ -90,7 +90,7 @@ class TSPipeline:
 
         :param data: data can be a TSDataset or data creator(will be supported).
                the TSDataset should follow the same operations as the training
-               TSDataset used in AutoTSTrainer.fit.
+               TSDataset used in AutoTSEstimator.fit.
         :param validation_data: validation data, same format as data.
         :param epochs: incremental fitting epoch. The value defaults to 1.
         :param metric: evaluate metric.


### PR DESCRIPTION
1. Rename AutoTSTrainer to AutoTSEstimator and other changes
2. Simplify imports namespace, anyone who wants to use AutoTSEstimator will only import
- `from zoo.chronos.data import TSDataset`
- `from zoo.chronos.autots.experimental import AutoTSEstimator, TSPipeline` (experimental will be removed later)
