### PR TITLE
Chronos: change logger to torch tensorboard interface from tensorboardx

### DIFF
--- a/pyzoo/test/zoo/automl/logger/test_tensorboardlogger.py
+++ b/pyzoo/test/zoo/automl/logger/test_tensorboardlogger.py
@@ -16,13 +16,13 @@
 import pytest
 
 from test.zoo.pipeline.utils.test_utils import ZooTestCase
-from zoo.automl.logger import TensorboardXLogger
+from zoo.automl.logger import TensorboardLogger
 import numpy as np
 import random
 import os.path
 
 
-class TestTensorboardXLogger(ZooTestCase):
+class TestTensorboardLogger(ZooTestCase):
 
     def setup_method(self, method):
         pass
@@ -30,7 +30,7 @@ class TestTensorboardXLogger(ZooTestCase):
     def teardown_method(self, method):
         pass
 
-    def test_tbxlogger_valid_type(self):
+    def test_tblogger_valid_type(self):
         trail_num = 100
         test_config = {}
         test_metric = {}
@@ -43,14 +43,14 @@ class TestTensorboardXLogger(ZooTestCase):
                 {"matrix_good": random.randint(0, 100)/100,
                  "matrix_unstable": np.nan if random.random() < 0.5 else 1,
                  "matrix_bad": np.nan}
-        logger = TensorboardXLogger(os.path.abspath(os.path.expanduser("~/test_tbxlogger")))
+        logger = TensorboardLogger(os.path.abspath(os.path.expanduser("~/test_tbxlogger")))
         logger.run(test_config, test_metric)
         logger.close()
 
-    def test_tbxlogger_keys(self):
+    def test_tblogger_keys(self):
         test_config = {"run1": {"lr": 0.01}}
         test_metric = {"run2": {"lr": 0.02}}
-        logger = TensorboardXLogger(os.path.abspath(os.path.expanduser("~/test_tbxlogger")))
+        logger = TensorboardLogger(os.path.abspath(os.path.expanduser("~/test_tbxlogger")))
         with pytest.raises(Exception):
             logger.run(test_config, test_metric)
         logger.close()

--- a/pyzoo/zoo/automl/logger/__init__.py
+++ b/pyzoo/zoo/automl/logger/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from .tensorboardxlogger import TensorboardXLogger
+from .tensorboardlogger import TensorboardLogger

--- a/pyzoo/zoo/automl/search/ray_tune_search_engine.py
+++ b/pyzoo/zoo/automl/search/ray_tune_search_engine.py
@@ -22,7 +22,7 @@ from zoo.automl.search.base import SearchEngine, TrialOutput, GoodError
 from zoo.automl.common.util import get_ckpt_hdfs, put_ckpt_hdfs, convert_bayes_configs
 from zoo.automl.common.parameters import DEFAULT_LOGGER_NAME, DEFAULT_METRIC_NAME
 from ray.tune import Stopper
-from zoo.automl.logger import TensorboardXLogger
+from zoo.automl.logger import TensorboardLogger
 from zoo.automl.model.abstract import ModelBuilder
 
 
@@ -174,11 +174,11 @@ class RayTuneSearchEngine(SearchEngine):
 
         # Visualization code for ray (leaderboard)
         logger_name = self.name if self.name else DEFAULT_LOGGER_NAME
-        tf_config, tf_metric = TensorboardXLogger._ray_tune_searcher_log_adapt(analysis)
+        tf_config, tf_metric = TensorboardLogger._ray_tune_searcher_log_adapt(analysis)
 
-        self.logger = TensorboardXLogger(logs_dir=os.path.join(self.logs_dir,
+        self.logger = TensorboardLogger(logs_dir=os.path.join(self.logs_dir,
                                                                logger_name+"_leaderboard"),
-                                         name=logger_name)
+                                        name=logger_name)
         self.logger.run(tf_config, tf_metric)
         self.logger.close()
 

--- a/pyzoo/zoo/automl/search/ray_tune_search_engine.py
+++ b/pyzoo/zoo/automl/search/ray_tune_search_engine.py
@@ -177,7 +177,7 @@ class RayTuneSearchEngine(SearchEngine):
         tf_config, tf_metric = TensorboardLogger._ray_tune_searcher_log_adapt(analysis)
 
         self.logger = TensorboardLogger(logs_dir=os.path.join(self.logs_dir,
-                                                               logger_name+"_leaderboard"),
+                                                              logger_name+"_leaderboard"),
                                         name=logger_name)
         self.logger.run(tf_config, tf_metric)
         self.logger.close()


### PR DESCRIPTION
This can solve the OLD & critical sort malfunction in Tensorboard #3426

- `torch.utils.tensorboard` is more stable than `tensorboardx`
- they have nearly the same interface