### PR TITLE
Add two properties to yaml config files in trusted-realtime-ml/scala/docker-graphene/kubernetes

### DIFF
--- a/heyang_pr_test
+++ b/heyang_pr_test
@@ -1,0 +1,1 @@
+this is a pr test

--- a/heyang_pr_test
+++ b/heyang_pr_test
@@ -1,1 +1,0 @@
-this is a pr test

--- a/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/taskmanager-deployment.yaml.back
+++ b/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/taskmanager-deployment.yaml.back
@@ -24,9 +24,6 @@ spec:
         command: ["/bin/bash","-c"]
         args:
               - export FLINK_TASK_MANAGER_IP=$(hostname -I);
-                export OMP_NUM_THREADS=${CORE_NUM};
-                export KMP_AFFINITY=verbose,granularity=fine,compact,1,0;
-                export KMP_BLOCKTIME=20;
                 cd /ppml/trusted-realtime-ml/java;
                 test "$SGX_MODE" = sgx && bash init-java.sh | tee ../init-java.log ;
                 bash start-flink-taskmanager.sh | tee ../taskmanager.log;

--- a/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/taskmanager-deployment.yaml.back
+++ b/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/taskmanager-deployment.yaml.back
@@ -25,7 +25,7 @@ spec:
         args:
               - export FLINK_TASK_MANAGER_IP=$(hostname -I);
                 cd /ppml/trusted-realtime-ml/java;
-                test "$SGX_MODE" = sgx && bash init-java.sh | tee ../init-java.log ;
+                test "$SGX_MODE" = sgx && bash init.sh | tee ../init.log ;
                 bash start-flink-taskmanager.sh | tee ../taskmanager.log;
                 tail -f /dev/null
 #        args: ["export FLINK_JOB_MANAGER_IP=flink-jobmanager; tail -f /dev/null"]

--- a/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/taskmanager-deployment.yaml.back
+++ b/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/taskmanager-deployment.yaml.back
@@ -30,6 +30,10 @@ spec:
                 tail -f /dev/null
 #        args: ["export FLINK_JOB_MANAGER_IP=flink-jobmanager; tail -f /dev/null"]
         env:
+          - name: CORE_NUM
+            value: "16"
+          - name: SGX_MEM_SIZE
+            value: "32G"
           - name: FLINK_JOB_MANAGER_IP
             valueFrom:
               configMapKeyRef:

--- a/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/templates/jobmanager-deployment.yaml
+++ b/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/templates/jobmanager-deployment.yaml
@@ -34,11 +34,11 @@ spec:
               configMapKeyRef:
                 name: flink-config
                 key: flink.jobmanager.ip
-          - name: XMX_SIZE
-            valueFrom:
-              configMapKeyRef:
-                name: flink-config
-                key: xmx.size
+                #          - name: XMX_SIZE
+                #            valueFrom:
+                #              configMapKeyRef:
+                #                name: flink-config
+                #                key: xmx.size
           - name: SGX_MODE
             valueFrom:
               configMapKeyRef:

--- a/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/templates/master-deployment.yaml
+++ b/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/templates/master-deployment.yaml
@@ -28,6 +28,8 @@ spec:
         ports:
         - containerPort: 6379
         env:
+          - name: CORE_NUM #batchsize per instance
+            value: "16"
           - name: FLINK_JOB_MANAGER_IP
             valueFrom:
               configMapKeyRef:

--- a/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/templates/taskmanager-statefulset.yaml
+++ b/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/templates/taskmanager-statefulset.yaml
@@ -40,10 +40,6 @@ spec:
         command: ["/bin/bash","-c"]
         args:
               - export FLINK_TASK_MANAGER_IP=$(hostname -I);
-                export OMP_NUM_THREADS=${CORE_NUM};
-                export KMP_AFFINITY=verbose,granularity=fine,compact,1,0;
-                export KMP_BLOCKTIME=20;
-                export KMP_SETTINGS=1;
                 cd /ppml/trusted-realtime-ml/java;
                 test "$SGX_MODE" = sgx && bash init.sh | tee ../init-java.log ;
                 instance_id=`echo $POD_NAME | awk -F '-' '{print $NF}'`;

--- a/ppml/trusted-realtime-ml/scala/docker-graphene/start-flink-taskmanager.sh
+++ b/ppml/trusted-realtime-ml/scala/docker-graphene/start-flink-taskmanager.sh
@@ -22,7 +22,8 @@ if [[ $sgx_mode == "sgx" || $sgx_mode == "SGX" ]];then cmd_prefix="graphene-sgx 
 
 echo "### Launching Flink Taskmanager ###"
 
-eval ${cmd_prefix}bash -c \" /opt/jdk8/bin/java \
+ ${cmd_prefix}bash -c " export OMP_NUM_THREADS=${CORE_NUM} && export KMP_AFFINITY=verbose,granularity=fine,compact,1,0 && export KMP_BLOCKTIME=20 && export KMP_SETTINGS=1 && \
+    /opt/jdk8/bin/java \
     -XX:+UseG1GC \
     -Xms2g \
     -Xmx${xmx_size} \
@@ -60,4 +61,4 @@ eval ${cmd_prefix}bash -c \" /opt/jdk8/bin/java \
     -D taskmanager.memory.managed.size=${taskmanager_memory_managed_size} \
     -D taskmanager.cpu.cores=${core_num} \
     -D taskmanager.memory.task.heap.size=${taskmanager_memory_task_heap_size} \
-    -D taskmanager.memory.task.off-heap.size=953mb \" | tee ./flink-taskmanager-${sgx_mode}.log
+    -D taskmanager.memory.task.off-heap.size=953mb " 2>&1 | tee ./flink-taskmanager-${sgx_mode}.log


### PR DESCRIPTION
Users prone to make mistakes when they have to edit yaml files, which put a strict requirement for the indent format. Therefore, CORE_NUM and SGX_MEM_SIZE are directly added to the files and users just need to edit their values. These two properties can be applied to the standard component.