### PR TITLE
Exclude dllib from orca jar

### DIFF
--- a/scala/orca/pom.xml
+++ b/scala/orca/pom.xml
@@ -25,6 +25,7 @@
             <groupId>com.intel.analytics.bigdl</groupId>
             <artifactId>bigdl-dllib</artifactId>
             <version>0.14.0-SNAPSHOT</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.intel.analytics.zoo</groupId>

--- a/scala/serving/pom.xml
+++ b/scala/serving/pom.xml
@@ -19,6 +19,16 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>18.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.intel.analytics.bigdl</groupId>
+            <artifactId>bigdl-dllib</artifactId>
+            <version>0.14.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
             <groupId>com.intel.analytics.bigdl</groupId>
             <artifactId>bigdl-orca</artifactId>
             <version>0.14.0-SNAPSHOT</version>


### PR DESCRIPTION
Related PR #4839 
This PR excluded dllib from orca jar and add dllib dependency in serving jar

With PR #4851, orca jar size can be reduced to 130M