### PR TITLE
Add profile for linux and mac in bigdl-orca jar

### DIFF
--- a/python/dllib/test/dev/release/release.sh
+++ b/python/dllib/test/dev/release/release.sh
@@ -41,7 +41,7 @@ if [ "$platform" ==  "mac" ]; then
     verbose_pname="macosx_10_11_x86_64"
 elif [ "$platform" == "linux" ]; then
     echo "Building bigdl for linux system"
-    dist_profile="-P $spark_profile"
+    dist_profile="-P linux -P $spark_profile"
     verbose_pname="manylinux1_x86_64"
 else
     echo "unsupport platform"

--- a/python/orca/dev/release/release.sh
+++ b/python/orca/dev/release/release.sh
@@ -41,7 +41,7 @@ if [ "$platform" ==  "mac" ]; then
     verbose_pname="macosx_10_11_x86_64"
 elif [ "$platform" == "linux" ]; then
     echo "Building bigdl for linux system"
-    dist_profile="-P $spark_profile"
+    dist_profile="-P linux -P $spark_profile"
     verbose_pname="manylinux1_x86_64"
 else
     echo "unsupport platform"

--- a/scala/orca/pom.xml
+++ b/scala/orca/pom.xml
@@ -18,6 +18,8 @@
         <scoverage.aggregate>true</scoverage.aggregate>
         <runSpecsInParallel>false</runSpecsInParallel>
         <tagsToExclude>com.intel.analytics.bigdl.tags.Integration</tagsToExclude>
+        <core.artifactId>zoo-core-dist-all</core.artifactId>
+        <core.dependencyType>jar</core.dependencyType>
     </properties>
 
     <dependencies>
@@ -28,9 +30,9 @@
         </dependency>
         <dependency>
             <groupId>com.intel.analytics.zoo</groupId>
-            <artifactId>zoo-core-dist-all</artifactId>
+            <artifactId>${core.artifactId}</artifactId>
             <version>0.12.0-SNAPSHOT</version>
-            <type>jar</type>
+            <type>${core.dependencyType}</type>
         </dependency>
         <dependency>
             <groupId>org.tensorflow</groupId>
@@ -455,6 +457,37 @@
             <properties>
                 <tagsToExclude>com.intel.analytics.bigdl.tags.Serial,com.intel.analytics.bigdl.tags.Parallel</tagsToExclude>
             </properties>
+        </profile>
+
+        <profile>
+            <id>linux</id>
+            <properties>
+                <core.artifactId>zoo-core-dist-linux64</core.artifactId>
+                <core.dependencyType>pom</core.dependencyType>
+                <spark-mllib-scope>provided</spark-mllib-scope>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>mac</id>
+            <properties>
+                <core.artifactId>zoo-core-dist-mac</core.artifactId>
+                <core.dependencyType>pom</core.dependencyType>
+                <spark-mllib-scope>provided</spark-mllib-scope>
+            </properties>
+            <!--these are not supported right now, added to make the project compiles-->
+            <dependencies>
+                <dependency>
+                    <groupId>com.intel.analytics.zoo</groupId>
+                    <artifactId>zoo-core-mkl-linux</artifactId>
+                    <version>0.12.0-SNAPSHOT</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.intel.analytics.zoo</groupId>
+                    <artifactId>zoo-core-pmem-java-linux</artifactId>
+                    <version>0.12.0-SNAPSHOT</version>
+                </dependency>
+            </dependencies>
         </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Related [comments]( https://github.com/intel-analytics/analytics-zoo/pull/4839#issuecomment-927599056) in PR #4839.
With `make-dist -P linux`, orca jar size reduces from 384M to 276M