### PR TITLE
Exclude dllib from orca jar

### DIFF
--- a/scala/orca/pom.xml
+++ b/scala/orca/pom.xml
@@ -25,6 +25,7 @@
             <groupId>com.intel.analytics.bigdl</groupId>
             <artifactId>bigdl-dllib</artifactId>
             <version>0.14.0-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.intel.analytics.zoo</groupId>

--- a/scala/orca/pom.xml
+++ b/scala/orca/pom.xml
@@ -18,6 +18,8 @@
         <scoverage.aggregate>true</scoverage.aggregate>
         <runSpecsInParallel>false</runSpecsInParallel>
         <tagsToExclude>com.intel.analytics.bigdl.tags.Integration</tagsToExclude>
+        <core.artifactId>zoo-core-dist-all</core.artifactId>
+        <core.dependencyType>jar</core.dependencyType>
     </properties>
 
     <dependencies>
@@ -29,9 +31,9 @@
         </dependency>
         <dependency>
             <groupId>com.intel.analytics.zoo</groupId>
-            <artifactId>zoo-core-dist-all</artifactId>
+            <artifactId>${core.artifactId}</artifactId>
             <version>0.12.0-SNAPSHOT</version>
-            <type>jar</type>
+            <type>${core.dependencyType}</type>
         </dependency>
         <dependency>
             <groupId>org.tensorflow</groupId>
@@ -456,6 +458,37 @@
             <properties>
                 <tagsToExclude>com.intel.analytics.bigdl.tags.Serial,com.intel.analytics.bigdl.tags.Parallel</tagsToExclude>
             </properties>
+        </profile>
+
+        <profile>
+            <id>linux</id>
+            <properties>
+                <core.artifactId>zoo-core-dist-linux64</core.artifactId>
+                <core.dependencyType>pom</core.dependencyType>
+                <spark-mllib-scope>provided</spark-mllib-scope>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>mac</id>
+            <properties>
+                <core.artifactId>zoo-core-dist-mac</core.artifactId>
+                <core.dependencyType>pom</core.dependencyType>
+                <spark-mllib-scope>provided</spark-mllib-scope>
+            </properties>
+            <!--these are not supported right now, added to make the project compiles-->
+            <dependencies>
+                <dependency>
+                    <groupId>com.intel.analytics.zoo</groupId>
+                    <artifactId>zoo-core-mkl-linux</artifactId>
+                    <version>0.12.0-SNAPSHOT</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.intel.analytics.zoo</groupId>
+                    <artifactId>zoo-core-pmem-java-linux</artifactId>
+                    <version>0.12.0-SNAPSHOT</version>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
After removing `bigdl-dllib`, orca jar size reduces from 389M to 245M

Before:
```
-rw-rw-r-- 1 shan shan 152822343 9月  24 10:18 bigdl-dllib-0.14.0-SNAPSHOT-jar-with-dependencies.jar
-rw-rw-r-- 1 shan shan    600532 9月  24 10:18 bigdl-dllib-0.14.0-SNAPSHOT-python-api.zip
-rw-rw-r-- 1 shan shan 389080878 9月  24 10:18 bigdl-orca-0.14.0-SNAPSHOT-jar-with-dependencies.jar
-rw-rw-r-- 1 shan shan    708745 9月  24 10:18 bigdl-orca-0.14.0-SNAPSHOT-python-api.zip

```
After:
```
-rw-rw-r-- 1 shan shan 122773321 9月  26 17:09 bigdl-dllib-0.14.0-SNAPSHOT-jar-with-dependencies.jar
-rw-rw-r-- 1 shan shan    600529 9月  26 17:09 bigdl-dllib-0.14.0-SNAPSHOT-python-api.zip
-rw-rw-r-- 1 shan shan 245061252 9月  26 17:09 bigdl-orca-0.14.0-SNAPSHOT-jar-with-dependencies.jar
-rw-rw-r-- 1 shan shan    818616 9月  26 17:09 bigdl-orca-0.14.0-SNAPSHOT-python-api.zip

```