### PR TITLE
unify release bigdl2.0 PyPI project name

### DIFF
--- a/python/dllib/src/setup.py
+++ b/python/dllib/src/setup.py
@@ -81,7 +81,7 @@ def get_bigdl_packages():
 
 def setup_package():
     metadata = dict(
-        name='BigDL-dllib',
+        name='bigdl-dllib',
         version=VERSION,
         description='Distributed Deep Learning Library for Apache Spark',
         author='BigDL Authors',


### PR DESCRIPTION
@jason-dai Which name we will choose to release on PyPI? "BigDL-dllib", "BigDL-nano" or "bigdl-dllib", "bigdl-nano"?