### PR TITLE
Add string type option in convert_row_to_numpy

### DIFF
--- a/pyzoo/test/zoo/orca/learn/ray/tf/test_tf_ray_estimator.py
+++ b/pyzoo/test/zoo/orca/learn/ray/tf/test_tf_ray_estimator.py
@@ -598,6 +598,7 @@ class TestTFRayEstimator(TestCase):
         estimator = Estimator.from_keras(model_creator=model_creator)
         output_df = estimator.predict(input_df, batch_size=1, feature_cols=["input"])
         output = output_df.collect()
+        print(output)
 
 
 if __name__ == "__main__":

--- a/pyzoo/test/zoo/orca/learn/ray/tf/test_tf_ray_estimator.py
+++ b/pyzoo/test/zoo/orca/learn/ray/tf/test_tf_ray_estimator.py
@@ -578,6 +578,27 @@ class TestTFRayEstimator(TestCase):
         finally:
             os.remove("/tmp/cifar10_keras.ckpt")
 
+    def test_string_input(self):
+
+        def model_creator(config):
+            import tensorflow as tf
+            vectorize_layer = tf.keras.layers.experimental.preprocessing.TextVectorization(
+                max_tokens=10, output_mode='int', output_sequence_length=4)
+            model = tf.keras.models.Sequential()
+            model.add(tf.keras.Input(shape=(1,), dtype=tf.string))
+            model.add(vectorize_layer)
+            return model
+
+        from zoo.orca import OrcaContext
+        from pyspark.sql.types import StructType, StructField, StringType
+        spark = OrcaContext.get_spark_session()
+        schema = StructType([StructField("input", StringType(), True)])
+        input_data = [["foo qux bar"], ["qux baz"]]
+        input_df = spark.createDataFrame(input_data, schema)
+        estimator = Estimator.from_keras(model_creator=model_creator)
+        output_df = estimator.predict(input_df, batch_size=1, feature_cols=["input"])
+        output = output_df.collect()
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/pyzoo/zoo/orca/learn/openvino/estimator.py
+++ b/pyzoo/zoo/orca/learn/openvino/estimator.py
@@ -111,7 +111,8 @@ class OpenvinoEstimator(SparkEstimator):
                                               validation_data=None,
                                               feature_cols=feature_cols,
                                               label_cols=None,
-                                              mode="predict")
+                                              mode="predict",
+                                              accept_str_col=False)
             transformed_data = xshards.transform_shard(predict_transform, self.batch_size)
             result_rdd = self.model.distributed_predict(transformed_data.rdd, sc)
             return convert_predict_rdd_to_dataframe(data, result_rdd.flatMap(lambda data: data))

--- a/pyzoo/zoo/orca/learn/openvino/estimator.py
+++ b/pyzoo/zoo/orca/learn/openvino/estimator.py
@@ -111,8 +111,7 @@ class OpenvinoEstimator(SparkEstimator):
                                               validation_data=None,
                                               feature_cols=feature_cols,
                                               label_cols=None,
-                                              mode="predict",
-                                              accept_str_col=False)
+                                              mode="predict")
             transformed_data = xshards.transform_shard(predict_transform, self.batch_size)
             result_rdd = self.model.distributed_predict(transformed_data.rdd, sc)
             return convert_predict_rdd_to_dataframe(data, result_rdd.flatMap(lambda data: data))

--- a/pyzoo/zoo/orca/learn/tf2/estimator.py
+++ b/pyzoo/zoo/orca/learn/tf2/estimator.py
@@ -221,7 +221,8 @@ class TensorFlow2Estimator(OrcaRayEstimator):
         data, validation_data = maybe_dataframe_to_xshards(data, validation_data,
                                                            feature_cols, label_cols,
                                                            mode="fit",
-                                                           num_workers=self.num_workers)
+                                                           num_workers=self.num_workers,
+                                                           accept_str_col=True)
 
         if isinstance(data, SparkXShards):
             if data._get_class_name() == 'pandas.core.frame.DataFrame':
@@ -305,7 +306,8 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                                              feature_cols=feature_cols,
                                              label_cols=label_cols,
                                              mode="evaluate",
-                                             num_workers=self.num_workers)
+                                             num_workers=self.num_workers,
+                                             accept_str_col=True)
 
         if isinstance(data, SparkXShards):
             if data._get_class_name() == 'pandas.core.frame.DataFrame':
@@ -380,7 +382,8 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                                               validation_data=None,
                                               feature_cols=feature_cols,
                                               label_cols=None,
-                                              mode="predict")
+                                              mode="predict",
+                                              accept_str_col=True)
             pred_shards = self._predict_spark_xshards(xshards, params)
             result = convert_predict_xshards_to_dataframe(data, pred_shards)
         elif isinstance(data, SparkXShards):

--- a/pyzoo/zoo/orca/learn/utils.py
+++ b/pyzoo/zoo/orca/learn/utils.py
@@ -263,7 +263,7 @@ def process_xshards_of_pandas_dataframe(data, feature_cols, label_cols=None, val
         return data
 
 
-def _dataframe_to_xshards(data, feature_cols, label_cols=None, accept_str_col=True):
+def _dataframe_to_xshards(data, feature_cols, label_cols=None, accept_str_col=False):
     from zoo.orca import OrcaContext
     schema = data.schema
     shard_size = OrcaContext._shard_size
@@ -280,7 +280,7 @@ def _dataframe_to_xshards(data, feature_cols, label_cols=None, accept_str_col=Tr
 
 
 def dataframe_to_xshards(data, validation_data, feature_cols, label_cols, mode="fit",
-                         num_workers=None, accept_str_col=True):
+                         num_workers=None, accept_str_col=False):
     from pyspark.sql import DataFrame
     valid_mode = {"fit", "evaluate", "predict"}
     assert mode in valid_mode, f"invalid mode {mode} " \
@@ -306,14 +306,15 @@ def dataframe_to_xshards(data, validation_data, feature_cols, label_cols, mode="
 
 
 def maybe_dataframe_to_xshards(data, validation_data, feature_cols, label_cols, mode="fit",
-                               num_workers=None):
+                               num_workers=None, accept_str_col=False):
     from pyspark.sql import DataFrame
     if isinstance(data, DataFrame):
         data, validation_data = dataframe_to_xshards(data, validation_data,
                                                      feature_cols=feature_cols,
                                                      label_cols=label_cols,
                                                      mode=mode,
-                                                     num_workers=num_workers)
+                                                     num_workers=num_workers,
+                                                     accept_str_col=accept_str_col)
     return data, validation_data
 
 

--- a/pyzoo/zoo/orca/learn/utils.py
+++ b/pyzoo/zoo/orca/learn/utils.py
@@ -263,14 +263,15 @@ def process_xshards_of_pandas_dataframe(data, feature_cols, label_cols=None, val
         return data
 
 
-def _dataframe_to_xshards(data, feature_cols, label_cols=None):
+def _dataframe_to_xshards(data, feature_cols, label_cols=None, accept_str_col=True):
     from zoo.orca import OrcaContext
     schema = data.schema
     shard_size = OrcaContext._shard_size
     numpy_rdd = data.rdd.map(lambda row: convert_row_to_numpy(row,
                                                               schema,
                                                               feature_cols,
-                                                              label_cols))
+                                                              label_cols,
+                                                              accept_str_col))
     shard_rdd = numpy_rdd.mapPartitions(lambda x: arrays2dict(x,
                                                               feature_cols,
                                                               label_cols,
@@ -279,7 +280,7 @@ def _dataframe_to_xshards(data, feature_cols, label_cols=None):
 
 
 def dataframe_to_xshards(data, validation_data, feature_cols, label_cols, mode="fit",
-                         num_workers=None):
+                         num_workers=None, accept_str_col=True):
     from pyspark.sql import DataFrame
     valid_mode = {"fit", "evaluate", "predict"}
     assert mode in valid_mode, f"invalid mode {mode} " \
@@ -296,9 +297,10 @@ def dataframe_to_xshards(data, validation_data, feature_cols, label_cols, mode="
         if data.rdd.getNumPartitions() < num_workers:
             data = data.repartition(num_workers)
 
-    data = _dataframe_to_xshards(data, feature_cols, label_cols)
+    data = _dataframe_to_xshards(data, feature_cols, label_cols, accept_str_col)
     if validation_data is not None:
-        validation_data = _dataframe_to_xshards(validation_data, feature_cols, label_cols)
+        validation_data = _dataframe_to_xshards(validation_data, feature_cols, label_cols,
+                                                accept_str_col)
 
     return data, validation_data
 

--- a/pyzoo/zoo/util/utils.py
+++ b/pyzoo/zoo/util/utils.py
@@ -154,7 +154,7 @@ def set_python_home():
         os.environ['PYTHONHOME'] = "/".join(detect_python_location().split("/")[:-2])
 
 
-def _is_scalar_type(dtype):
+def _is_scalar_type(dtype, accept_str_col=False):
     import pyspark.sql.types as df_types
     if isinstance(dtype, df_types.FloatType):
         return True
@@ -164,18 +164,18 @@ def _is_scalar_type(dtype):
         return True
     if isinstance(dtype, df_types.DoubleType):
         return True
-    if isinstance(dtype, df_types.StringType):
+    if accept_str_col and isinstance(dtype, df_types.StringType):
         return True
     return False
 
 
-def convert_row_to_numpy(row, schema, feature_cols, label_cols):
+def convert_row_to_numpy(row, schema, feature_cols, label_cols, accept_str_col=False):
     def convert_for_cols(row, cols):
         import pyspark.sql.types as df_types
         result = []
         for name in cols:
             feature_type = schema[name].dataType
-            if _is_scalar_type(feature_type):
+            if _is_scalar_type(feature_type, accept_str_col):
                 result.append(np.array(row[name]))
             elif isinstance(feature_type, df_types.ArrayType):
                 result.append(np.array(row[name]).astype(np.float32))


### PR DESCRIPTION
Logically, only tf2 estimator and pytorch ray estimator can support string input. BigDL backends use Sample and string is not supported.