### PR TITLE
Chronos: forecaster onnx sess thread limit and other settings

### DIFF
--- a/pyzoo/test/zoo/chronos/model/forecast/test_lstm_forecaster.py
+++ b/pyzoo/test/zoo/chronos/model/forecast/test_lstm_forecaster.py
@@ -84,7 +84,11 @@ class TestChronosModelLSTMForecaster(TestCase):
             mse_onnx = forecaster.evaluate_with_onnx(test_data,
                                                      multioutput="raw_values")
             np.testing.assert_almost_equal(mse, mse_onnx, decimal=5)
-            forecaster.build_onnx(thread_num=1)
+            with pytest.raises(RuntimeError):
+                forecaster.build_onnx(sess_options=1)
+            sess_options = onnxruntime.SessionOptions()
+            sess_options.intra_op_num_threads = 1
+            forecaster.build_onnx(sess_options=sess_options)
             mse = forecaster.evaluate(test_data)
             mse_onnx = forecaster.evaluate_with_onnx(test_data)
             np.testing.assert_almost_equal(mse, mse_onnx, decimal=5)

--- a/pyzoo/test/zoo/chronos/model/forecast/test_lstm_forecaster.py
+++ b/pyzoo/test/zoo/chronos/model/forecast/test_lstm_forecaster.py
@@ -84,6 +84,7 @@ class TestChronosModelLSTMForecaster(TestCase):
             mse_onnx = forecaster.evaluate_with_onnx(test_data,
                                                      multioutput="raw_values")
             np.testing.assert_almost_equal(mse, mse_onnx, decimal=5)
+            forecaster.build_onnx(thread_num=1)
             mse = forecaster.evaluate(test_data)
             mse_onnx = forecaster.evaluate_with_onnx(test_data)
             np.testing.assert_almost_equal(mse, mse_onnx, decimal=5)

--- a/pyzoo/test/zoo/chronos/model/forecast/test_seq2seq_forecaster.py
+++ b/pyzoo/test/zoo/chronos/model/forecast/test_seq2seq_forecaster.py
@@ -86,6 +86,7 @@ class TestChronosModelTCNForecaster(TestCase):
             mse_onnx = forecaster.evaluate_with_onnx(test_data,
                                                      multioutput="raw_values")
             np.testing.assert_almost_equal(mse, mse_onnx, decimal=5)
+            forecaster.build_onnx(thread_num=1)
             mse = forecaster.evaluate(test_data)
             mse_onnx = forecaster.evaluate_with_onnx(test_data)
             np.testing.assert_almost_equal(mse, mse_onnx, decimal=5)

--- a/pyzoo/test/zoo/chronos/model/forecast/test_seq2seq_forecaster.py
+++ b/pyzoo/test/zoo/chronos/model/forecast/test_seq2seq_forecaster.py
@@ -86,6 +86,8 @@ class TestChronosModelTCNForecaster(TestCase):
             mse_onnx = forecaster.evaluate_with_onnx(test_data,
                                                      multioutput="raw_values")
             np.testing.assert_almost_equal(mse, mse_onnx, decimal=5)
+            with pytest.raises(RuntimeError):
+                forecaster.build_onnx(sess_options=1)
             forecaster.build_onnx(thread_num=1)
             mse = forecaster.evaluate(test_data)
             mse_onnx = forecaster.evaluate_with_onnx(test_data)

--- a/pyzoo/test/zoo/chronos/model/forecast/test_tcn_forecaster.py
+++ b/pyzoo/test/zoo/chronos/model/forecast/test_tcn_forecaster.py
@@ -89,6 +89,8 @@ class TestChronosModelTCNForecaster(TestCase):
             mse_onnx = forecaster.evaluate_with_onnx(test_data,
                                                      multioutput="raw_values")
             np.testing.assert_almost_equal(mse, mse_onnx, decimal=5)
+            with pytest.raises(RuntimeError):
+                forecaster.build_onnx(sess_options=1)
             forecaster.build_onnx(thread_num=1)
             mse = forecaster.evaluate(test_data)
             mse_onnx = forecaster.evaluate_with_onnx(test_data)

--- a/pyzoo/test/zoo/chronos/model/forecast/test_tcn_forecaster.py
+++ b/pyzoo/test/zoo/chronos/model/forecast/test_tcn_forecaster.py
@@ -89,6 +89,7 @@ class TestChronosModelTCNForecaster(TestCase):
             mse_onnx = forecaster.evaluate_with_onnx(test_data,
                                                      multioutput="raw_values")
             np.testing.assert_almost_equal(mse, mse_onnx, decimal=5)
+            forecaster.build_onnx(thread_num=1)
             mse = forecaster.evaluate(test_data)
             mse_onnx = forecaster.evaluate_with_onnx(test_data)
             np.testing.assert_almost_equal(mse, mse_onnx, decimal=5)

--- a/pyzoo/zoo/automl/model/base_pytorch_model.py
+++ b/pyzoo/zoo/automl/model/base_pytorch_model.py
@@ -320,7 +320,7 @@ class PytorchBaseModel(BaseModel):
                        for m in metrics]
         return eval_result
 
-    def _build_onnx(self, x, dirname=None, thread_num=None):
+    def _build_onnx(self, x, dirname=None, thread_num=None, sess_options=None):
         if not self.model_built:
             raise RuntimeError("You must call fit_eval or restore\
                                first before calling onnx methods!")
@@ -345,9 +345,10 @@ class PytorchBaseModel(BaseModel):
                                         'output': {0: 'batch_size'}})
         self.onnx_model = onnx.load(os.path.join(dirname, "cache.onnx"))
         onnx.checker.check_model(self.onnx_model)
-        sess_options = onnxruntime.SessionOptions()
-        if thread_num is not None:
-            sess_options.intra_op_num_threads = thread_num
+        if sess_options is None:
+            sess_options = onnxruntime.SessionOptions()
+            if thread_num is not None:
+                sess_options.intra_op_num_threads = thread_num
         self.ort_session = onnxruntime.InferenceSession(os.path.join(dirname, "cache.onnx"),
                                                         sess_options=sess_options)
         self.onnx_model_built = True

--- a/pyzoo/zoo/automl/model/base_pytorch_model.py
+++ b/pyzoo/zoo/automl/model/base_pytorch_model.py
@@ -320,7 +320,7 @@ class PytorchBaseModel(BaseModel):
                        for m in metrics]
         return eval_result
 
-    def _build_onnx(self, x, dirname=None):
+    def _build_onnx(self, x, dirname=None, thread_num=None):
         if not self.model_built:
             raise RuntimeError("You must call fit_eval or restore\
                                first before calling onnx methods!")
@@ -345,7 +345,11 @@ class PytorchBaseModel(BaseModel):
                                         'output': {0: 'batch_size'}})
         self.onnx_model = onnx.load(os.path.join(dirname, "cache.onnx"))
         onnx.checker.check_model(self.onnx_model)
-        self.ort_session = onnxruntime.InferenceSession(os.path.join(dirname, "cache.onnx"))
+        sess_options = onnxruntime.SessionOptions()
+        if thread_num is not None:
+            sess_options.intra_op_num_threads = thread_num
+        self.ort_session = onnxruntime.InferenceSession(os.path.join(dirname, "cache.onnx"),
+                                                        sess_options=sess_options)
         self.onnx_model_built = True
 
     def predict_with_onnx(self, x, mc=False, dirname=None, batch_size=32):

--- a/pyzoo/zoo/chronos/model/forecast/base_forecaster.py
+++ b/pyzoo/zoo/chronos/model/forecast/base_forecaster.py
@@ -147,6 +147,9 @@ class BasePytorchForecaster(Forecaster):
         Predict using a trained forecaster with onnxruntime. The method can only be
         used when forecaster is a non-distributed version.
 
+        Directly call this method without calling build_onnx is valid and Forecaster will
+        automatically build an onnxruntime session with default settings.
+
         :param data: The data support following formats:
 
                | 1. a numpy ndarray x:
@@ -229,6 +232,9 @@ class BasePytorchForecaster(Forecaster):
         """
         Evaluate using a trained forecaster with onnxruntime. The method can only be
         used when forecaster is a non-distributed version.
+
+        Directly call this method without calling build_onnx is valid and Forecaster will
+        automatically build an onnxruntime session with default settings.
 
         Please note that evaluate result is calculated by scaled y and yhat. If you scaled
         your data (e.g. use .scale() on the TSDataset) please follow the following code
@@ -338,7 +344,7 @@ class BasePytorchForecaster(Forecaster):
         else:
             return self.internal.model
 
-    def build_onnx(self, thread_num=None):
+    def build_onnx(self, thread_num=None, sess_options=None):
         '''
         Build onnx model to speed up inference and reduce latency.
         The method is Not required to call before predict_with_onnx,
@@ -351,6 +357,9 @@ class BasePytorchForecaster(Forecaster):
 
         :param thread_num: int, the num of thread limit. The value is set to None by
                default where no limit is set.
+        :param sess_options: an onnxruntime.SessionOptions instance, if you set this
+               other than None, a new onnxruntime session will be built on this setting
+               and ignore other settings you assigned(e.g. thread_num...).
 
         Example:
             >>> # to pre build onnx sess
@@ -360,6 +369,10 @@ class BasePytorchForecaster(Forecaster):
             >>> # directly call onnx related method is also supported
             >>> pred = forecaster.predict_with_onnx(data)
         '''
+        import onnxruntime
+        if sess_options is not None and not isinstance(sess_options, onnxruntime.SessionOptions):
+            raise RuntimeError("sess_options should be an onnxruntime.SessionOptions instance"
+                               f", but f{type(sess_options)}")
         if self.distributed:
             raise NotImplementedError("build_onnx has not been supported for distributed\
                                        forecaster. You can call .to_local() to transform the\
@@ -367,7 +380,10 @@ class BasePytorchForecaster(Forecaster):
         import torch
         dummy_input = torch.rand(1, self.data_config["past_seq_len"],
                                  self.data_config["input_feature_num"])
-        self.internal._build_onnx(dummy_input, dirname=None, thread_num=thread_num)
+        self.internal._build_onnx(dummy_input,
+                                  dirname=None,
+                                  thread_num=thread_num,
+                                  sess_options=None)
 
     def export_onnx_file(self, dirname):
         """

--- a/pyzoo/zoo/chronos/model/forecast/base_forecaster.py
+++ b/pyzoo/zoo/chronos/model/forecast/base_forecaster.py
@@ -351,6 +351,14 @@ class BasePytorchForecaster(Forecaster):
 
         :param thread_num: int, the num of thread limit. The value is set to None by
                default where no limit is set.
+
+        Example:
+            >>> # to pre build onnx sess
+            >>> forecaster.build_onnx(thread_num=1)  # build onnx runtime sess for single thread
+            >>> pred = forecaster.predict_with_onnx(data)
+            >>> # ------------------------------------------------------
+            >>> # directly call onnx related method is also supported
+            >>> pred = forecaster.predict_with_onnx(data)
         '''
         if self.distributed:
             raise NotImplementedError("build_onnx has not been supported for distributed\


### PR DESCRIPTION
Still finding if we need to add more settings to this method.
effectiveness validation is also on-going

api doc: https://junweitestdoc.readthedocs.io/en/onnx-improvements-threads/doc/PythonAPI/Chronos/forecasters.html#zoo.chronos.model.forecast.base_forecaster.BasePytorchForecaster.build_onnx