### PR TITLE
refactor add_value_features and reindex using tables instead of dicts

### DIFF
--- a/pyzoo/zoo/friesian/feature/table.py
+++ b/pyzoo/zoo/friesian/feature/table.py
@@ -25,7 +25,7 @@ from pyspark.sql import Row, Window
 from pyspark.sql.types import IntegerType, ShortType, LongType, FloatType, DecimalType, \
     DoubleType, ArrayType, DataType, StructType, StringType, StructField
 from pyspark.sql.functions import col as pyspark_col, concat, udf, array, broadcast, \
-    lit, rank, monotonically_increasing_id
+    lit, rank, monotonically_increasing_id, row_number, desc
 
 from pyspark.ml import Pipeline
 from pyspark.ml.feature import MinMaxScaler, VectorAssembler, Bucketizer
@@ -1379,68 +1379,46 @@ class FeatureTable(Table):
         joined_df = self.df.join(table.df, on=on, how=how)
         return FeatureTable(joined_df)
 
-    def add_value_features(self, columns, mapping, key, value):
+    def add_value_features(self, columns, dict_tbl, key, value):
         """
          Add features based on key_cols and another key value table,
-         for each col in columns, it adds a value_col using key-value pairs from mapping
+         for each col in columns, it adds a value_col using key-value pairs from dict_tbl
 
-         :param columns: a list of str
-         :param mapping: Key value mapping
+         :param columns: str or a list of str
+         :param dict_tbl: key value mapping table
          :param key: str, name of key column in tbl
          :param value: str, name of value column in tbl
 
          :return: FeatureTable
          """
-        columns = str_to_list(columns, "columns")
-
-        spark = OrcaContext.get_spark_session()
-        keyvalue_bc = spark.sparkContext.broadcast(mapping)
-        keyvalue_map = keyvalue_bc.value
-
-        def gen_values(items):
-            getvalue = lambda item: keyvalue_map.get(item, 0)
-            if isinstance(items, int) or items is None:
-                values = getvalue(items)
-            elif isinstance(items, list) and isinstance(items[0], int):
-                values = [getvalue(item) for item in items]
-            elif isinstance(items, list) and isinstance(items[0], list) and isinstance(items[0][0],
-                                                                                       int):
-                values = []
-                for line in items:
-                    line_cats = [getvalue(item) for item in line]
-                    values.append(line_cats)
-            else:
-                raise ValueError('only int, list[int], and list[list[int]] are supported.')
-            return values
-
-        df = self.df
-        for c in columns:
-            col_type = df.schema[c].dataType
-            cat_udf = udf(gen_values, col_type)
-            df = df.withColumn(c.replace(key, value), cat_udf(pyspark_col(c)))
+        if isinstance(columns, str):
+            columns = [columns]
+        assert isinstance(columns, list), \
+            "columns should be str or a list of str, but get a " + type(columns)
+        df = add_value_features(self.df, columns, dict_tbl.df, key, value)
         return FeatureTable(df)
 
-    def reindex(self, columns=[], index_dicts=[]):
+    def reindex(self, columns=[], index_tbls=[]):
         """
         Replace the value using index_dicts for each col in columns, set 0 for default
 
         :param columns: str of a list of str
-        :param index_dicts: dict or list of dicts from int to int
+        :param dict_tbls: table or list of tables, each one has a mapping from old index to new one
 
         :return: FeatureTable
          """
         columns = str_to_list(columns, "columns")
 
-        if isinstance(index_dicts, dict):
-            index_dicts = [index_dicts]
-        assert isinstance(index_dicts, list), \
-            "index_dicts should be dict or a list of dict, but get a " + type(index_dicts)
-        assert len(columns) == len(index_dicts), \
+        if isinstance(index_tbls, dict):
+            index_tbls = [index_tbls]
+        assert isinstance(index_tbls, list), \
+            "index_dicts should be table or a list of table, but get a " + type(index_tbls)
+        assert len(columns) == len(index_tbls), \
             "each column of columns should have one corresponding index_dict"
 
         tbl = FeatureTable(self.df)
         for i, c in enumerate(columns):
-            tbl = tbl.add_value_features(c, index_dicts[i], key=c, value=c)
+            tbl = tbl.add_value_features(c, index_tbls[i], key=c, value=c)
         return tbl
 
     def gen_reindex_mapping(self, columns=[], freq_limit=10):
@@ -1451,7 +1429,7 @@ class FeatureTable(Table):
                will be omitted. Can be represented as either an integer or dict.
                For instance, 15, {'col_4': 10, 'col_5': 2} etc. Default is 10,
 
-        :return: a dictionary of list of dictionaries, a mapping from old index to new index
+        :return: a list of FeatureTables, each table has a mapping from old index to new index
                 new index starts from 1, save 0 for default
          """
         str_to_list(columns, "columns")
@@ -1459,21 +1437,19 @@ class FeatureTable(Table):
             freq_limit = {col: freq_limit for col in columns}
         assert isinstance(freq_limit, dict), \
             "freq_limit should be int or dict, but get a " + type(freq_limit)
-        index_dicts = []
+        index_tbls = []
         for c in columns:
             c_count = self.select(c).group_by(c, agg={c: "count"}).rename(
                 {"count(" + c + ")": "count"})
-            c_count = c_count.filter(pyspark_col("count") >= freq_limit[c]) \
-                .order_by("count", ascending=False)
-            c_count_pd = c_count.to_pandas()
-            c_count_pd.reindex()
-            c_count_pd[c + "_new"] = c_count_pd.index + 1
-            index_dict = dict(zip(c_count_pd[c], c_count_pd[c + "_new"]))
-            index_dicts.append(index_dict)
+            c_count = c_count.filter(pyspark_col("count") >= freq_limit[c])
+            w = Window.orderBy(desc("count"))
+            index_df = c_count.df.withColumn(c + "_new", row_number().over(w))
+            index_tbl = FeatureTable(index_df).select([c, c + "_new"])
+            index_tbls.append(index_tbl)
         if isinstance(columns, str):
-            index_dicts = index_dicts[0]
+            index_tbls = index_tbls[0]
 
-        return index_dicts
+        return index_tbls
 
     def group_by(self, columns=[], agg="count", join=False):
         """

--- a/pyzoo/zoo/friesian/feature/utils.py
+++ b/pyzoo/zoo/friesian/feature/utils.py
@@ -74,6 +74,10 @@ def add_neg_hist_seq(df, item_size, item_history_col, neg_num):
     return callZooFunc("float", "addNegHisSeq", df, item_size, item_history_col, neg_num)
 
 
+def add_value_features(df, cols, map_df, key, value):
+    return callZooFunc("float", "addValueFeatures", df, cols, map_df, key, value)
+
+
 def mask(df, mask_cols, seq_len):
     return callZooFunc("float", "mask", df, mask_cols, seq_len)
 


### PR DESCRIPTION
move add_value_features to scala side to boost performance.
refactor add_value_features  and reindex to take tables instead of python dicts.
refactor gen_reindex_mapping  to output tables instead of python dicts.
