### PR TITLE
Add pip wheel support of Turbojpeg

### DIFF
--- a/python/nano/recipe/build.sh
+++ b/python/nano/recipe/build.sh
@@ -8,4 +8,4 @@ do
     cp "${RECIPE_DIR}/${CHANGE}.sh" "${PREFIX}/etc/conda/${CHANGE}.d/${PKG_NAME}_${CHANGE}.sh"
 done
 
-python $SRC_DIR/setup.py install --single-version-externally-managed --record=record.txt --no-deps
+pip install $SRC_DIR --no-deps

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -46,16 +46,16 @@ def get_nano_packages():
     return nano_packages
 
 
-def download_libs():
-    url = "https://github.com/yangw1234/jemalloc/releases/download/v5.2.1-binary/libjemalloc.so"
+def download_libs(url: str):
     libs_dir = os.path.join(nano_home, "bigdl", "nano", "libs")
     if not os.path.exists(libs_dir):
         os.mkdir(libs_dir)
-    jemalloc_file = os.path.join(libs_dir, "libjemalloc.so")
-    if not os.path.exists(jemalloc_file):
-        urllib.request.urlretrieve(url, jemalloc_file)
-    st = os.stat(jemalloc_file)
-    os.chmod(jemalloc_file, st.st_mode | stat.S_IEXEC)
+    libso_file_name = url.split('/')[-1]
+    libso_file = os.path.join(libs_dir, libso_file_name)
+    if not os.path.exists(libso_file):
+        urllib.request.urlretrieve(url, libso_file)
+    st = os.stat(libso_file)
+    os.chmod(libso_file, st.st_mode | stat.S_IEXEC)
 
 
 class URLHtmlParser(HTMLParser):
@@ -99,7 +99,8 @@ def setup_package():
     ipex_link = f"https://intel-optimized-pytorch.s3.cn-north-1.amazonaws.com.cn/wheels/" \
                 f"v{ipex_version_major}/{ipex_whl_name}"
 
-    torch_links = parse_find_index_page("https://download.pytorch.org/whl/torch_stable.html")
+    torch_links = parse_find_index_page(
+        "https://download.pytorch.org/whl/torch_stable.html")
     torchvision_version = "0.9.0"
     torchvision_whl_name = f"cpu/torchvision-{torchvision_version}%2Bcpu-cp{py_version.major}{py_version.minor}" \
                            f"-cp{py_version.major}{py_version.minor}m-linux_x86_64.whl"
@@ -109,8 +110,10 @@ def setup_package():
 
     # both pytorch_lightning and ipex depends on pytorch
     # listing it here to make sure installing the correct version
-    pytorch_link = "https://download.pytorch.org/whl/" + torch_links[pytorch_whl_name]
-    torchvision_link = "https://download.pytorch.org/whl/" + torch_links[torchvision_whl_name]
+    pytorch_link = "https://download.pytorch.org/whl/" + \
+        torch_links[pytorch_whl_name]
+    torchvision_link = "https://download.pytorch.org/whl/" + \
+        torch_links[torchvision_whl_name]
 
     install_requires = ["intel-openmp"]
 
@@ -123,8 +126,12 @@ def setup_package():
                         f"torch_ipex @ {ipex_link}",
                         f"torchvision @ {torchvision_link}"]
 
-
-    download_libs()
+    lib_urls = [
+        "https://github.com/yangw1234/jemalloc/releases/download/v5.2.1-binary/libjemalloc.so",
+        "https://github.com/leonardozcm/libjpeg-turbo/releases/download/2.1.1/libturbojpeg.so.0.2.0"
+    ]
+    for url in lib_urls:
+        download_libs(url)
 
     metadata = dict(
         name='bigdl-nano',
@@ -134,9 +141,11 @@ def setup_package():
         author_email='',
         url='https://github.com/intel-analytics/analytics-zoo/tree/bigdl-2.0',
         install_requires=install_requires,
-        extras_require={"tensorflow": tensorflow_requires, "pytorch": pytorch_requires},
+        extras_require={"tensorflow": tensorflow_requires,
+                        "pytorch": pytorch_requires},
         packages=get_nano_packages(),
-        package_data={"bigdl.nano": ["libs/libjemalloc.so"]},
+        package_data={"bigdl.nano": [
+            "libs/libjemalloc.so", "libs/libturbojpeg.so.0.2.0"]},
         package_dir={'': 'src'},
         scripts=['script/bigdl-nano-init']
     )

--- a/python/nano/src/bigdl/nano/pytorch/vision/datasets/datasets.py
+++ b/python/nano/src/bigdl/nano/pytorch/vision/datasets/datasets.py
@@ -22,6 +22,17 @@ import cv2
 import os
 import numpy as np
 import torch
+from logging import warning
+from os.path import split, join, realpath
+
+
+local_libturbo_path = None
+_turbo_path = realpath(join(split(realpath(__file__))[0],
+                            "../../../libs/libturbojpeg.so.0.2.0"))
+if os.path.exists(_turbo_path):
+    local_libturbo_path = _turbo_path
+else:
+    warning("libturbojpeg.so.0 not found in bigdl-nano, try to load from system.")
 
 
 class ImageFolder(torchvision.datasets.ImageFolder):
@@ -65,7 +76,7 @@ class ImageFolder(torchvision.datasets.ImageFolder):
 
     def decode_img_libjpeg_turbo(self, img_str: str):
         if self.jpeg is None:
-            self.jpeg = TurboJPEG()
+            self.jpeg = TurboJPEG(lib_path=local_libturbo_path)
         bgr_array = self.jpeg.decode(img_str)
         return bgr_array
 
@@ -100,7 +111,7 @@ class SegmentationImageFolder:
         self.imgs = list(sorted(os.listdir(self.image_folder)))
         self.masks = list(sorted(os.listdir(self.mask_folder)))
         self.transforms = transforms
-        self.jpeg = TurboJPEG()
+        self.jpeg = TurboJPEG(lib_path=local_libturbo_path)
 
     def __getitem__(self, idx: int):
         img_path = os.path.join(self.image_folder, self.imgs[idx])


### PR DESCRIPTION
This pr makes nano load libturbojpeg.so from wheel package itself instead of conda package, with which we can directly run `pip install bigdl-nano` without `conda install Pyturbojpeg`.