### PR TITLE
Fix tensorboard hparam sorting issue

### DIFF
--- a/pyzoo/zoo/automl/logger/tensorboardxlogger.py
+++ b/pyzoo/zoo/automl/logger/tensorboardxlogger.py
@@ -98,8 +98,11 @@ class TensorboardXLogger():
         for key in config.keys():
             new_config[key] = {}
             for k, value in config[key].items():
-                if value is not None:
+                if type(value) in VALID_SUMMARY_TYPES and not np.isnan(value):
                     new_config[key][f'{self.name}/' + k] = value
+        for key in new_config.keys():
+            if new_config[key] == {}:
+                del new_config[key]
 
         new_metric = {}
         for key in metric.keys():
@@ -109,6 +112,9 @@ class TensorboardXLogger():
                     value = [value]
                 if type(value[-1]) in VALID_SUMMARY_TYPES and not np.isnan(value[-1]):
                     new_metric[key][f'{self.name}/' + k] = value
+        for key in new_metric.keys():
+            if new_metric[key] == {}:
+                del new_metric[key]
 
         # hparams log write
         for key in new_metric.keys():


### PR DESCRIPTION
#3426 
When a hparam column contains non-numeric value, it leads to sorting malfunction in Tensorboard.
Still need work on showing these columns.