### PR TITLE
Add order_by_freq for generate_string_idx

### DIFF
--- a/pyzoo/zoo/friesian/feature/table.py
+++ b/pyzoo/zoo/friesian/feature/table.py
@@ -700,8 +700,8 @@ class FeatureTable(Table):
                dict. For instance, 15, {'col_4': 10, 'col_5': 2} etc. Default is None,
                and in this case all the categories that appear will be encoded.
         :param order_by_freq: boolean, whether the result StringIndex will assign smaller indices
-               to values with more frequencies. Default is False and in this case order may not be
-               preserved for assigning indices.
+               to values with more frequencies. Default is False and in this case frequency order
+               may not be preserved when assigning indices.
 
         :return: A tuple of a new FeatureTable which transforms categorical features into unique
                  integer values, and a list of StringIndex for the mapping.
@@ -811,8 +811,8 @@ class FeatureTable(Table):
                dict. For instance, 15, {'col_4': 10, 'col_5': 2} etc. Default is None,
                and in this case all the categories that appear will be encoded.
         :param order_by_freq: boolean, whether the result StringIndex will assign smaller indices
-               to values with more frequencies. Default is False and in this case order may not be
-               preserved for assigning indices.
+               to values with more frequencies. Default is False and in this case frequency order
+               may not be preserved when assigning indices.
 
         :return: A StringIndex or a list of StringIndex.
         """

--- a/pyzoo/zoo/friesian/feature/table.py
+++ b/pyzoo/zoo/friesian/feature/table.py
@@ -690,7 +690,7 @@ class FeatureTable(Table):
         cross_hash_df = FeatureTable(cross_hash_df).hash_encode([cross_col_name], bins)
         return cross_hash_df
 
-    def category_encode(self, columns, freq_limit=None):
+    def category_encode(self, columns, freq_limit=None, order_by_freq=False):
         """
         Category encode the given columns.
 
@@ -703,7 +703,7 @@ class FeatureTable(Table):
         :return: A tuple of a new FeatureTable which transforms categorical features into unique
                  integer values, and a list of StringIndex for the mapping.
         """
-        indices = self.gen_string_idx(columns, freq_limit)
+        indices = self.gen_string_idx(columns, freq_limit, order_by_freq)
         return self.encode_string(columns, indices), indices
 
     def one_hot_encode(self, columns, sizes=None, prefix=None, keep_original_columns=False):
@@ -797,7 +797,7 @@ class FeatureTable(Table):
         data_df = data_df.drop("friesian_onehot")
         return FeatureTable(data_df)
 
-    def gen_string_idx(self, columns, freq_limit=None):
+    def gen_string_idx(self, columns, freq_limit=None, order_by_freq=False):
         """
         Generate unique index value of categorical features. The resulting index would
         start from 1 with 0 reserved for unknown features.
@@ -825,7 +825,7 @@ class FeatureTable(Table):
             else:
                 raise ValueError("freq_limit only supports int, dict or None, but get " +
                                  freq_limit.__class__.__name__)
-        df_id_list = generate_string_idx(self.df, columns, freq_limit)
+        df_id_list = generate_string_idx(self.df, columns, freq_limit, order_by_freq)
         string_idx_list = list(map(lambda x: StringIndex(x[0], x[1]),
                                    zip(df_id_list, columns)))
         # If input is a single column (not a list), then the output would be a single StringIndex.

--- a/pyzoo/zoo/friesian/feature/table.py
+++ b/pyzoo/zoo/friesian/feature/table.py
@@ -699,6 +699,9 @@ class FeatureTable(Table):
                will be omitted from the encoding. Can be represented as either an integer,
                dict. For instance, 15, {'col_4': 10, 'col_5': 2} etc. Default is None,
                and in this case all the categories that appear will be encoded.
+        :param order_by_freq: boolean, whether the result StringIndex will assign smaller indices
+               to values with more frequencies. Default is False and in this case order may not be
+               preserved for assigning indices.
 
         :return: A tuple of a new FeatureTable which transforms categorical features into unique
                  integer values, and a list of StringIndex for the mapping.
@@ -807,6 +810,9 @@ class FeatureTable(Table):
                will be omitted from the encoding. Can be represented as either an integer,
                dict. For instance, 15, {'col_4': 10, 'col_5': 2} etc. Default is None,
                and in this case all the categories that appear will be encoded.
+        :param order_by_freq: boolean, whether the result StringIndex will assign smaller indices
+               to values with more frequencies. Default is False and in this case order may not be
+               preserved for assigning indices.
 
         :return: A StringIndex or a list of StringIndex.
         """

--- a/pyzoo/zoo/friesian/feature/utils.py
+++ b/pyzoo/zoo/friesian/feature/utils.py
@@ -27,7 +27,7 @@ def log_with_clip(df, columns, clip=True):
     return callZooFunc("float", "log", df, columns, clip)
 
 
-def generate_string_idx(df, columns, freq_limit):
+def generate_string_idx(df, columns, freq_limit, order_by_freq):
     return callZooFunc("float", "generateStringIdx", df, columns, freq_limit)
 
 

--- a/pyzoo/zoo/friesian/feature/utils.py
+++ b/pyzoo/zoo/friesian/feature/utils.py
@@ -28,7 +28,7 @@ def log_with_clip(df, columns, clip=True):
 
 
 def generate_string_idx(df, columns, freq_limit, order_by_freq):
-    return callZooFunc("float", "generateStringIdx", df, columns, freq_limit)
+    return callZooFunc("float", "generateStringIdx", df, columns, freq_limit, order_by_freq)
 
 
 def fill_na(df, fill_val, columns):

--- a/zoo/src/main/scala/com/intel/analytics/zoo/friesian/python/PythonFriesian.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/friesian/python/PythonFriesian.scala
@@ -91,7 +91,8 @@ class PythonFriesian[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonZ
     spark.createDataFrame(dfUpdated, schema)
   }
 
-  def generateStringIdx(df: DataFrame, columns: JList[String], frequencyLimit: String = null)
+  def generateStringIdx(df: DataFrame, columns: JList[String], frequencyLimit: String = null,
+                        orderByFrequency: Boolean = false)
   : JList[DataFrame] = {
     var default_limit: Option[Int] = None
     val freq_map = scala.collection.mutable.Map[String, Int]()
@@ -113,17 +114,20 @@ class PythonFriesian[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonZ
         .filter(s"${col_n} is not null")
         .groupBy(col_n)
         .count()
+      val df_col_ordered = if (orderByFrequency) {
+        df_col.orderBy(col("count").desc)
+      } else df_col
       val df_col_filtered = if (freq_map.contains(col_n)) {
-        df_col.filter(s"count >= ${freq_map(col_n)}")
+        df_col_ordered.filter(s"count >= ${freq_map(col_n)}")
       } else if (default_limit.isDefined) {
-        df_col.filter(s"count >= ${default_limit.get}")
+        df_col_ordered.filter(s"count >= ${default_limit.get}")
       } else {
-        df_col
+        df_col_ordered
       }
 
       df_col_filtered.cache()
       val count_list: Array[(Int, Int)] = df_col_filtered.rdd.mapPartitions(Utils.getPartitionSize)
-        .collect()
+        .collect().sortBy(_._1)  // further guarantee prior partitions are given smaller indices.
       val base_dict = scala.collection.mutable.Map[Int, Int]()
       var running_sum = 0
       for (count_tuple <- count_list) {
@@ -132,7 +136,7 @@ class PythonFriesian[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonZ
       }
       val base_dict_bc = df_col_filtered.rdd.sparkContext.broadcast(base_dict)
 
-      val windowSpec = Window.partitionBy("part_id").orderBy("count")
+      val windowSpec = Window.partitionBy("part_id").orderBy(col("count").desc)
       val df_with_part_id = df_col_filtered.withColumn("part_id", spark_partition_id())
       val df_row_number = df_with_part_id.withColumn("row_number", row_number.over(windowSpec))
       val get_label = udf((part_id: Int, row_number: Int) => {
@@ -140,7 +144,7 @@ class PythonFriesian[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonZ
       })
       df_row_number
         .withColumn("id", get_label(col("part_id"), col("row_number")))
-        .drop("part_id", "row_number", "count")
+        .drop("part_id", "row_number")
     }).asJava
   }
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/friesian/python/PythonFriesian.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/friesian/python/PythonFriesian.scala
@@ -144,7 +144,7 @@ class PythonFriesian[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonZ
       })
       df_row_number
         .withColumn("id", get_label(col("part_id"), col("row_number")))
-        .drop("part_id", "row_number")
+        .drop("part_id", "row_number", "count")
     }).asJava
   }
 

--- a/zoo/src/test/scala/com/intel/analytics/zoo/friesian/FriesianSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/friesian/FriesianSpec.scala
@@ -124,6 +124,17 @@ class FriesianSpec extends ZooSpecHelper {
     assert(stringIdxList.get(1).count == 1)
   }
 
+  "AssignStringIdx limit order by freq" should "work properly" in {
+    val path = resource.getFile + "/data1.parquet"
+    val df = sqlContext.read.parquet(path)
+    val cols = Array("col_4", "col_5")
+    val stringIdxList = friesian.generateStringIdx(df, cols.toList.asJava, orderByFrequency = true)
+    val col4Idx = stringIdxList.get(0).collect().sortBy(_.getInt(1))
+    val col5Idx = stringIdxList.get(1).collect().sortBy(_.getInt(1))
+    assert(col4Idx(0).getString(0) == "abc")
+    assert(col5Idx(0).getString(0) == "aa")
+  }
+
   "mask Int" should "work properly" in {
     val data = sc.parallelize(Seq(
       Row("jack", Seq(1, 2, 3, 4, 5)),


### PR DESCRIPTION
Used by recsys preprocessing and it is probably a useful feature to assign more frequent values smaller ids.