### PR TITLE
Chronos user guide broken link fix

### DIFF
--- a/docs/readthedocs/source/doc/Chronos/Overview/chronos.md
+++ b/docs/readthedocs/source/doc/Chronos/Overview/chronos.md
@@ -90,7 +90,7 @@ ts_pipeline = trainer.fit(train_df, validation_df, recipe=SmokeRecipe())
 `recipe` configures the search space for auto tuning. View [Recipe API docs](../../PythonAPI/Chronos/autots.html#chronos-config-recipe) for available recipes. 
 After training, it will return a [TSPipeline](../../PythonAPI/Chronos/autots.html#zoo.chronos.autots.forecast.TSPipeline), which includes not only the model, but also the data preprocessing/post processing steps. 
 
-Appropriate hyperparameters are automatically selected for the models and data processing steps in the pipeline during the fit process, and you may use built-in [visualization tool](https://github.com/intel-analytics/analytics-zoo/blob/master/docs/docs/ProgrammingGuide/AutoML/visualization\.md) to inspect the training results after training stopped.
+Appropriate hyperparameters are automatically selected for the models and data processing steps in the pipeline during the fit process, and you may use built-in [visualization tool](https://analytics-zoo.github.io/master/#ProgrammingGuide/AutoML/visualization/) (This link lead to our old document, please head back after reading the visualization page.) to inspect the training results after training stopped. 
 
 
 ##### **4.1.4 Use TSPipeline**

--- a/docs/readthedocs/source/doc/Chronos/Overview/chronos.md
+++ b/docs/readthedocs/source/doc/Chronos/Overview/chronos.md
@@ -90,7 +90,7 @@ ts_pipeline = trainer.fit(train_df, validation_df, recipe=SmokeRecipe())
 `recipe` configures the search space for auto tuning. View [Recipe API docs](../../PythonAPI/Chronos/autots.html#chronos-config-recipe) for available recipes. 
 After training, it will return a [TSPipeline](../../PythonAPI/Chronos/autots.html#zoo.chronos.autots.forecast.TSPipeline), which includes not only the model, but also the data preprocessing/post processing steps. 
 
-Appropriate hyperparameters are automatically selected for the models and data processing steps in the pipeline during the fit process, and you may use built-in [visualization tool](https://github.com/intel-analytics/analytics-zoo/blob/master/docs/docs/ProgrammingGuide/AutoML/visualization.md) to inspect the training results after training stopped.
+Appropriate hyperparameters are automatically selected for the models and data processing steps in the pipeline during the fit process, and you may use built-in [visualization tool](https://github.com/intel-analytics/analytics-zoo/blob/master/docs/docs/ProgrammingGuide/AutoML/visualization\.md) to inspect the training results after training stopped.
 
 
 ##### **4.1.4 Use TSPipeline**


### PR DESCRIPTION
We need an ugly workaround to include a .md link in sphinx document.
Please refer to https://github.com/miyakogi/m2r/issues/41 and https://stackoverflow.com/questions/52496591/sphinx-and-markdown-md-links
Thus I currently use our old document link and a warning text to workaround.
We will add the page to readthedoc later.
The pr is related to #4095.