### PR TITLE
Chronos: change inference code in pytorch base model to use no_grad

### DIFF
--- a/pyzoo/zoo/automl/model/base_pytorch_model.py
+++ b/pyzoo/zoo/automl/model/base_pytorch_model.py
@@ -255,15 +255,12 @@ class PytorchBaseModel(BaseModel):
             self.model.eval()
         test_loader = DataLoader(TensorDataset(x),
                                  batch_size=int(batch_size))
-        result = np.zeros((x.shape[0],
-                           self.config["future_seq_len"],
-                           self.config["output_feature_num"]))
-        idx = 0
+        y_list = []
         with torch.no_grad():
             for x_test_batch in test_loader:
-                result[idx:idx+batch_size] = self.model(x_test_batch[0]).numpy()
-                idx += batch_size
-        return result
+                y_list.append(self.model(x_test_batch[0]).numpy())
+        yhat = np.concatenate(y_list, axis=0)
+        return yhat
 
     def predict_with_uncertainty(self, x, n_iter=100):
         result = np.zeros((n_iter,) + (x.shape[0], self.config["output_feature_num"]))

--- a/pyzoo/zoo/automl/model/base_pytorch_model.py
+++ b/pyzoo/zoo/automl/model/base_pytorch_model.py
@@ -255,11 +255,15 @@ class PytorchBaseModel(BaseModel):
             self.model.eval()
         test_loader = DataLoader(TensorDataset(x),
                                  batch_size=int(batch_size))
-        yhat_list = []
-        for x_test_batch in test_loader:
-            yhat_list.append(self.model(x_test_batch[0]).detach().numpy())
-        yhat = np.concatenate(yhat_list, axis=0)
-        return yhat
+        result = np.zeros((x.shape[0],
+                           self.config["future_seq_len"],
+                           self.config["output_feature_num"]))
+        idx = 0
+        with torch.no_grad():
+            for x_test_batch in test_loader:
+                result[idx:idx+batch_size] = self.model(x_test_batch[0]).numpy()
+                idx += batch_size
+        return result
 
     def predict_with_uncertainty(self, x, n_iter=100):
         result = np.zeros((n_iter,) + (x.shape[0], self.config["output_feature_num"]))


### PR DESCRIPTION
This will give a 1.15X speed up for the pytorch prediction.