### PR TITLE
Revert "grpc pom fix to exclude scala2.11 only support 2.12(spark 3.0)"

### DIFF
--- a/zoo/pom.xml
+++ b/zoo/pom.xml
@@ -116,24 +116,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <source>1.8</source>
-                            <target>1.8</target>
-                            <excludes>
-                                <exclude>**/com/intel/analytics/zoo/grpc/**</exclude>
-                            </excludes>
-                        </configuration>
-                    </plugin>
-                    <plugin>
                         <groupId>net.alchim31.maven</groupId>
                         <artifactId>scala-maven-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <exclude>**/com/intel/analytics/zoo/grpc/**</exclude>
-                            </excludes>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>
@@ -512,7 +496,7 @@
         <dependency>
             <groupId>com.intel.analytics.zoo</groupId>
             <artifactId>${core.artifactId}</artifactId>
-            <version>0.10.0</version>
+            <version>0.12.0-SNAPSHOT</version>
             <type>${core.dependencyType}</type>
         </dependency>
         <dependency>
@@ -683,25 +667,22 @@
             <groupId>org.apache.tomcat</groupId>
             <artifactId>annotations-api</artifactId>
             <version>6.0.53</version>
-            <scope>${grpc.scope}</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
             <version>3.15.8</version>
-            <scope>${grpc.scope}</scope>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java-util</artifactId>
             <version>3.15.8</version>
-            <scope>${grpc.scope}</scope>
         </dependency>
         <dependency>
             <groupId>com.google.flatbuffers</groupId>
             <artifactId>flatbuffers-java</artifactId>
             <version>1.9.0</version>
-            <scope>${grpc.scope}</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Reverts intel-analytics/analytics-zoo#4410