### PR TITLE
Upgrade IPEX to version 1.9.0

### DIFF
--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -95,23 +95,26 @@ def setup_package():
 
     assert py_version.major == 3, "Nano only supports python3.x"
 
-    ipex_version = "1.8.0"
-    ipex_version_major = "1.8"
-    ipex_whl_name = f"torch_ipex-{ipex_version}-cp{py_version.major}{py_version.minor}" \
-                    f"-cp{py_version.major}{py_version.minor}m-linux_x86_64.whl"
+    ipex_version = "1.9.0"
+    ipex_version_major = "1.9"
+    ipex_whl_name_suffix = f"-cp{py_version.major}{py_version.minor}m-linux_x86_64.whl" if py_version.minor < 8 else f"-cp{py_version.major}{py_version.minor}-linux_x86_64.whl"
+    ipex_whl_name = f"torch_ipex-{ipex_version}-cp{py_version.major}{py_version.minor}" +\
+        ipex_whl_name_suffix
     ipex_link = f"https://intel-optimized-pytorch.s3.cn-north-1.amazonaws.com.cn/wheels/" \
                 f"v{ipex_version_major}/{ipex_whl_name}"
 
     torch_links = parse_find_index_page(
         "https://download.pytorch.org/whl/torch_stable.html")
-    torchvision_version = "0.9.0"
-    pytorch_version = "1.8.0"
+    torchvision_version = "0.10.0"
+    pytorch_version = "1.9.0"
     pytorch_url_suffix = "m-linux_x86_64.whl" if py_version.minor < 8 else "-linux_x86_64.whl"
 
     torchvision_whl_name = f"cpu/torchvision-{torchvision_version}%2Bcpu-cp{py_version.major}{py_version.minor}" \
-                           f"-cp{py_version.major}{py_version.minor}" + pytorch_url_suffix
+                           f"-cp{py_version.major}{py_version.minor}" + \
+        pytorch_url_suffix
     pytorch_whl_name = f"cpu/torch-{pytorch_version}%2Bcpu-cp{py_version.major}{py_version.minor}" \
-                       f"-cp{py_version.major}{py_version.minor}" + pytorch_url_suffix
+                       f"-cp{py_version.major}{py_version.minor}" + \
+        pytorch_url_suffix
 
     # both pytorch_lightning and ipex depends on pytorch
     # listing it here to make sure installing the correct version


### PR DESCRIPTION
Upgrade IPEX from 1.8.0 to 1.9.0.

Pytroch upgrade from 1.8.0 to 1.9.0. 

torchvision upgrade from 0.9.0 to 0.10.0

Mannulay tested on clx-004.
According to test result, and benchmark, the thoughput will increase 5-6% without accuracy drop after upgrade. 