### PR TITLE
Modify scripts in realtime cluster serving

### DIFF
--- a/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/start-all-but-flink.sh
+++ b/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/start-all-but-flink.sh
@@ -36,7 +36,7 @@ echo "http-frontend started"
 while ! nc -z $LOCAL_IP 10020; do
   sleep 1
 done
-./start-cluster-serving-job.sh &
+./start-cluster-serving-job.sh
 echo "cluster-serving-job started"
 
 

--- a/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/start-all-but-flink.sh
+++ b/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/start-all-but-flink.sh
@@ -40,4 +40,4 @@ done
 echo "cluster-serving-job started"
 
 
-bash /ppml/trusted-realtime-ml/check-status.sh
+bash /ppml/trusted-realtime-ml/check-status.sh redis frontend serving

--- a/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/taskmanager-deployment.yaml.back
+++ b/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/taskmanager-deployment.yaml.back
@@ -30,6 +30,10 @@ spec:
                 tail -f /dev/null
 #        args: ["export FLINK_JOB_MANAGER_IP=flink-jobmanager; tail -f /dev/null"]
         env:
+          - name: CORE_NUM
+            value: "16"
+          - name: SGX_MEM_SIZE
+            value: "32G"
           - name: FLINK_JOB_MANAGER_IP
             valueFrom:
               configMapKeyRef:

--- a/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/templates/jobmanager-deployment.yaml
+++ b/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/templates/jobmanager-deployment.yaml
@@ -28,7 +28,9 @@ spec:
             bash start-flink-jobmanager.sh | tee ../jobmanager.log; 
             tail -f /dev/null
 #        args: ["tail -f /dev/null"]
-        env: 
+        env:
+          - name: SGX_MEM_SIZE
+            value: "16G" 
           - name: FLINK_JOB_MANAGER_IP
             valueFrom:
               configMapKeyRef:

--- a/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/templates/master-deployment.yaml
+++ b/ppml/trusted-realtime-ml/scala/docker-graphene/kubernetes/templates/master-deployment.yaml
@@ -28,6 +28,8 @@ spec:
         ports:
         - containerPort: 6379
         env:
+          - name: CORE_NUM
+            value: "16"
           - name: FLINK_JOB_MANAGER_IP
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
1. Modify start-all-but-flink.sh to avoid check status before job submitted, which can cause a check fail.
2. Add some properties to make the yaml scripts more user-friendly.