### PR TITLE
Bigdl-Nano: Check environment variables when import this module

### DIFF
--- a/python/nano/example/pytorch/pl-finetune/README.md
+++ b/python/nano/example/pytorch/pl-finetune/README.md
@@ -9,13 +9,12 @@ We recommend you to use [Anaconda](https://www.anaconda.com/distribution/#linux)
 conda create -n nano python=3.7  # "nano" is conda environment name, you can use any name you like.
 conda activate nano
 pip install jsonargparse[signatures]
-conda install PyTurboJPEG -c conda-forge
 
 pip install bigdl-nano[pytorch]
 ```
 Initialize environment variables with script `bigdl-nano-init` installed with bigdl-nano.
 ```
-bigdl-nano-init
+source bigdl-nano-init
 ``` 
 You may find environment variables set like follows:
 ```

--- a/python/nano/example/pytorch/semantic_segmentation/README.md
+++ b/python/nano/example/pytorch/semantic_segmentation/README.md
@@ -13,7 +13,7 @@ pip install bigdl-nano[pytorch]
 ```
 Initialize environment variables with script `bigdl-nano-init` installed with bigdl-nano.
 ```
-bigdl-nano-init
+source bigdl-nano-init
 ``` 
 You may find environment variables set like follows:
 ```

--- a/python/nano/script/bigdl-nano-init
+++ b/python/nano/script/bigdl-nano-init
@@ -171,16 +171,19 @@ if [ ! -z "${DISABLE_OPENMP_VAR:-}" ]; then
 	unset OMP_NUM_THREADS
 	unset KMP_AFFINITY
 	unset KMP_BLOCKTIME
+	unset DISABLE_OPENMP_VAR
 	export LD_PRELOAD=`echo $LD_PRELOAD | sed "s/\s.*libiomp5\.so//g" | sed "s/.*libiomp5\.so\s*//g"`
 fi
 if [ ! -z "${DISABLE_JEMALLOC_VAR:-}" ]; then
 	unset MALLOC_CONF
+	unset DISABLE_JEMALLOC_VAR
 	export LD_PRELOAD=`echo $LD_PRELOAD | sed "s/\s.*libjemalloc\.so//g" | sed "s/.*libjemalloc\.so\s*//g"`
 fi
 if [ -z "${LD_PRELOAD:-}" ]; then
 	unset LD_PRELOAD
 fi
 if [ -z "${ENABLE_TF_OPTS:-}" ]; then
+	unset ENABLE_TF_OPTS
 	unset TF_ENABLE_ONEDNN_OPTS
 fi
 

--- a/python/nano/script/bigdl-nano-init
+++ b/python/nano/script/bigdl-nano-init
@@ -199,3 +199,4 @@ echo "TF_ENABLE_ONEDNN_OPTS=${TF_ENABLE_ONEDNN_OPTS}"
 echo "+++++++++++++++++++++++++"
 # Run the commands after bigdl-nano-init
 echo "Complete."
+${@:1}

--- a/python/nano/src/bigdl/nano/__init__.py
+++ b/python/nano/src/bigdl/nano/__init__.py
@@ -28,7 +28,6 @@ def check_nano_envs():
             _unset_envs.append(k)
 
     if len(_unset_envs):
-        print
         warning("\n" + "*"*150 +
                 f"\nNano environment variables {_unset_envs} are not set.\n"
                 f"Please run `source bigdl-nano-init` to initialize them, "

--- a/python/nano/src/bigdl/nano/__init__.py
+++ b/python/nano/src/bigdl/nano/__init__.py
@@ -1,0 +1,41 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os
+from logging import warning
+
+envs_checklist = ["LD_PRELOAD", "MALLOC_CONF", "OMP_NUM_THREADS", "KMP_AFFINITY",
+                  "KMP_BLOCKTIME"]
+
+_unset_envs = []
+
+
+def check_nano_envs():
+    for k in envs_checklist:
+        if not os.environ.get(k, None):
+            _unset_envs.append(k)
+
+    if len(_unset_envs):
+        print
+        warning("\n" + "*"*150 +
+                f"\nNano environment variables {_unset_envs} are not set.\n"
+                f"Please run `source bigdl-nano-init` to initialize them, "
+                f"or you can prefix `bigdl-nano-init` to the command you run.\n"
+                f"\nExample:\n"
+                f"bigdl-nano-init python pytorch-lenet.py --device ipex\n"
+                + "*"*150)
+
+
+check_nano_envs()

--- a/python/nano/src/bigdl/nano/__init__.py
+++ b/python/nano/src/bigdl/nano/__init__.py
@@ -29,11 +29,11 @@ def check_nano_envs():
 
     if len(_unset_envs):
         highlight_boundary = "\n{}\n".format("*" * 150)
-        warning(f"{highlight_boundary}\nNano environment variables {_unset_envs} are not set.\n"
+        warning(f"{highlight_boundary}Nano environment variables {_unset_envs} are not set.\n"
                 f"Please run `source bigdl-nano-init` to initialize them, "
                 f"or you can prefix `bigdl-nano-init` to the command you run.\n"
                 f"\nExample:\n"
-                f"bigdl-nano-init python pytorch-lenet.py --device ipex\n"
+                f"bigdl-nano-init python pytorch-lenet.py --device ipex"
                 f"{highlight_boundary}")
 
 

--- a/python/nano/src/bigdl/nano/__init__.py
+++ b/python/nano/src/bigdl/nano/__init__.py
@@ -28,13 +28,13 @@ def check_nano_envs():
             _unset_envs.append(k)
 
     if len(_unset_envs):
-        warning("\n" + "*"*150 +
-                f"\nNano environment variables {_unset_envs} are not set.\n"
+        highlight_boundary = "\n{}\n".format("*" * 150)
+        warning(f"{highlight_boundary}\nNano environment variables {_unset_envs} are not set.\n"
                 f"Please run `source bigdl-nano-init` to initialize them, "
                 f"or you can prefix `bigdl-nano-init` to the command you run.\n"
                 f"\nExample:\n"
                 f"bigdl-nano-init python pytorch-lenet.py --device ipex\n"
-                + "*"*150)
+                f"{highlight_boundary}")
 
 
 check_nano_envs()


### PR DESCRIPTION
warning message:
```
WARNING:root:
******************************************************************************************************************************************************
Nano environment variables ['LD_PRELOAD', 'MALLOC_CONF', 'OMP_NUM_THREADS', 'KMP_AFFINITY', 'KMP_BLOCKTIME'] are not set.
Please run `source bigdl-nano-init` to initialize them, or you can prefix `bigdl-nano-init` to the command you run.

Example:
bigdl-nano-init python pytorch-lenet.py --device ipex
******************************************************************************************************************************************************
```