### PR TITLE
update pom.xml to reduce whl size

### DIFF
--- a/zoo/pom.xml
+++ b/zoo/pom.xml
@@ -358,6 +358,7 @@
             <properties>
                 <core.artifactId>zoo-core-dist-linux64</core.artifactId>
                 <core.dependencyType>pom</core.dependencyType>
+                <spark-mllib-scope>provided</spark-mllib-scope>
             </properties>
         </profile>
 
@@ -1094,6 +1095,12 @@
                                     <exclude>org.apache.commons:commons-compress</exclude>
                                     <exclude>org.scala-lang:scala-reflect</exclude>
                                     <exclude>xerces:xercesImpl</exclude>
+				    <exclude>org.scalanlp:*</exclude>
+				    <exclude>net.sf.opencsv:*</exclude>
+				    <exclude>com.github.rwl:*</exclude>
+				    <exclude>org.spire-math:*</exclude>
+				    <exclude>org.typelevel:*</exclude>
+				    <exclude>com.chuusai:*</exclude>
                                 </excludes>
                             </artifactSet>
                         </configuration>
@@ -1131,6 +1138,12 @@
                                     <exclude>org.apache.commons:commons-compress</exclude>
                                     <exclude>org.scala-lang:scala-reflect</exclude>
                                     <exclude>xerces:xercesImpl</exclude>
+				    <exclude>org.scalanlp:*</exclude>
+				    <exclude>net.sf.opencsv:*</exclude>
+				    <exclude>com.github.rwl:*</exclude>
+				    <exclude>org.spire-math:*</exclude>
+				    <exclude>org.typelevel:*</exclude>
+				    <exclude>com.chuusai:*</exclude>
                                 </excludes>
                             </artifactSet>
                         </configuration>


### PR DESCRIPTION
update pom.xml to reduce whl size from 207MB to 160MB.
Remove breeze from jar.
Some dependencies are included by #4717. Just remove them.