### PR TITLE
Add union column support for generate string index

### DIFF
--- a/pyzoo/test/zoo/friesian/feature/test_table.py
+++ b/pyzoo/test/zoo/friesian/feature/test_table.py
@@ -226,6 +226,31 @@ class TestTable(TestCase):
         assert string_idx_list[0].size() == 3, "col_4 should have 3 indices"
         assert string_idx_list[1].size() == 2, "col_5 should have 2 indices"
 
+    def test_gen_string_idx_union(self):
+        file_path = os.path.join(self.resource_path, "friesian/feature/parquet/data1.parquet")
+        feature_tbl = FeatureTable.read_parquet(file_path)
+        string_idx_list1 = feature_tbl \
+            .gen_string_idx(["col_4", 'col_5'],
+                            freq_limit=1)
+        assert string_idx_list1[0].size() == 3, "col_4 should have 3 indices"
+        assert string_idx_list1[1].size() == 2, "col_5 should have 2 indices"
+        new_tbl1 = feature_tbl.encode_string(['col_4', 'col_5'], string_idx_list1)
+        assert new_tbl1.max("col_5").to_list("max")[0] == 2, "col_5 max value should be 2"
+
+        string_idx_list2 = feature_tbl \
+            .gen_string_idx(["col_4", {"src_cols": ["col_4", "col_5"], "col_name": 'col_5'}],
+                            freq_limit=1)
+        assert string_idx_list2[0].size() == 3, "col_4 should have 3 indices"
+        assert string_idx_list2[1].size() == 4, "col_5 should have 4 indices"
+        new_tbl2 = feature_tbl.encode_string(['col_4', 'col_5'], string_idx_list2)
+        assert new_tbl2.max("col_5").to_list("max")[0] == 4, "col_5 max value should be 4"
+
+        string_idx_3 = feature_tbl \
+            .gen_string_idx({"src_cols": ["col_4", "col_5"], "col_name": 'col_5'}, freq_limit=1)
+        assert string_idx_3.size() == 4, "col_5 should have 4 indices"
+        new_tbl3 = feature_tbl.encode_string('col_5', string_idx_3)
+        assert new_tbl3.max("col_5").to_list("max")[0] == 4, "col_5 max value should be 4"
+
     def test_clip(self):
         file_path = os.path.join(self.resource_path, "friesian/feature/parquet/data1.parquet")
         feature_tbl = FeatureTable.read_parquet(file_path)

--- a/pyzoo/zoo/friesian/feature/table.py
+++ b/pyzoo/zoo/friesian/feature/table.py
@@ -700,7 +700,7 @@ class FeatureTable(Table):
         """
         return cls(Table._read_csv(paths, delimiter, header, names, dtype))
 
-    def encode_string(self, columns, indices):
+    def encode_string(self, columns, indices, broadcast=True):
         """
         Encode columns with provided list of StringIndex.
 
@@ -727,7 +727,8 @@ class FeatureTable(Table):
         for i in range(len(columns)):
             index_tbl = indices[i]
             col_name = columns[i]
-            index_tbl.broadcast()
+            if broadcast:
+                index_tbl.broadcast()
             data_df = data_df.join(index_tbl.df, col_name, how="left") \
                 .drop(col_name).withColumnRenamed("id", col_name)
         return FeatureTable(data_df)

--- a/pyzoo/zoo/friesian/feature/table.py
+++ b/pyzoo/zoo/friesian/feature/table.py
@@ -917,7 +917,8 @@ class FeatureTable(Table):
 
         :param columns: str, dict or a list of str, dict, target column(s) to generate StringIndex.
          dict is a mapping of source column names -> target column name if needs to combine multiple
-         source columns to generate index. For example: {'src_cols':['a_user', 'b_user'], 'col_name':'user'}.
+         source columns to generate index.
+         For example: {'src_cols':['a_user', 'b_user'], 'col_name':'user'}.
         :param freq_limit: int, dict or None. Categories with a count/frequency below freq_limit
                will be omitted from the encoding. Can be represented as either an integer,
                dict. For instance, 15, {'col_4': 10, 'col_5': 2} etc. Default is None,
@@ -975,14 +976,16 @@ class FeatureTable(Table):
                         dict_df = self.df.select(F.col(src_c).alias(col_name))
                     else:
                         dict_df = dict_df.union(self.df.select(F.col(src_c).alias(col_name)))
-                union_id_list = generate_string_idx(dict_df, [col_name], freq_limit, order_by_freq)
+                union_id_list = generate_string_idx(dict_df, [col_name],
+                                                    freq_limit, order_by_freq)
                 df_id_list.extend(union_id_list)
                 out_columns.append(col_name)
             else:
                 simple_columns.append(c)
                 out_columns.append(c)
         if simple_columns:
-            simple_df_id_list = generate_string_idx(self.df, simple_columns, freq_limit, order_by_freq)
+            simple_df_id_list = generate_string_idx(self.df, simple_columns,
+                                                    freq_limit, order_by_freq)
             df_id_list.extend(simple_df_id_list)
 
         string_idx_list = list(map(lambda x: StringIndex(x[0], x[1]),

--- a/pyzoo/zoo/friesian/feature/table.py
+++ b/pyzoo/zoo/friesian/feature/table.py
@@ -914,7 +914,9 @@ class FeatureTable(Table):
         Generate unique index value of categorical features. The resulting index would
         start from 1 with 0 reserved for unknown features.
 
-        :param columns: str or a list of str, target columns to generate StringIndex.
+        :param columns: str, dict or a list of str, dict, target column(s) to generate StringIndex.
+         dict is a mapping of source column names -> target column name if needs to combine multiple
+         source columns to generate index. For example: {'src_cols':['a_user', 'b_user'], 'col_name':'user'}.
         :param freq_limit: int, dict or None. Categories with a count/frequency below freq_limit
                will be omitted from the encoding. Can be represented as either an integer,
                dict. For instance, 15, {'col_4': 10, 'col_5': 2} etc. Default is None,
@@ -927,11 +929,18 @@ class FeatureTable(Table):
         """
         if columns is None:
             raise ValueError("columns should be str or a list of str, but got None.")
-        columns_is_str = False
+        is_single_column = False
         if not isinstance(columns, list):
-            columns_is_str = True
+            is_single_column = True
             columns = [columns]
-        check_col_exists(self.df, columns)
+        src_columns = []
+        for c in columns:
+            if isinstance(c, dict):
+                if 'src_cols' in c:
+                    src_columns.extend(c['src_cols'])
+            else:
+                src_columns.append(c)
+        check_col_exists(self.df, src_columns)
         if freq_limit:
             if isinstance(freq_limit, int):
                 freq_limit = str(freq_limit)
@@ -940,11 +949,46 @@ class FeatureTable(Table):
             else:
                 raise ValueError("freq_limit only supports int, dict or None, but get " +
                                  freq_limit.__class__.__name__)
-        df_id_list = generate_string_idx(self.df, columns, freq_limit, order_by_freq)
+        out_columns = []
+        simple_columns = []
+        df_id_list = []
+        for c in columns:
+            if isinstance(c, dict):
+                if 'src_cols' in c:
+                    src_cols = c['src_cols']
+                else:
+                    raise ValueError("Union columns must has argument 'src_cols'")
+                if 'col_name' in c:
+                    col_name = c['col_name']
+                else:
+                    col_name = src_cols[0] + '_union'
+                # process simple columns
+                if simple_columns:
+                    simple_df_id_list = generate_string_idx(self.df, simple_columns,
+                                                            freq_limit, order_by_freq)
+                    df_id_list.extend(simple_df_id_list)
+                    simple_columns = []
+                # process union columns
+                for i, src_c in enumerate(src_cols):
+                    if i == 0:
+                        dict_df = self.df.select(F.col(src_c).alias(col_name))
+                    else:
+                        dict_df = dict_df.union(self.df.select(F.col(src_c).alias(col_name)))
+                union_id_list = generate_string_idx(dict_df, [col_name], freq_limit, order_by_freq)
+                df_id_list.extend(union_id_list)
+                out_columns.append(col_name)
+            else:
+                simple_columns.append(c)
+                out_columns.append(c)
+        if simple_columns:
+            simple_df_id_list = generate_string_idx(self.df, simple_columns, freq_limit, order_by_freq)
+            df_id_list.extend(simple_df_id_list)
+
         string_idx_list = list(map(lambda x: StringIndex(x[0], x[1]),
-                                   zip(df_id_list, columns)))
+                                   zip(df_id_list, out_columns)))
+
         # If input is a single column (not a list), then the output would be a single StringIndex.
-        if len(string_idx_list) == 1 and columns_is_str:
+        if len(string_idx_list) == 1 and is_single_column:
             return string_idx_list[0]
         else:
             return string_idx_list


### PR DESCRIPTION
Add union column support for generate string index.
The column input for generate string index can include {'src_cols": [xx, yy], 'col_name': zz}