### PR TITLE
Bigdl nano: Makes torch function replacement a plugin-like operation

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/accelerators/__init__.py
+++ b/python/nano/src/bigdl/nano/pytorch/accelerators/__init__.py
@@ -68,3 +68,6 @@ def nano_save(obj, f, pickle_module=pickle, pickle_protocol=DEFAULT_PROTOCOL,
 
 
 torch.save = nano_save
+
+from .ipex_torchfunctional import apply_torch_functional_replacement
+apply_torch_functional_replacement()

--- a/python/nano/src/bigdl/nano/pytorch/accelerators/__init__.py
+++ b/python/nano/src/bigdl/nano/pytorch/accelerators/__init__.py
@@ -15,6 +15,7 @@
 #
 
 
+from .ipex_torchfunctional import apply_torch_functional_replacement
 from typing import Dict, List, Tuple
 import pickle
 import copy
@@ -69,5 +70,4 @@ def nano_save(obj, f, pickle_module=pickle, pickle_protocol=DEFAULT_PROTOCOL,
 
 torch.save = nano_save
 
-from .ipex_torchfunctional import apply_torch_functional_replacement
 apply_torch_functional_replacement()

--- a/python/nano/src/bigdl/nano/pytorch/accelerators/ipex_torchfunctional.py
+++ b/python/nano/src/bigdl/nano/pytorch/accelerators/ipex_torchfunctional.py
@@ -1,3 +1,55 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# 
+# workaround_cross_entropy is adapted from 
+# 
+# https://github.com/pytorch/pytorch/blob/c7c711bfb88fcb0ef573125a5a8655c49156055b
+# /torch/nn/functional.py#L2767
+# 
+# Note: This license has also been called the "New BSD License" or "Modified BSD License". See also
+# the 2-clause BSD License.
+#
+# Copyright (c) 2019 The DeepGLO Project.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+# and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of
+# conditions and the following disclaimer in the documentation and/or other materials provided
+# with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to
+# endorse or promote products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+# AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+# OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+
 import torch
 from torch.overrides import has_torch_function_variadic, handle_torch_function
 from typing import Callable, Optional

--- a/python/nano/src/bigdl/nano/pytorch/accelerators/ipex_torchfunctional.py
+++ b/python/nano/src/bigdl/nano/pytorch/accelerators/ipex_torchfunctional.py
@@ -1,0 +1,89 @@
+import torch
+from torch.overrides import has_torch_function_variadic, handle_torch_function
+from typing import Callable, Optional
+
+Tensor = torch.Tensor
+torch_nn_functional = torch.nn.functional
+_Reduction = torch.nn._reduction
+
+
+def replace_torch_function(function_name: str, replace_func: Callable):
+    setattr(torch.nn.functional, function_name, replace_func)
+
+
+def workaround_cross_entropy(
+    input: Tensor,
+    target: Tensor,
+    weight: Optional[Tensor] = None,
+    size_average: Optional[bool] = None,
+    ignore_index: int = -100,
+    reduce: Optional[bool] = None,
+    reduction: str = "mean",
+) -> Tensor:
+    r"""This criterion combines `log_softmax` and `nll_loss` in a single
+    function.
+
+    See :class:`~torch.nn.CrossEntropyLoss` for details.
+
+    Args:
+        input (Tensor) : :math:`(N, C)` where `C = number of classes` or :math:`(N, C, H, W)`
+            in case of 2D Loss, or :math:`(N, C, d_1, d_2, ..., d_K)` where :math:`K \geq 1`
+            in the case of K-dimensional loss.
+        target (Tensor) : :math:`(N)` where each value is :math:`0 \leq \text{targets}[i] \leq C-1`,
+            or :math:`(N, d_1, d_2, ..., d_K)` where :math:`K \geq 1` for
+            K-dimensional loss.
+        weight (Tensor, optional): a manual rescaling weight given to each
+            class. If given, has to be a Tensor of size `C`
+        size_average (bool, optional): Deprecated (see :attr:`reduction`). By default,
+            the losses are averaged over each loss element in the batch. Note that for
+            some losses, there multiple elements per sample. If the field :attr:`size_average`
+            is set to ``False``, the losses are instead summed for each minibatch. Ignored
+            when reduce is ``False``. Default: ``True``
+        ignore_index (int, optional): Specifies a target value that is ignored
+            and does not contribute to the input gradient. When :attr:`size_average` is
+            ``True``, the loss is averaged over non-ignored targets. Default: -100
+        reduce (bool, optional): Deprecated (see :attr:`reduction`). By default, the
+            losses are averaged or summed over observations for each minibatch depending
+            on :attr:`size_average`. When :attr:`reduce` is ``False``, returns a loss per
+            batch element instead and ignores :attr:`size_average`. Default: ``True``
+        reduction (string, optional): Specifies the reduction to apply to the output:
+            ``'none'`` | ``'mean'`` | ``'sum'``. ``'none'``: no reduction will be applied,
+            ``'mean'``: the sum of the output will be divided by the number of
+            elements in the output, ``'sum'``: the output will be summed. Note: :attr:`size_average`
+            and :attr:`reduce` are in the process of being deprecated, and in the meantime,
+            specifying either of those two args will override :attr:`reduction`. Default: ``'mean'``
+
+    Examples::
+
+        >>> input = torch.randn(3, 5, requires_grad=True)
+        >>> target = torch.randint(5, (3,), dtype=torch.int64)
+        >>> loss = F.cross_entropy(input, target)
+        >>> loss.backward()
+    """
+    if has_torch_function_variadic(input, target):
+        return handle_torch_function(
+            workaround_cross_entropy,
+            (input, target),
+            input,
+            target,
+            weight=weight,
+            size_average=size_average,
+            ignore_index=ignore_index,
+            reduce=reduce,
+            reduction=reduction,
+        )
+    if size_average is not None or reduce is not None:
+        reduction = _Reduction.legacy_get_string(size_average, reduce)
+    return torch_nn_functional.nll_loss(torch_nn_functional.log_softmax(input, 1).contiguous(), target, weight, None, ignore_index, None, reduction)
+
+
+# Usage: append your target method and your own implements to  `replacement_dict`
+
+# Apply ops replacements here
+replacement_dict = {
+    "cross_entropy" : workaround_cross_entropy
+}
+
+def apply_torch_functional_replacement():
+    for k,v in replacement_dict.items():
+        replace_torch_function(k, v)

--- a/python/nano/src/bigdl/nano/pytorch/accelerators/ipex_torchfunctional.py
+++ b/python/nano/src/bigdl/nano/pytorch/accelerators/ipex_torchfunctional.py
@@ -20,46 +20,6 @@ def workaround_cross_entropy(
     reduce: Optional[bool] = None,
     reduction: str = "mean",
 ) -> Tensor:
-    r"""This criterion combines `log_softmax` and `nll_loss` in a single
-    function.
-
-    See :class:`~torch.nn.CrossEntropyLoss` for details.
-
-    Args:
-        input (Tensor) : :math:`(N, C)` where `C = number of classes` or :math:`(N, C, H, W)`
-            in case of 2D Loss, or :math:`(N, C, d_1, d_2, ..., d_K)` where :math:`K \geq 1`
-            in the case of K-dimensional loss.
-        target (Tensor) : :math:`(N)` where each value is :math:`0 \leq \text{targets}[i] \leq C-1`,
-            or :math:`(N, d_1, d_2, ..., d_K)` where :math:`K \geq 1` for
-            K-dimensional loss.
-        weight (Tensor, optional): a manual rescaling weight given to each
-            class. If given, has to be a Tensor of size `C`
-        size_average (bool, optional): Deprecated (see :attr:`reduction`). By default,
-            the losses are averaged over each loss element in the batch. Note that for
-            some losses, there multiple elements per sample. If the field :attr:`size_average`
-            is set to ``False``, the losses are instead summed for each minibatch. Ignored
-            when reduce is ``False``. Default: ``True``
-        ignore_index (int, optional): Specifies a target value that is ignored
-            and does not contribute to the input gradient. When :attr:`size_average` is
-            ``True``, the loss is averaged over non-ignored targets. Default: -100
-        reduce (bool, optional): Deprecated (see :attr:`reduction`). By default, the
-            losses are averaged or summed over observations for each minibatch depending
-            on :attr:`size_average`. When :attr:`reduce` is ``False``, returns a loss per
-            batch element instead and ignores :attr:`size_average`. Default: ``True``
-        reduction (string, optional): Specifies the reduction to apply to the output:
-            ``'none'`` | ``'mean'`` | ``'sum'``. ``'none'``: no reduction will be applied,
-            ``'mean'``: the sum of the output will be divided by the number of
-            elements in the output, ``'sum'``: the output will be summed. Note: :attr:`size_average`
-            and :attr:`reduce` are in the process of being deprecated, and in the meantime,
-            specifying either of those two args will override :attr:`reduction`. Default: ``'mean'``
-
-    Examples::
-
-        >>> input = torch.randn(3, 5, requires_grad=True)
-        >>> target = torch.randint(5, (3,), dtype=torch.int64)
-        >>> loss = F.cross_entropy(input, target)
-        >>> loss.backward()
-    """
     if has_torch_function_variadic(input, target):
         return handle_torch_function(
             workaround_cross_entropy,
@@ -74,16 +34,21 @@ def workaround_cross_entropy(
         )
     if size_average is not None or reduce is not None:
         reduction = _Reduction.legacy_get_string(size_average, reduce)
-    return torch_nn_functional.nll_loss(torch_nn_functional.log_softmax(input, 1).contiguous(), target, weight, None, ignore_index, None, reduction)
+
+    # `log_softmax(input, 1).contiguous()` makes multidimensional tensors continuous in memory
+    # May fix https://github.com/intel/intel-extension-for-pytorch/issues/175#issue-972312586
+    return torch_nn_functional.nll_loss(torch_nn_functional.log_softmax(input, 1).contiguous(),
+                                        target, weight, None, ignore_index, None, reduction)
 
 
 # Usage: append your target method and your own implements to  `replacement_dict`
 
 # Apply ops replacements here
 replacement_dict = {
-    "cross_entropy" : workaround_cross_entropy
+    "cross_entropy": workaround_cross_entropy
 }
 
+
 def apply_torch_functional_replacement():
-    for k,v in replacement_dict.items():
+    for k, v in replacement_dict.items():
         replace_torch_function(k, v)

--- a/python/nano/src/bigdl/nano/pytorch/accelerators/ipex_torchfunctional.py
+++ b/python/nano/src/bigdl/nano/pytorch/accelerators/ipex_torchfunctional.py
@@ -13,17 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 # 
-# workaround_cross_entropy is adapted from 
-# 
+# `workaround_cross_entropy` is adapted from pytorch team.
 # https://github.com/pytorch/pytorch/blob/c7c711bfb88fcb0ef573125a5a8655c49156055b
 # /torch/nn/functional.py#L2767
 # 
 # Note: This license has also been called the "New BSD License" or "Modified BSD License". See also
 # the 2-clause BSD License.
 #
-# Copyright (c) 2019 The DeepGLO Project.
+# Copyright (c) 2016 The Pytorch Project.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification, are permitted

--- a/python/nano/src/bigdl/nano/pytorch/accelerators/ipex_torchfunctional.py
+++ b/python/nano/src/bigdl/nano/pytorch/accelerators/ipex_torchfunctional.py
@@ -13,49 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# 
-# `workaround_cross_entropy` is adapted from pytorch team.
-# https://github.com/pytorch/pytorch/blob/c7c711bfb88fcb0ef573125a5a8655c49156055b
-# /torch/nn/functional.py#L2767
-# 
-# Note: This license has also been called the "New BSD License" or "Modified BSD License". See also
-# the 2-clause BSD License.
-#
-# Copyright (c) 2016 The Pytorch Project.
-# All rights reserved.
-#
-# Redistribution and use in source and binary forms, with or without modification, are permitted
-# provided that the following conditions are met:
-#
-# 1. Redistributions of source code must retain the above copyright notice, this list of conditions
-# and the following disclaimer.
-#
-# 2. Redistributions in binary form must reproduce the above copyright notice, this list of
-# conditions and the following disclaimer in the documentation and/or other materials provided
-# with the distribution.
-#
-# 3. Neither the name of the copyright holder nor the names of its contributors may be used to
-# endorse or promote products derived from this software without specific prior written permission.
-#
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
-# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
-# AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
-# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
-# OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
-# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-# POSSIBILITY OF SUCH DAMAGE.
 
 
 import torch
-from torch.overrides import has_torch_function_variadic, handle_torch_function
-from typing import Callable, Optional
+from torch.nn import functional as F
+from typing import Callable
 
 Tensor = torch.Tensor
-torch_nn_functional = torch.nn.functional
-_Reduction = torch.nn._reduction
-
+_cross_entropy = F.cross_entropy
 
 def replace_torch_function(function_name: str, replace_func: Callable):
     setattr(torch.nn.functional, function_name, replace_func)
@@ -64,31 +29,12 @@ def replace_torch_function(function_name: str, replace_func: Callable):
 def workaround_cross_entropy(
     input: Tensor,
     target: Tensor,
-    weight: Optional[Tensor] = None,
-    size_average: Optional[bool] = None,
-    ignore_index: int = -100,
-    reduce: Optional[bool] = None,
-    reduction: str = "mean",
+    *args,
+    **kwargs
 ) -> Tensor:
-    if has_torch_function_variadic(input, target):
-        return handle_torch_function(
-            workaround_cross_entropy,
-            (input, target),
-            input,
-            target,
-            weight=weight,
-            size_average=size_average,
-            ignore_index=ignore_index,
-            reduce=reduce,
-            reduction=reduction,
-        )
-    if size_average is not None or reduce is not None:
-        reduction = _Reduction.legacy_get_string(size_average, reduce)
-
-    # `log_softmax(input, 1).contiguous()` makes multidimensional tensors continuous in memory
-    # May fix https://github.com/intel/intel-extension-for-pytorch/issues/175#issue-972312586
-    return torch_nn_functional.nll_loss(torch_nn_functional.log_softmax(input, 1).contiguous(),
-                                        target, weight, None, ignore_index, None, reduction)
+    input = input.cpu()
+    target = target.cpu()
+    return _cross_entropy(input, target, *args, **kwargs)
 
 
 # Usage: append your target method and your own implements to  `replacement_dict`

--- a/python/nano/src/bigdl/nano/pytorch/accelerators/ipex_torchfunctional.py
+++ b/python/nano/src/bigdl/nano/pytorch/accelerators/ipex_torchfunctional.py
@@ -22,6 +22,7 @@ from typing import Callable
 Tensor = torch.Tensor
 _cross_entropy = F.cross_entropy
 
+
 def replace_torch_function(function_name: str, replace_func: Callable):
     setattr(torch.nn.functional, function_name, replace_func)
 


### PR DESCRIPTION
For the development of ipex is on going, there are some operations or functions we can not call directly [#4600](https://github.com/intel-analytics/analytics-zoo/pull/4600#discussion_r699773873).
This pr provides a way for us to apply any workaround as an alternative if it fixs the issue temporarily. The replacement takes place whenever ipex accelerator is imported, in another word `use_ipex` is specfied as true in Trainer, but it will not affect default behaviors.