### PR TITLE
Add ray daemon to kill ray processes

### DIFF
--- a/pyzoo/zoo/ray/process.py
+++ b/pyzoo/zoo/ray/process.py
@@ -16,11 +16,7 @@
 
 import os
 import subprocess
-import signal
-import atexit
-import sys
-
-from zoo.ray.utils import gen_shutdown_per_node, is_local
+from zoo.ray.utils import is_local
 
 
 class ProcessInfo(object):

--- a/pyzoo/zoo/ray/process.py
+++ b/pyzoo/zoo/ray/process.py
@@ -130,9 +130,7 @@ class ProcessMonitor:
         ray.shutdown()
         if not self.sc:
             print("WARNING: SparkContext has been stopped before cleaning the Ray resources")
-        if self.sc and (not is_local(self.sc)):
-            self.ray_rdd.map(gen_shutdown_per_node(self.pgids, self.node_ips)).collect()
-        else:
+        if not self.sc or is_local(self.sc):
             gen_shutdown_per_node(self.pgids, self.node_ips)([])
 
     @staticmethod

--- a/pyzoo/zoo/ray/ray_daemon.py
+++ b/pyzoo/zoo/ray/ray_daemon.py
@@ -1,0 +1,30 @@
+import os
+import sys
+import signal
+import psutil
+import logging
+logging.basicConfig(filename='daemon.log', level=logging.INFO)
+
+def is_jvm_alive(spark_executor_pid):
+    return psutil.pid_exists(spark_executor_pid)
+
+
+def stop_ray(pgid):
+    logging.info(f"Stopping pgid {pgid} by ray_daemon.")
+    try:
+        os.killpg(pgid, signal.SIGKILL)
+    except Exception:
+        logging.error("WARNING: cannot kill pgid: {}".format(pgid))
+
+
+def manager():
+    pgid = int(sys.argv[1])
+    spark_executor_pid = int(sys.argv[2])
+    import time
+    while is_jvm_alive(spark_executor_pid):
+        time.sleep(1)
+    stop_ray(pgid)
+
+
+if __name__ == "__main__":
+    manager()

--- a/pyzoo/zoo/ray/ray_daemon.py
+++ b/pyzoo/zoo/ray/ray_daemon.py
@@ -6,25 +6,21 @@ import logging
 logging.basicConfig(filename='daemon.log', level=logging.INFO)
 
 
-def is_jvm_alive(spark_executor_pid):
-    return psutil.pid_exists(spark_executor_pid)
-
-
-def stop_ray(pgid):
+def stop(pgid):
     logging.info(f"Stopping pgid {pgid} by ray_daemon.")
     try:
         os.killpg(pgid, signal.SIGKILL)
     except Exception:
-        logging.error("WARNING: cannot kill pgid: {}".format(pgid))
+        logging.error("Cannot kill pgid: {}".format(pgid))
 
 
 def manager():
-    pgid = int(sys.argv[1])
-    spark_executor_pid = int(sys.argv[2])
+    pid_to_watch = int(sys.argv[1])
+    pgid_to_kill = int(sys.argv[2])
     import time
-    while is_jvm_alive(spark_executor_pid):
+    while psutil.pid_exists(pid_to_watch):
         time.sleep(1)
-    stop_ray(pgid)
+    stop(pgid_to_kill)
 
 
 if __name__ == "__main__":

--- a/pyzoo/zoo/ray/ray_daemon.py
+++ b/pyzoo/zoo/ray/ray_daemon.py
@@ -5,6 +5,7 @@ import psutil
 import logging
 logging.basicConfig(filename='daemon.log', level=logging.INFO)
 
+
 def is_jvm_alive(spark_executor_pid):
     return psutil.pid_exists(spark_executor_pid)
 

--- a/pyzoo/zoo/ray/ray_daemon.py
+++ b/pyzoo/zoo/ray/ray_daemon.py
@@ -9,6 +9,7 @@ logging.basicConfig(filename='daemon.log', level=logging.INFO)
 def stop(pgid):
     logging.info(f"Stopping pgid {pgid} by ray_daemon.")
     try:
+        # SIGTERM may not kill all the children processes in the group.
         os.killpg(pgid, signal.SIGKILL)
     except Exception:
         logging.error("Cannot kill pgid: {}".format(pgid))

--- a/pyzoo/zoo/ray/ray_daemon.py
+++ b/pyzoo/zoo/ray/ray_daemon.py
@@ -1,3 +1,19 @@
+#
+# Copyright 2018 Analytics Zoo Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import os
 import sys
 import signal

--- a/pyzoo/zoo/ray/raycontext.py
+++ b/pyzoo/zoo/ray/raycontext.py
@@ -193,8 +193,8 @@ class RayServiceFuncGenerator(object):
     @staticmethod
     def start_ray_daemon(python_loc, pid_to_watch, pgid_to_kill):
         daemon_path = os.path.join(os.path.dirname(__file__), "ray_daemon.py")
-        start_daemon_command = ['nohup', python_loc, daemon_path,
-                                str(pgid_to_kill), str(pid_to_watch)]
+        start_daemon_command = ['nohup', python_loc, daemon_path, str(pid_to_watch),
+                                str(pgid_to_kill)]
         subprocess.Popen(start_daemon_command, preexec_fn=os.setpgrp)
         time.sleep(1)
 

--- a/pyzoo/zoo/ray/raycontext.py
+++ b/pyzoo/zoo/ray/raycontext.py
@@ -475,11 +475,6 @@ class RayContext(object):
             return
         import ray
         ray.shutdown()
-        if not self.is_local:
-            if not self.ray_processesMonitor:
-                print("Please start the runner first before closing it")
-            else:
-                self.ray_processesMonitor.clean_fn()
         self.initialized = False
 
     def purge(self):
@@ -610,7 +605,6 @@ class RayContext(object):
         RayServiceFuncGenerator.start_ray_daemon("python",
                                                  pid_to_watch=os.getpid(),
                                                  pgid_to_kill=process_info.pgid)
-        # ProcessMonitor.register_shutdown_hook(pgid=process_info.pgid)
 
     def _start_driver(self, num_cores, redis_address):
         print("Start to launch ray driver on local")

--- a/pyzoo/zoo/ray/raycontext.py
+++ b/pyzoo/zoo/ray/raycontext.py
@@ -195,6 +195,7 @@ class RayServiceFuncGenerator(object):
         daemon_path = os.path.join(os.path.dirname(__file__), "ray_daemon.py")
         start_daemon_command = ['nohup', python_loc, daemon_path, str(pid_to_watch),
                                 str(pgid_to_kill)]
+        # put ray daemon process in its children's process group to avoid being killed by spark.
         subprocess.Popen(start_daemon_command, preexec_fn=os.setpgrp)
         time.sleep(1)
 

--- a/pyzoo/zoo/ray/raycontext.py
+++ b/pyzoo/zoo/ray/raycontext.py
@@ -541,9 +541,6 @@ class RayContext(object):
                 self._address_info = ray.init(**init_params)
             else:
                 self.cluster_ips = self._gather_cluster_ips()
-                from bigdl.util.common import init_executor_gateway
-                init_executor_gateway(self.sc)
-                print("JavaGatewayServer has been successfully launched on executors")
                 redis_address = self._start_cluster()
                 self._address_info = self._start_driver(num_cores=driver_cores,
                                                         redis_address=redis_address)

--- a/pyzoo/zoo/ray/utils.py
+++ b/pyzoo/zoo/ray/utils.py
@@ -68,7 +68,8 @@ def gen_shutdown_per_node(pgids, node_ips=None):
         for pgid in effect_pgids:
             print("Stopping by pgid {}".format(pgid))
             try:
-                os.killpg(pgid, signal.SIGTERM)
+                # SIGTERM may not kill all the children processes in the group.
+                os.killpg(pgid, signal.SIGKILL)
             except Exception:
                 print("WARNING: cannot kill pgid: {}".format(pgid))
 
@@ -78,3 +79,8 @@ def gen_shutdown_per_node(pgids, node_ips=None):
 def is_local(sc):
     master = sc.getConf().get("spark.master")
     return master == "local" or master.startswith("local[")
+
+
+def get_parent_pid(pid):
+    cur_proc = psutil.Process(pid)
+    return cur_proc.ppid()

--- a/pyzoo/zoo/ray/utils.py
+++ b/pyzoo/zoo/ray/utils.py
@@ -15,8 +15,6 @@
 #
 
 import re
-import os
-import signal
 import psutil
 
 
@@ -53,28 +51,6 @@ def resource_to_bytes(resource_str):
         raise Exception("Size must be specified as bytes(b),"
                         "kilobytes(k), megabytes(m), gigabytes(g). "
                         "E.g. 50b, 100k, 250m, 30g")
-
-
-def gen_shutdown_per_node(pgids, node_ips=None):
-    import ray._private.services as rservices
-    pgids = to_list(pgids)
-
-    def _shutdown_per_node(iter):
-        print("Stopping pgids: {}".format(pgids))
-        if node_ips:
-            current_node_ip = rservices.get_node_ip_address()
-            effect_pgids = [pair[0] for pair in zip(pgids, node_ips) if pair[1] == current_node_ip]
-        else:
-            effect_pgids = pgids
-        for pgid in effect_pgids:
-            print("Stopping by pgid {}".format(pgid))
-            try:
-                # SIGTERM may not kill all the children processes in the group.
-                os.killpg(pgid, signal.SIGKILL)
-            except Exception:
-                print("WARNING: cannot kill pgid: {}".format(pgid))
-
-    return _shutdown_per_node
 
 
 def is_local(sc):

--- a/pyzoo/zoo/ray/utils.py
+++ b/pyzoo/zoo/ray/utils.py
@@ -17,6 +17,7 @@
 import re
 import os
 import signal
+import psutil
 
 
 def to_list(input):


### PR DESCRIPTION
## What is this PR for? 
While running `RayOnSpark` in cluster, if the spark executor is killed abruptly (e.g. killed by yarn due to memory-deficiency), the ray processes will keep running until meet further error (e.g "No module named zoo"). However, the ray processes should be killed immediately if the spark executor died. 

## Related issue
#4425 

## What does this PR include? 

1. This PR added a ray daemon to watch spark executor and kill ray processes after the spark executor is died.
2. This PR removes `shutdown_hook` and `clean_fn` in `ProcessMonitor` which are also for killing ray processes. And the functions don't work at all circumstances, such as `core_dump`.

## How is this PR tested? 
This PR has only been tested on **Linux**.
In both "standalone" mode and "yarn-client" mode:

- [x] exit normally
- [x] exit with errors which occur at different stages
- [x] interrupted with Ctrl + C 
- [x] kill -9 spark executor
- [x] kill -9 driver

In "yarn-client" mode, "core dump" after ray initialized has also been tested.

## Remained issue
1. Application keeps running after one spark executor is killed abruptly, since the processes on other nodes are not influenced. 
2. Test on MAC/Win
3. Better debug log for `ray_daemon`

