### PR TITLE
[Bigdl-Nano] Enable tcmalloc in nano and turn jemalloc as an option

### DIFF
--- a/python/nano/script/bigdl-nano-init
+++ b/python/nano/script/bigdl-nano-init
@@ -13,9 +13,14 @@ function disable-openmp-var {
 	export DISABLE_OPENMP_VAR=1
 }
 
-function disable-jemalloc-var {
+function enable-jemalloc-var {
 	echo "Option: Disable jemalloc and unset related variables"
-	export DISABLE_JEMALLOC_VAR=1
+	export ENABLE_JEMALLOC_VAR=1
+}
+
+function disable-tcmalloc-var {
+	echo "Option: Disable tcmalloc and unset related variables"
+	export DISABLE_TCMALLOC_VAR=1
 }
 
 function enable-tensorflow-var {
@@ -38,19 +43,23 @@ function display-help {
         echo "Optional options:"
         echo "    -h, --help                Display this help message and exit."
         echo "    -o, --disable-openmp      Disable openMP and unset related variables"
-        echo "    -j, --disable-jemalloc    Disable jemalloc and unset related variables"
+        echo "    -j, --enable-jemalloc     Enable jemalloc and unset related variables"
+		echo "	  -c, --disable-tcmalloc   Disable tcmalloc and unset related variables"
 		echo "    -t, --enable-tensorflow   Enable tensorflow optimaztion"
 }
 
-while getopts ":ojht-:" opt; do
+while getopts ":ojhtc-:" opt; do
 	case ${opt} in
 		- )
 			case "${OPTARG}" in
 				disable-openmp)
 					disable-openmp-var
 					;;
-				disable-jemalloc)
-					disable-jemalloc-var
+				enable-jemalloc)
+					enable-jemalloc-var
+					;;
+				disable-tcmalloc)
+					disable-tcmalloc-var
 					;;
 				enable-tensorflow)
 					enable-tensorflow-var
@@ -69,7 +78,10 @@ while getopts ":ojht-:" opt; do
 			disable-openmp-var
 			;;
 		j )
-			disable-jemalloc-var
+			enable-jemalloc-var
+			;;
+		c )
+			disable-tcmalloc-var
 			;;
 		t )
 			enable-tensorflow-var
@@ -89,6 +101,7 @@ shift $((OPTIND -1))
 # Init
 OPENMP=0
 JEMALLOC=0
+TCMALLOC=0
 
 # Find conda dir
 if [ $0 != $BASH_SOURCE ]; then
@@ -144,6 +157,9 @@ fi
 # Detect jemalloc library
 JEMALLOC=1
 
+# Detect tcmalloc library
+TCMALLOC=1
+
 # set env variables
 echo "Setting MALLOC_CONF..."
 export MALLOC_CONF="oversize_threshold:1,background_thread:true,metadata_thp:auto,dirty_decay_ms:-1,muzzy_decay_ms:-1"
@@ -154,11 +170,21 @@ if [ -z "${LD_PRELOAD:-}" ]; then
 	if [[ $OPENMP -eq 1 && -z "${DISABLE_OPENMP_VAR:-}" ]]; then
 		export LD_PRELOAD="${LIB_DIR}/libiomp5.so"
 	fi
-	if [[ $JEMALLOC -eq 1 && -z "${DISABLE_JEMALLOC_VAR:-}" ]]; then
+	if [[ $JEMALLOC -eq 1 && ! -z "${ENABLE_JEMALLOC_VAR:-}" ]]; then
+	    DISABLE_TCMALLOC_VAR=1
 		if [ -z "${LD_PRELOAD:-}" ]; then
 			export LD_PRELOAD="${LIB_DIR}/libjemalloc.so"
 		else
 			export LD_PRELOAD="${LD_PRELOAD} ${NANO_DIR}/libs/libjemalloc.so"
+		fi
+	fi
+
+	# Set TCMALLOC lib path
+	if [[ $TCMALLOC -eq 1 && -z "${DISABLE_TCMALLOC_VAR:-}" ]]; then
+		if [ -z "${LD_PRELOAD:-}" ]; then
+			export LD_PRELOAD="${LIB_DIR}/libtcmalloc.so"
+		else
+			export LD_PRELOAD="${LD_PRELOAD} ${NANO_DIR}/libs/libtcmalloc.so"
 		fi
 	fi
 fi
@@ -174,11 +200,17 @@ if [ ! -z "${DISABLE_OPENMP_VAR:-}" ]; then
 	unset DISABLE_OPENMP_VAR
 	export LD_PRELOAD=`echo $LD_PRELOAD | sed "s/\s.*libiomp5\.so//g" | sed "s/.*libiomp5\.so\s*//g"`
 fi
-if [ ! -z "${DISABLE_JEMALLOC_VAR:-}" ]; then
+if [ -z "${ENABLE_JEMALLOC_VAR:-}" ]; then
+	unset ENABLE_JEMALLOC_VAR
 	unset MALLOC_CONF
-	unset DISABLE_JEMALLOC_VAR
 	export LD_PRELOAD=`echo $LD_PRELOAD | sed "s/\s.*libjemalloc\.so//g" | sed "s/.*libjemalloc\.so\s*//g"`
 fi
+
+if [ ! -z "${DISABLE_TCMALLOC_VAR:-}" ]; then
+	unset DISABLE_TCMALLOC_VAR
+	export LD_PRELOAD=`echo $LD_PRELOAD | sed "s/\s.*libtcmalloc\.so//g" | sed "s/.*libtcmalloc\.so\s*//g"`
+fi
+
 if [ -z "${LD_PRELOAD:-}" ]; then
 	unset LD_PRELOAD
 fi

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -133,7 +133,8 @@ def setup_package():
 
     lib_urls = [
         "https://github.com/yangw1234/jemalloc/releases/download/v5.2.1-binary/libjemalloc.so",
-        "https://github.com/leonardozcm/libjpeg-turbo/releases/download/2.1.1/libturbojpeg.so.0.2.0"
+        "https://github.com/leonardozcm/libjpeg-turbo/releases/download/2.1.1/libturbojpeg.so.0.2.0",
+        "https://github.com/leonardozcm/tcmalloc/releases/download/v1/libtcmalloc.so"
     ]
     for url in lib_urls:
         download_libs(url)
@@ -150,7 +151,7 @@ def setup_package():
                         "pytorch": pytorch_requires},
         packages=get_nano_packages(),
         package_data={"bigdl.nano": [
-            "libs/libjemalloc.so", "libs/libturbojpeg.so.0.2.0"]},
+            "libs/libjemalloc.so", "libs/libturbojpeg.so.0.2.0", "libs/libtcmalloc.so"]},
         package_dir={'': 'src'},
         scripts=['script/bigdl-nano-init']
     )

--- a/python/nano/src/bigdl/nano/__init__.py
+++ b/python/nano/src/bigdl/nano/__init__.py
@@ -16,7 +16,7 @@
 import os
 from logging import warning
 
-envs_checklist = ["LD_PRELOAD", "MALLOC_CONF", "OMP_NUM_THREADS", "KMP_AFFINITY",
+envs_checklist = ["LD_PRELOAD", "OMP_NUM_THREADS", "KMP_AFFINITY",
                   "KMP_BLOCKTIME"]
 
 _unset_envs = []

--- a/python/nano/src/bigdl/nano/common/common.py
+++ b/python/nano/src/bigdl/nano/common/common.py
@@ -80,12 +80,12 @@ def _find_library(library_name: str, priority_dir: Union[str, None] = None) -> U
     return res[0].decode("utf-8") if len(res) > 0 else None
 
 
-def init_nano(use_jemalloc: bool = True, use_openmp: bool = True,
+def init_nano(use_malloc: str = "tc", use_openmp: bool = True,
               print_environment: bool = False) -> None:
     """
     Configure necessary environment variables for jemalloc and openmp libraries.
-    :param use_jemalloc: If this is set to True, then use jemalloc library. Otherwise disable
-        jemalloc and related environment variables.
+    :param use_malloc: Allocator to be chosen, either "je" for jemalloc or "tc" for tcmalloc.
+        default as tcmalloc.
     :param use_openmp: If this is set to True, then use intel openmp library. Otherwise disable
         openmp and related environment variables.
     :param print_environment: If this is set to True, print all environment variables after
@@ -111,6 +111,7 @@ def init_nano(use_jemalloc: bool = True, use_openmp: bool = True,
     conda_lib_dir = conda_dir + "/lib" if conda_dir is not None else None
     openmp_lib_dir = _find_library("libiomp5.so", conda_lib_dir)
     jemalloc_lib_dir = _find_library("libjemalloc.so", conda_lib_dir)
+    tc_malloc_lib_dir = _find_library("libtcmalloc.so", conda_lib_dir)
     ld_preload_list = []
 
     # Detect Intel OpenMP library
@@ -143,6 +144,11 @@ def init_nano(use_jemalloc: bool = True, use_openmp: bool = True,
     else:
         warnings.warn("jemalloc library (libjemalloc.so) is nor found.")
 
+    if tc_malloc_lib_dir is not None:
+        ld_preload_list.append(tc_malloc_lib_dir)
+    else:
+        warnings.warn("tcmalloc library (libtcmalloc.so) is nor found.")
+
     # Set LD_PRELOAD
     if not _env_variable_is_set("LD_PRELOAD", env_copy):
         env_copy["LD_PRELOAD"] = " ".join(ld_preload_list)
@@ -155,12 +161,16 @@ def init_nano(use_jemalloc: bool = True, use_openmp: bool = True,
         env_copy.pop("KMP_BLOCKTIME")
         ld_preload = [lib for lib in ld_preload if "libiomp5.so" not in lib]
 
-    if not use_jemalloc:
+    if use_malloc is not "je":
         env_copy.pop("MALLOC_CONF")
         ld_preload = [lib for lib in ld_preload if "libjemalloc.so" not in lib]
+    
+    if use_malloc is not "tc":
+        ld_preload = [lib for lib in ld_preload if "libtcmalloc.so" not in lib]
 
     env_copy["LD_PRELOAD"] = " ".join(ld_preload)
     env_copy["BIGDL_NANO_CHILD"] = "1"
+
     if print_environment:
         print(env_copy)
 

--- a/python/nano/src/bigdl/nano/common/common.py
+++ b/python/nano/src/bigdl/nano/common/common.py
@@ -164,7 +164,7 @@ def init_nano(use_malloc: str = "tc", use_openmp: bool = True,
     if use_malloc is not "je":
         env_copy.pop("MALLOC_CONF")
         ld_preload = [lib for lib in ld_preload if "libjemalloc.so" not in lib]
-    
+
     if use_malloc is not "tc":
         ld_preload = [lib for lib in ld_preload if "libtcmalloc.so" not in lib]
 


### PR DESCRIPTION
By default we will use tcmalloc as our memory allocator and jemalloc will also be available.
Usage:
```
bigdl-nano-init python ...  # tcmalloc only
bigdl-nano-init -j python ...  # jemalloc only
bigdl-nano-init -c python ...  # ptmalloc (no optimaztions)
```
