### PR TITLE
Add TSDataset.to_torch_data_loader

### DIFF
--- a/pyzoo/test/zoo/chronos/data/test_tsdataset.py
+++ b/pyzoo/test/zoo/chronos/data/test_tsdataset.py
@@ -284,7 +284,36 @@ class TestTSDataset(ZooTestCase):
         assert np.array_equal(y, np.array([[[2.4, 2.6]]]))
 
     def test_tsdataset_to_torch_loader_roll(self):
-        import torch
+        df_single_id = get_ts_df()
+        df_multi_id = get_multi_id_ts_df()
+        for df in [df_single_id, df_multi_id]:
+            horizon = random.randint(1, 10)
+            lookback = random.randint(1, 20)
+            batch_size = 32
+
+            tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col="value",
+                                           extra_feature_col=["extra feature"], id_col="id")
+
+            # train
+            torch_loader = tsdata.to_torch_loader(batch_size=32,
+                                                  roll=True,
+                                                  lookback=lookback,
+                                                  horizon=horizon)
+            for x_batch, y_batch in torch_loader:
+                assert tuple(x_batch.size()) == (batch_size, lookback, 2)
+                assert tuple(y_batch.size()) == (batch_size, horizon, 1)
+                break
+
+            # test
+            torch_loader = tsdata.to_torch_loader(batch_size=32,
+                                                  roll=True,
+                                                  lookback=lookback,
+                                                  horizon=0)
+            for x_batch in torch_loader:
+                assert tuple(x_batch.size()) == (batch_size, lookback, 2)
+                break
+
+    def test_tsdataset_to_torch_loader(self):
         df = get_ts_df()
         horizon = random.randint(1, 10)
         lookback = random.randint(1, 20)
@@ -293,23 +322,16 @@ class TestTSDataset(ZooTestCase):
         tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col="value",
                                        extra_feature_col=["extra feature"], id_col="id")
 
-        # train
-        torch_loader = tsdata.to_torch_loader(batch_size=32,
-                                              roll=True,
-                                              lookback=lookback,
-                                              horizon=horizon)
-        for x_batch, y_batch in torch_loader:
+        with pytest.raises(RuntimeError):
+            tsdata.to_torch_loader()
+
+        tsdata.roll(lookback=lookback, horizon=horizon)
+        loader = tsdata.to_torch_loader(batch_size=32,
+                                        lookback=lookback,
+                                        horizon=horizon)
+        for x_batch, y_batch in loader:
             assert tuple(x_batch.size()) == (batch_size, lookback, 2)
             assert tuple(y_batch.size()) == (batch_size, horizon, 1)
-            break
-
-        # test
-        torch_loader = tsdata.to_torch_loader(batch_size=32,
-                                              roll=True,
-                                              lookback=lookback,
-                                              horizon=0)
-        for x_batch in torch_loader:
-            assert tuple(x_batch.size()) == (batch_size, lookback, 2)
             break
 
     def test_tsdataset_imputation(self):

--- a/pyzoo/test/zoo/chronos/data/test_tsdataset.py
+++ b/pyzoo/test/zoo/chronos/data/test_tsdataset.py
@@ -295,30 +295,30 @@ class TestTSDataset(ZooTestCase):
                                            extra_feature_col=["extra feature"], id_col="id")
 
             # train
-            torch_loader = tsdata.to_torch_loader(batch_size=32,
-                                                  roll=True,
-                                                  lookback=lookback,
-                                                  horizon=horizon)
+            torch_loader = tsdata.to_torch_data_loader(batch_size=32,
+                                                       roll=True,
+                                                       lookback=lookback,
+                                                       horizon=horizon)
             for x_batch, y_batch in torch_loader:
                 assert tuple(x_batch.size()) == (batch_size, lookback, 2)
                 assert tuple(y_batch.size()) == (batch_size, horizon, 1)
                 break
 
             # test
-            torch_loader = tsdata.to_torch_loader(batch_size=32,
-                                                  roll=True,
-                                                  lookback=lookback,
-                                                  horizon=0)
+            torch_loader = tsdata.to_torch_data_loader(batch_size=32,
+                                                       roll=True,
+                                                       lookback=lookback,
+                                                       horizon=0)
             for x_batch in torch_loader:
                 assert tuple(x_batch.size()) == (batch_size, lookback, 2)
                 break
 
             # specify feature_col
-            torch_loader = tsdata.to_torch_loader(batch_size=32,
-                                                  roll=True,
-                                                  lookback=lookback,
-                                                  horizon=horizon,
-                                                  feature_col=[])
+            torch_loader = tsdata.to_torch_data_loader(batch_size=32,
+                                                       roll=True,
+                                                       lookback=lookback,
+                                                       horizon=horizon,
+                                                       feature_col=[])
             for x_batch, y_batch in torch_loader:
                 assert tuple(x_batch.size()) == (batch_size, lookback, 1)
                 assert tuple(y_batch.size()) == (batch_size, horizon, 1)
@@ -334,12 +334,12 @@ class TestTSDataset(ZooTestCase):
                                        extra_feature_col=["extra feature"], id_col="id")
 
         with pytest.raises(RuntimeError):
-            tsdata.to_torch_loader()
+            tsdata.to_torch_data_loader()
 
         tsdata.roll(lookback=lookback, horizon=horizon)
-        loader = tsdata.to_torch_loader(batch_size=32,
-                                        lookback=lookback,
-                                        horizon=horizon)
+        loader = tsdata.to_torch_data_loader(batch_size=32,
+                                             lookback=lookback,
+                                             horizon=horizon)
         for x_batch, y_batch in loader:
             assert tuple(x_batch.size()) == (batch_size, lookback, 2)
             assert tuple(y_batch.size()) == (batch_size, horizon, 1)

--- a/pyzoo/test/zoo/chronos/data/test_tsdataset.py
+++ b/pyzoo/test/zoo/chronos/data/test_tsdataset.py
@@ -313,6 +313,17 @@ class TestTSDataset(ZooTestCase):
                 assert tuple(x_batch.size()) == (batch_size, lookback, 2)
                 break
 
+            # specify feature_col
+            torch_loader = tsdata.to_torch_loader(batch_size=32,
+                                                  roll=True,
+                                                  lookback=lookback,
+                                                  horizon=horizon,
+                                                  feature_col=[])
+            for x_batch, y_batch in torch_loader:
+                assert tuple(x_batch.size()) == (batch_size, lookback, 1)
+                assert tuple(y_batch.size()) == (batch_size, horizon, 1)
+                break
+
     def test_tsdataset_to_torch_loader(self):
         df = get_ts_df()
         horizon = random.randint(1, 10)

--- a/pyzoo/test/zoo/chronos/data/test_tsdataset.py
+++ b/pyzoo/test/zoo/chronos/data/test_tsdataset.py
@@ -283,6 +283,35 @@ class TestTSDataset(ZooTestCase):
         assert np.array_equal(x, np.array([[[1.9, 2.3, 1, 2, 0, 9]]]))
         assert np.array_equal(y, np.array([[[2.4, 2.6]]]))
 
+    def test_tsdataset_to_torch_loader_roll(self):
+        import torch
+        df = get_ts_df()
+        horizon = random.randint(1, 10)
+        lookback = random.randint(1, 20)
+        batch_size = 32
+
+        tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col="value",
+                                       extra_feature_col=["extra feature"], id_col="id")
+
+        # train
+        torch_loader = tsdata.to_torch_loader(batch_size=32,
+                                              roll=True,
+                                              lookback=lookback,
+                                              horizon=horizon)
+        for x_batch, y_batch in torch_loader:
+            assert tuple(x_batch.size()) == (batch_size, lookback, 2)
+            assert tuple(y_batch.size()) == (batch_size, horizon, 1)
+            break
+
+        # test
+        torch_loader = tsdata.to_torch_loader(batch_size=32,
+                                              roll=True,
+                                              lookback=lookback,
+                                              horizon=0)
+        for x_batch in torch_loader:
+            assert tuple(x_batch.size()) == (batch_size, lookback, 2)
+            break
+
     def test_tsdataset_imputation(self):
         for val in ["last", "const", "linear"]:
             df = get_ugly_ts_df()

--- a/pyzoo/test/zoo/chronos/data/utils/test_roll_dataset.py
+++ b/pyzoo/test/zoo/chronos/data/utils/test_roll_dataset.py
@@ -75,8 +75,7 @@ class TestRollDataset:
             else:
                 # for test, y is None.
                 xi = x[i]
-                roll_dataset_xi, roll_dataset_yi = roll_dataset[i]
-                assert roll_dataset_yi is None
+                roll_dataset_xi = roll_dataset[i]
                 np.testing.assert_array_almost_equal(xi, roll_dataset_xi.detach().numpy())
 
     @staticmethod

--- a/pyzoo/test/zoo/chronos/data/utils/test_roll_dataset.py
+++ b/pyzoo/test/zoo/chronos/data/utils/test_roll_dataset.py
@@ -1,0 +1,107 @@
+#
+# Copyright 2018 Analytics Zoo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+import numpy as np
+import pandas as pd
+import random
+from zoo.chronos.data import TSDataset
+from zoo.chronos.data.utils.roll_dataset import RollDataset
+
+
+def get_ts_df():
+    sample_num = np.random.randint(100, 200)
+    train_df = pd.DataFrame({"datetime": pd.date_range('1/1/2019', periods=sample_num),
+                             "value": np.random.randn(sample_num),
+                             "id": np.array(['00']*sample_num),
+                             "extra feature": np.random.randn(sample_num)})
+    return train_df
+
+
+def get_multi_id_ts_df():
+    sample_num = 100
+    train_df = pd.DataFrame({"value": np.random.randn(sample_num),
+                             "id": np.array(['00']*50 + ['01']*50),
+                             "extra feature": np.random.randn(sample_num)})
+    train_df["datetime"] = pd.date_range('1/1/2019', periods=sample_num)
+    train_df.loc[50:100, "datetime"] = pd.date_range('1/1/2019', periods=50)
+    return train_df
+
+
+class TestRollDataset:
+
+    @staticmethod
+    def assert_equal_with_tsdataset(df,
+                                    horizon,
+                                    lookback,
+                                    feature_num=1,
+                                    ):
+        # get results rolled by tsdata.roll
+        extra_feature_col = None if feature_num == 0 else ["extra feature"]
+        tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col="value",
+                                       extra_feature_col=extra_feature_col, id_col="id")
+        tsdata.roll(lookback=lookback, horizon=horizon)
+        x, y = tsdata.to_numpy()
+
+        # get results rolled by RollDataset
+        roll_dataset = RollDataset(df=df,
+                                   lookback=lookback,
+                                   horizon=horizon,
+                                   feature_col=tsdata.feature_col,
+                                   target_col=tsdata.target_col,
+                                   id_col=tsdata.id_col)
+
+        assert len(roll_dataset) == len(x)
+        for i in range(len(x)):
+            if horizon != 0:
+                # for train and y is not None.
+                xi, yi = x[i], y[i]
+                roll_dataset_xi, roll_dataset_yi = roll_dataset[i]
+                np.testing.assert_array_almost_equal(xi, roll_dataset_xi.detach().numpy())
+                np.testing.assert_array_almost_equal(yi, roll_dataset_yi.detach().numpy())
+            else:
+                # for test, y is None.
+                xi = x[i]
+                roll_dataset_xi, roll_dataset_yi = roll_dataset[i]
+                assert roll_dataset_yi is None
+                np.testing.assert_array_almost_equal(xi, roll_dataset_xi.detach().numpy())
+
+    @staticmethod
+    def combination_tests_for_df(df):
+        lookback = random.randint(1, 20)
+
+        horizon_tests = [
+            random.randint(1, 10),  # train & horizon is int
+            [1, 4, 16],  # train & horizon is list of ints
+            0,  # test
+        ]
+        # todo: add tests for multiple targets and feature_num > 1
+        feature_num_tests = [0, 1]
+
+        for horizon in horizon_tests:
+            for feature_num in feature_num_tests:
+                TestRollDataset.assert_equal_with_tsdataset(df=df,
+                                                            horizon=horizon,
+                                                            lookback=lookback,
+                                                            feature_num=feature_num)
+
+    def test_single_id(self):
+        df = get_ts_df()
+        TestRollDataset.combination_tests_for_df(df)
+
+    def test_multi_id(self):
+        df = get_multi_id_ts_df()
+        TestRollDataset.combination_tests_for_df(df)

--- a/pyzoo/test/zoo/chronos/data/utils/test_roll_dataset.py
+++ b/pyzoo/test/zoo/chronos/data/utils/test_roll_dataset.py
@@ -104,3 +104,14 @@ class TestRollDataset:
     def test_multi_id(self):
         df = get_multi_id_ts_df()
         TestRollDataset.combination_tests_for_df(df)
+
+    def test_df_nan(self):
+        df = get_ts_df()
+        df["value"][0] = np.nan
+        with pytest.raises(AssertionError):
+            RollDataset(df=df,
+                        lookback=2,
+                        horizon=1,
+                        feature_col=["extra feature"],
+                        target_col=["value"],
+                        id_col="id")

--- a/pyzoo/zoo/chronos/data/tsdataset.py
+++ b/pyzoo/zoo/chronos/data/tsdataset.py
@@ -564,7 +564,7 @@ class TSDataset:
 
         return self
 
-    def to_torch_loader(self, batch_size=32, roll=True, lookback=None, horizon=None):
+    def to_torch_loader(self, batch_size=32, roll=False, lookback=None, horizon=None):
         """
         to be added
         """
@@ -586,6 +586,9 @@ class TSDataset:
                               batch_size=batch_size,
                               shuffle=True)
         else:
+            if self.numpy_x is None:
+                raise RuntimeError("Please call \"roll\" method before transforming a TSDataset to "
+                                   "torch DataLoader without rolling (default roll=False)!")
             x, y = self.to_numpy()
             return DataLoader(TensorDataset(torch.from_numpy(x).float(),
                                             torch.from_numpy(y).float()),

--- a/pyzoo/zoo/chronos/data/tsdataset.py
+++ b/pyzoo/zoo/chronos/data/tsdataset.py
@@ -632,6 +632,10 @@ class TSDataset:
                 else self.feature_col
             target_col = _to_list(target_col, "target_col") if target_col is not None \
                 else self.target_col
+
+            # set scaler index for unscale_numpy
+            self.scaler_index = [self.target_col.index(t) for t in target_col]
+
             torch_dataset = RollDataset(self.df,
                                         lookback=lookback,
                                         horizon=horizon,

--- a/pyzoo/zoo/chronos/data/tsdataset.py
+++ b/pyzoo/zoo/chronos/data/tsdataset.py
@@ -564,6 +564,34 @@ class TSDataset:
 
         return self
 
+    def to_torch_loader(self, batch_size=32, roll=True, lookback=None, horizon=None):
+        """
+        to be added
+        """
+        from torch.utils.data import TensorDataset, DataLoader
+        import torch
+        if roll:
+            if lookback is None:
+                raise ValueError("You must input lookback if roll is True")
+            if horizon is None:
+                raise ValueError("You must input horizon if roll is True")
+            from zoo.chronos.data.utils.roll_dataset import RollDataset
+            torch_dataset = RollDataset(self.df,
+                                        lookback=lookback,
+                                        horizon=horizon,
+                                        feature_col=self.feature_col,
+                                        target_col=self.target_col,
+                                        id_col=self.id_col)
+            return DataLoader(torch_dataset,
+                              batch_size=batch_size,
+                              shuffle=True)
+        else:
+            x, y = self.to_numpy()
+            return DataLoader(TensorDataset(torch.from_numpy(x).float(),
+                                            torch.from_numpy(y).float()),
+                              batch_size=batch_size,
+                              shuffle=True)
+
     def to_numpy(self):
         '''
         Export rolling result in form of a tuple of numpy ndarray (x, y).

--- a/pyzoo/zoo/chronos/data/tsdataset.py
+++ b/pyzoo/zoo/chronos/data/tsdataset.py
@@ -564,7 +564,13 @@ class TSDataset:
 
         return self
 
-    def to_torch_loader(self, batch_size=32, roll=False, lookback=None, horizon=None):
+    def to_torch_loader(self,
+                        batch_size=32,
+                        roll=False,
+                        lookback=None,
+                        horizon=None,
+                        feature_col=None,
+                        target_col=None,):
         """
         to be added
         """
@@ -576,11 +582,15 @@ class TSDataset:
             if horizon is None:
                 raise ValueError("You must input horizon if roll is True")
             from zoo.chronos.data.utils.roll_dataset import RollDataset
+            feature_col = _to_list(feature_col, "feature_col") if feature_col is not None \
+                else self.feature_col
+            target_col = _to_list(target_col, "target_col") if target_col is not None \
+                else self.target_col
             torch_dataset = RollDataset(self.df,
                                         lookback=lookback,
                                         horizon=horizon,
-                                        feature_col=self.feature_col,
-                                        target_col=self.target_col,
+                                        feature_col=feature_col,
+                                        target_col=target_col,
                                         id_col=self.id_col)
             return DataLoader(torch_dataset,
                               batch_size=batch_size,

--- a/pyzoo/zoo/chronos/data/tsdataset.py
+++ b/pyzoo/zoo/chronos/data/tsdataset.py
@@ -564,23 +564,23 @@ class TSDataset:
 
         return self
 
-    def to_torch_loader(self,
-                        batch_size=32,
-                        roll=False,
-                        lookback=None,
-                        horizon=None,
-                        feature_col=None,
-                        target_col=None,):
+    def to_torch_data_loader(self,
+                             batch_size=32,
+                             roll=False,
+                             lookback=None,
+                             horizon=None,
+                             feature_col=None,
+                             target_col=None, ):
         """
         Convert TSDataset to a PyTorch DataLoader with or without rolling. We recommend to use
-        to_torch_loader(roll=True) if you don't need to output the rolled numpy array. It is
+        to_torch_data_loader(roll=True) if you don't need to output the rolled numpy array. It is
         much more efficient than rolling separately, especially when the dataframe or lookback
         is large.
 
         :param batch_size: int, the batch_size for a Pytorch DataLoader. It defaults to 32.
         :param roll: Boolean. Whether to roll the dataframe before converting to DataLoader.
                If True, you must also specify lookback and horizon for rolling. If False, you must
-               have called tsdataset.roll() before calling to_torch_loader(). Default to False.
+               have called tsdataset.roll() before calling to_torch_data_loader(). Default to False.
         :param lookback: int, lookback value.
         :param horizon: int or list,
                if `horizon` is an int, we will sample `horizon` step
@@ -596,7 +596,7 @@ class TSDataset:
 
         :return: A pytorch DataLoader instance.
 
-        to_torch_loader() can be called by:
+        to_torch_data_loader() can be called by:
 
         >>> # Here is a df example:
         >>> # id        datetime      value   "extra feature 1"   "extra feature 2"
@@ -609,15 +609,15 @@ class TSDataset:
         >>>                                   extra_feature_col=["extra feature 1",
         >>>                                                      "extra feature 2"])
         >>> horizon, lookback = 1, 1
-        >>> data_loader = tsdataset.to_torch_loader(batch_size=32,
-        >>>                                         roll=True,
-        >>>                                         lookback=lookback,
-        >>>                                         horizon=horizon)
+        >>> data_loader = tsdataset.to_torch_data_loader(batch_size=32,
+        >>>                                              roll=True,
+        >>>                                              lookback=lookback,
+        >>>                                              horizon=horizon)
         >>> # or roll outside. That might be less efficient than the way above.
         >>> tsdataset.roll(lookback=lookback, horizon=horizon, id_sensitive=False)
         >>> x, y = tsdataset.to_numpy()
         >>> print(x, y) # x = [[[1.9, 1, 2 ]], [[2.3, 0, 9 ]]] y = [[[ 2.4 ]], [[ 2.6 ]]]
-        >>> data_loader = tsdataset.to_torch_loader(batch_size=32)
+        >>> data_loader = tsdataset.to_torch_data_loader(batch_size=32)
 
         """
         from torch.utils.data import TensorDataset, DataLoader

--- a/pyzoo/zoo/chronos/data/utils/roll_dataset.py
+++ b/pyzoo/zoo/chronos/data/utils/roll_dataset.py
@@ -52,14 +52,15 @@ class RollDataset(Dataset):
         start_idx = self.roll_start_idxes[idx]
         x = self.arr[start_idx: start_idx + self.lookback]
         x = torch.from_numpy(x).float()
-
-        arr_target_only = self.arr[:, :self.target_num]
         if self.horizon == 0:
-            y = None
-            return x, y
+            return x
+
+        # cal y
+        arr_target_only = self.arr[:, :self.target_num]
         if isinstance(self.horizon, int):
             y = arr_target_only[start_idx + self.lookback: start_idx + self.lookback + self.horizon]
         else:
+            # horizon is a list of int
             horizons = np.array(self.horizon)
             y = np.take(arr_target_only, horizons + start_idx + self.lookback - 1, axis=0)
         y = torch.from_numpy(y).float()

--- a/pyzoo/zoo/chronos/data/utils/roll_dataset.py
+++ b/pyzoo/zoo/chronos/data/utils/roll_dataset.py
@@ -85,4 +85,3 @@ class RollDataset(Dataset):
             y = np.take(arr_target_only, horizons + start_idx + self.lookback - 1, axis=0)
         y = torch.from_numpy(y).float()
         return x, y
-

--- a/pyzoo/zoo/chronos/data/utils/roll_dataset.py
+++ b/pyzoo/zoo/chronos/data/utils/roll_dataset.py
@@ -39,6 +39,8 @@ class RollDataset(Dataset):
         2. if contains multiple ids, rows of same id should be consecutive
         3. dataframe has been ordered by timestamp for each id.
         """
+        feature_col = _to_list(feature_col, "feature_col")
+        target_col = _to_list(target_col, "target_col")
         _check_cols_no_na(df, col_names=target_col + feature_col)
         self.arr = df.loc[:, target_col + feature_col].to_numpy(copy=False)
         max_horizon = horizon if isinstance(horizon, int) else max(horizon)

--- a/pyzoo/zoo/chronos/data/utils/roll_dataset.py
+++ b/pyzoo/zoo/chronos/data/utils/roll_dataset.py
@@ -18,6 +18,8 @@ import numpy as np
 from torch.utils.data import Dataset
 import torch
 
+from zoo.chronos.data.utils.utils import _check_cols_no_na, _to_list
+
 
 def get_roll_start_idx(df, id_col, window_size):
     import itertools
@@ -31,12 +33,13 @@ def get_roll_start_idx(df, id_col, window_size):
 class RollDataset(Dataset):
     def __init__(self, df, lookback, horizon, feature_col, target_col, id_col):
         """
-        todo: add check for df
+        todo: add check for df pre-requests 2, 3.
         pre-request for df:
-        1. all the values are not nan
+        1. all the values in target_col and feature_col are not nan
         2. if contains multiple ids, rows of same id should be consecutive
         3. dataframe has been ordered by timestamp for each id.
         """
+        _check_cols_no_na(df, col_names=target_col + feature_col)
         self.arr = df.loc[:, target_col + feature_col].to_numpy(copy=False)
         max_horizon = horizon if isinstance(horizon, int) else max(horizon)
         window_size = lookback + max_horizon

--- a/pyzoo/zoo/chronos/data/utils/roll_dataset.py
+++ b/pyzoo/zoo/chronos/data/utils/roll_dataset.py
@@ -37,7 +37,7 @@ class RollDataset(Dataset):
         2. if contains multiple ids, rows of same id should be consecutive
         3. dataframe has been ordered by timestamp for each id.
         """
-        self.arr = df.loc[:, target_col + feature_col].to_numpy()
+        self.arr = df.loc[:, target_col + feature_col].to_numpy(copy=False)
         max_horizon = horizon if isinstance(horizon, int) else max(horizon)
         window_size = lookback + max_horizon
         self.roll_start_idxes = get_roll_start_idx(df, id_col, window_size=window_size)

--- a/pyzoo/zoo/chronos/data/utils/roll_dataset.py
+++ b/pyzoo/zoo/chronos/data/utils/roll_dataset.py
@@ -1,0 +1,63 @@
+#
+# Copyright 2018 Analytics Zoo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import numpy as np
+from torch.utils.data import Dataset
+import torch
+
+
+def get_roll_start_idx(df, id_col, window_size):
+    import itertools
+    id_start_idxes = df.index[df[id_col] != df[id_col].shift(1)].tolist()
+    roll_start_idx_iter = ((range(id_start_idxes[i], id_start_idxes[i+1] - window_size + 1))
+                           for i in range(len(id_start_idxes) - 1))
+    roll_start_idxes = list(itertools.chain.from_iterable(roll_start_idx_iter))
+    return roll_start_idxes
+
+
+class RollDataset(Dataset):
+    def __init__(self, df, lookback, horizon, feature_col, target_col, id_col):
+        """
+        todo: add check for df
+        pre-request for df:
+        1. all the values are not nan
+        2. if contains multiple ids, rows of same id should be consecutive
+        3. dataframe has been ordered by timestamp for each id.
+        """
+        self.arr = df.loc[:, target_col + feature_col].to_numpy()
+        max_horizon = horizon if isinstance(horizon, int) else max(horizon)
+        window_size = lookback + max_horizon
+        self.roll_start_idxes = get_roll_start_idx(df, id_col, window_size=window_size)
+        self.lookback = lookback
+        self.horizon = horizon
+        self.target_num = len(target_col)
+
+    def __len__(self):
+        return len(self.roll_start_idxes)
+
+    def __getitem__(self, idx):
+        start_idx = self.roll_start_idxes[idx]
+        x = self.arr[start_idx: start_idx + self.lookback]
+        arr_target_only = self.arr[:, :self.target_num]
+        if isinstance(self.horizon, int):
+            y = arr_target_only[start_idx + self.lookback: start_idx + self.lookback + self.horizon]
+        else:
+            horizons = np.array(self.horizon)
+            y = np.take(arr_target_only, horizons + start_idx + self.lookback - 1)
+        x = torch.from_numpy(x).float()
+        y = torch.from_numpy(y).float()
+        return x, y
+

--- a/pyzoo/zoo/chronos/data/utils/utils.py
+++ b/pyzoo/zoo/chronos/data/utils/utils.py
@@ -38,3 +38,9 @@ def _check_col_no_na(df, col_name):
     _check_col_within(df, col_name)
     assert df[col_name].isna().sum() == 0, \
         f"{col_name} column should not have N/A."
+
+
+def _check_cols_no_na(df, col_names):
+    col_names = _to_list(col_names, name=None)
+    for col_name in col_names:
+        _check_col_no_na(df, col_name)


### PR DESCRIPTION
This PR implements a more convenient and memory-friendly API: `to_torch_loader` for the case of `TSDataset` rolling and convert to `PyTorch DataLoader`.
### **Before**

```python
tsdata.roll(lookback=320, horizon=40)
x, y = tsdata.to_numpy()
dataloader = DataLoader(TensorDataset(torch.from_numpy(x).float(), torch.from_numpy(y).float()),
                        batch_size=32,
                        shuffle=True)
```
The rolled numpy (x, y) must be hold in memory. 
However, the rolled numpy could be much time bigger than the original df. In baidu traffic dataset's case (lookback=96, horizon=16), the original df is ~6G and the output numpy is ~100G.
### **After**
```python
dataloader = tsdata.to_torch_loader(batch_size=32, roll=True, look_back=320, horizon=40)
```
We use customized torch `Dataset`, which is lazy, so it doesn't require much memory.

If user have already got a rolled tsdataset and only want to convert to `DataLoader`:
```python
dataloader = tsdata.to_torch_loader(batch_size=32, roll=False)
```