### PR TITLE
TSDataset rolling method speed up

### DIFF
--- a/pyzoo/zoo/chronos/data/tsdataset.py
+++ b/pyzoo/zoo/chronos/data/tsdataset.py
@@ -426,22 +426,35 @@ class TSDataset:
             else self.roll_feature_df[additional_feature_col]
 
         # get rolling result for each sub dataframe
-        rolling_result = [roll_timeseries_dataframe(df=self.df[self.df[self.id_col] == id_name],
-                                                    roll_feature_df=roll_feature_df,
-                                                    lookback=lookback,
-                                                    horizon=horizon,
-                                                    feature_col=feature_col,
-                                                    target_col=target_col)
-                          for id_name in self._id_list]
+        # rolling_result = [roll_timeseries_dataframe(df=self.df[self.df[self.id_col] == id_name],
+        #                                             roll_feature_df=roll_feature_df,
+        #                                             lookback=lookback,
+        #                                             horizon=horizon,
+        #                                             feature_col=feature_col,
+        #                                             target_col=target_col)
+        #                   for id_name in self._id_list]
+        rolling_result = self.df.groupby([self.id_col])\
+                                .apply(lambda df:roll_timeseries_dataframe(df=df,
+                                                                           roll_feature_df=roll_feature_df,
+                                                                           lookback=lookback,
+                                                                           horizon=horizon,
+                                                                           feature_col=feature_col,
+                                                                           target_col=target_col))
+
+        # print(type(rolling_result))
+        # print(rolling_result)
+        # print(type(rolling_result[0][0]))
+        # print(rolling_result["00"][0].shape)
+        # assert 1==0
 
         # concat the result on required axis
         concat_axis = 2 if id_sensitive else 0
         self.numpy_x = np.concatenate([rolling_result[i][0]
-                                       for i in range(num_id)],
+                                       for i in self._id_list],
                                       axis=concat_axis).astype(np.float64)
         if horizon != 0:
             self.numpy_y = np.concatenate([rolling_result[i][1]
-                                           for i in range(num_id)],
+                                           for i in self._id_list],
                                           axis=concat_axis).astype(np.float64)
         else:
             self.numpy_y = None

--- a/pyzoo/zoo/chronos/data/tsdataset.py
+++ b/pyzoo/zoo/chronos/data/tsdataset.py
@@ -425,27 +425,14 @@ class TSDataset:
         roll_feature_df = None if self.roll_feature_df is None \
             else self.roll_feature_df[additional_feature_col]
 
-        # get rolling result for each sub dataframe
-        # rolling_result = [roll_timeseries_dataframe(df=self.df[self.df[self.id_col] == id_name],
-        #                                             roll_feature_df=roll_feature_df,
-        #                                             lookback=lookback,
-        #                                             horizon=horizon,
-        #                                             feature_col=feature_col,
-        #                                             target_col=target_col)
-        #                   for id_name in self._id_list]
-        rolling_result = self.df.groupby([self.id_col])\
-                                .apply(lambda df:roll_timeseries_dataframe(df=df,
-                                                                           roll_feature_df=roll_feature_df,
-                                                                           lookback=lookback,
-                                                                           horizon=horizon,
-                                                                           feature_col=feature_col,
-                                                                           target_col=target_col))
-
-        # print(type(rolling_result))
-        # print(rolling_result)
-        # print(type(rolling_result[0][0]))
-        # print(rolling_result["00"][0].shape)
-        # assert 1==0
+        rolling_result =\
+            self.df.groupby([self.id_col])\
+                   .apply(lambda df: roll_timeseries_dataframe(df=df,
+                                                               roll_feature_df=roll_feature_df,
+                                                               lookback=lookback,
+                                                               horizon=horizon,
+                                                               feature_col=feature_col,
+                                                               target_col=target_col))
 
         # concat the result on required axis
         concat_axis = 2 if id_sensitive else 0

--- a/pyzoo/zoo/chronos/data/utils/roll.py
+++ b/pyzoo/zoo/chronos/data/utils/roll.py
@@ -117,27 +117,39 @@ def _roll_timeseries_dataframe_train(df,
     return x, output_y[mask]
 
 
+def _shift(arr, num, fill_value=np.nan):
+    # this function is adapted from
+    # https://stackoverflow.com/questions/30399534/shift-elements-in-a-numpy-array
+    result = np.empty_like(arr)
+    if num > 0:
+        result[:num] = fill_value
+        result[num:] = arr[:-num]
+    elif num < 0:
+        result[num:] = fill_value
+        result[:num] = arr[-num:]
+    else:
+        result[:] = arr
+    return result
+
+
 def _roll_timeseries_ndarray(data, window):
     '''
     data should be a ndarray with num_dim = 2
     first dim is timestamp
     second dim is feature
     '''
-    assert data.ndim == 2
+    assert data.ndim == 2 # (num_timestep, num_feature)
+    data = np.expand_dims(data, axis=1) # (num_timestep, 1, num_feature)
 
+    # window index and capacity
     window_size = window if isinstance(window, int) else max(window)
     if isinstance(window, int):
         window_idx = np.arange(window)
     else:
         window_idx = np.array(window) - 1
 
-    result = []
-    mask = []
-    for i in range(data.shape[0]-window_size+1):
-        result.append(data[i+window_idx])
-        if pd.isna(data[i+window_idx]).any(axis=None):
-            mask.append(0)
-        else:
-            mask.append(1)
+    roll_data = np.concatenate([_shift(data, i) for i in range(0, -window_size, -1)], axis=1)
+    roll_data = roll_data[:data.shape[0]-window_size+1, window_idx, :]
+    mask = ~np.any(np.isnan(roll_data), axis=(1,2))
 
-    return np.asarray(result), np.asarray(mask)
+    return roll_data, mask

--- a/pyzoo/zoo/chronos/data/utils/roll.py
+++ b/pyzoo/zoo/chronos/data/utils/roll.py
@@ -138,8 +138,8 @@ def _roll_timeseries_ndarray(data, window):
     first dim is timestamp
     second dim is feature
     '''
-    assert data.ndim == 2 # (num_timestep, num_feature)
-    data = np.expand_dims(data, axis=1) # (num_timestep, 1, num_feature)
+    assert data.ndim == 2  # (num_timestep, num_feature)
+    data = np.expand_dims(data, axis=1)  # (num_timestep, 1, num_feature)
 
     # window index and capacity
     window_size = window if isinstance(window, int) else max(window)
@@ -150,6 +150,6 @@ def _roll_timeseries_ndarray(data, window):
 
     roll_data = np.concatenate([_shift(data, i) for i in range(0, -window_size, -1)], axis=1)
     roll_data = roll_data[:data.shape[0]-window_size+1, window_idx, :]
-    mask = ~np.any(np.isnan(roll_data), axis=(1,2))
+    mask = ~np.any(np.isnan(roll_data), axis=(1, 2))
 
     return roll_data, mask


### PR DESCRIPTION
1. Change rolling kernal from ~O(time series length) to ~O(lookback)
2. Use group by to speed up the code
3. speed up ~250X on baidu traffic dataset

related to #4186