### PR TITLE
[Experimental] Trial for RayOnSpark

### DIFF
--- a/pyzoo/zoo/common/nncontext.py
+++ b/pyzoo/zoo/common/nncontext.py
@@ -270,6 +270,7 @@ class ZooContextMeta(type):
 
     _log_output = False
     _barrier_mode = True
+    _ray_trial = False
 
     @property
     def log_output(cls):
@@ -303,6 +304,15 @@ class ZooContextMeta(type):
     def barrier_mode(cls, value):
         assert isinstance(value, bool), "barrier_mode should either be True or False"
         cls._barrier_mode = value
+
+    @property
+    def ray_trial(cls):
+        return cls._ray_trial
+
+    @ray_trial.setter
+    def ray_trial(cls, value):
+        assert isinstance(value, bool), "ray_trial should either be True or False"
+        cls._ray_trial = value
 
 
 class ZooContext(metaclass=ZooContextMeta):

--- a/pyzoo/zoo/orca/common.py
+++ b/pyzoo/zoo/orca/common.py
@@ -133,6 +133,14 @@ class OrcaContextMeta(type):
     def barrier_mode(cls, value):
         ZooContext.barrier_mode = value
 
+    @property
+    def ray_trial(cls):
+        return ZooContext.ray_trial
+
+    @ray_trial.setter
+    def ray_trial(cls, value):
+        ZooContext.ray_trial = value
+
 
 class OrcaContext(metaclass=OrcaContextMeta):
     @staticmethod

--- a/pyzoo/zoo/ray/raycontext.py
+++ b/pyzoo/zoo/ray/raycontext.py
@@ -618,7 +618,10 @@ class RayContext(object):
                     self.ray_service.gen_raylet_start2(redis_address)).collect()
                 raylet_process_infos = [process for process in raylet_process_infos if process]
                 # Here we can only start one ray process (ray master or raylet) on a node.
-                self.num_ray_nodes = len(raylet_process_infos) + 1
+                assert len(raylet_process_infos) == len(self.cluster_ips) - 1, \
+                    "There should be {} raylets launched across the cluster, but got {}"\
+                    .format(len(self.cluster_ips) - 1, len(raylet_process_infos))
+                self.num_ray_nodes = len(self.cluster_ips)
             else:
                 raylet_process_infos = ray_rdd.mapPartitions(
                     self.ray_service.gen_raylet_start(redis_address)).collect()


### PR DESCRIPTION
If we use total cores of tasks to launch ray, then we can only launch one process (either one master or raylet) on a single node. Then num_ray_nodes needs to be determined by the number of used nodes (set of cluster ips) in the cluster. Do you think it is reasonable? @jason-dai 