### PR TITLE
eliminate log4j 1.x

### DIFF
--- a/zoo/pom.xml
+++ b/zoo/pom.xml
@@ -113,6 +113,34 @@
                 <scala.macros.version>2.1.0</scala.macros.version>
                 <bigdl.artifactId>bigdl-SPARK_${spark-version.project}</bigdl.artifactId>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-all</artifactId>
+                    <version>4.1.48.Final</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                    <version>1.7.5</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>log4j</groupId>
+                            <artifactId>log4j</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-api</artifactId>
+                    <version>2.17.0</version>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-core</artifactId>
+                    <version>2.17.0</version>
+                </dependency>
+            </dependencies>
         </profile>
 
         <profile>
@@ -178,12 +206,12 @@
                 <dependency>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-api</artifactId>
-                    <version>2.16.0</version>
+                    <version>2.17.0</version>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-core</artifactId>
-                    <version>2.16.0</version>
+                    <version>2.17.0</version>
                 </dependency>
             </dependencies>
         </profile>
@@ -210,6 +238,7 @@
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>org/apache/log4j/net/JMSAppender.class</exclude>
                                     </excludes>
                                 </filter>
                             </filters>
@@ -299,12 +328,12 @@
                 <dependency>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-api</artifactId>
-                    <version>2.16.0</version>
+                    <version>2.17.0</version>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-core</artifactId>
-                    <version>2.16.0</version>
+                    <version>2.17.0</version>
                 </dependency>
                 <dependency>
                     <groupId>io.grpc</groupId>

--- a/zoo/pom.xml
+++ b/zoo/pom.xml
@@ -165,14 +165,25 @@
                     <version>4.1.48.Final</version>
                 </dependency>
                 <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                    <version>1.7.5</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>log4j</groupId>
+                            <artifactId>log4j</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-api</artifactId>
-                    <version>2.15.0</version>
+                    <version>2.16.0</version>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-core</artifactId>
-                    <version>2.15.0</version>
+                    <version>2.16.0</version>
                 </dependency>
             </dependencies>
         </profile>
@@ -275,14 +286,25 @@
                     <version>4.1.48.Final</version>
                 </dependency>
                 <dependency>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                    <version>1.7.5</version>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>log4j</groupId>
+                            <artifactId>log4j</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-api</artifactId>
-                    <version>2.15.0</version>
+                    <version>2.16.0</version>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-core</artifactId>
-                    <version>2.15.0</version>
+                    <version>2.16.0</version>
                 </dependency>
                 <dependency>
                     <groupId>io.grpc</groupId>

--- a/zoo/pom.xml
+++ b/zoo/pom.xml
@@ -115,11 +115,6 @@
             </properties>
             <dependencies>
                 <dependency>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-all</artifactId>
-                    <version>4.1.48.Final</version>
-                </dependency>
-                <dependency>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-log4j12</artifactId>
                     <version>1.7.5</version>

--- a/zoo/pom.xml
+++ b/zoo/pom.xml
@@ -515,6 +515,12 @@
             <artifactId>${bigdl.artifactId}</artifactId>
             <version>${bigdl.version}</version>
             <scope>${bigdl-scope}</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>ml.dmlc</groupId>

--- a/zoo/pom.xml
+++ b/zoo/pom.xml
@@ -277,12 +277,12 @@
                 <dependency>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-api</artifactId>
-                    <version>2.14.1</version>
+                    <version>2.15.0</version>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-core</artifactId>
-                    <version>2.14.1</version>
+                    <version>2.15.0</version>
                 </dependency>
                 <dependency>
                     <groupId>io.grpc</groupId>

--- a/zoo/pom.xml
+++ b/zoo/pom.xml
@@ -165,17 +165,6 @@
                     <version>4.1.48.Final</version>
                 </dependency>
                 <dependency>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                    <version>1.7.5</version>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>log4j</groupId>
-                            <artifactId>log4j</artifactId>
-                        </exclusion>
-                    </exclusions>
-                </dependency>
-                <dependency>
                     <groupId>org.apache.logging.log4j</groupId>
                     <artifactId>log4j-api</artifactId>
                     <version>2.15.0</version>
@@ -284,17 +273,6 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty-all</artifactId>
                     <version>4.1.48.Final</version>
-                </dependency>
-                <dependency>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                    <version>1.7.5</version>
-                    <exclusions>
-                        <exclusion>
-                            <groupId>log4j</groupId>
-                            <artifactId>log4j</artifactId>
-                        </exclusion>
-                    </exclusions>
                 </dependency>
                 <dependency>
                     <groupId>org.apache.logging.log4j</groupId>
@@ -521,6 +499,16 @@
             <artifactId>spark-mllib_${scala.major.version}</artifactId>
             <version>${spark.version}</version>
             <scope>${spark-mllib-scope}</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>log4j</groupId>
+                    <artifactId>log4j</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.intel.analytics.bigdl</groupId>

--- a/zoo/pom.xml
+++ b/zoo/pom.xml
@@ -537,12 +537,12 @@
             <artifactId>${bigdl.artifactId}</artifactId>
             <version>${bigdl.version}</version>
             <scope>${bigdl-scope}</scope>
-            <exclusions>
+            <!--<exclusions>
                 <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
-            </exclusions>
+            </exclusions>-->
         </dependency>
         <dependency>
             <groupId>ml.dmlc</groupId>

--- a/zoo/src/main/java/com/intel/analytics/zoo/grpc/ZooGrpcClient.java
+++ b/zoo/src/main/java/com/intel/analytics/zoo/grpc/ZooGrpcClient.java
@@ -18,7 +18,7 @@ package com.intel.analytics.zoo.grpc;
 
 
 import io.grpc.*;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 
 import java.io.IOException;
@@ -30,7 +30,7 @@ import java.util.function.Function;
  * To implement specific gRPC client, overwrite parseConfig() and loadServices() method
  */
 public class ZooGrpcClient extends AbstractZooGrpc{
-    protected static final Logger logger = Logger.getLogger(ZooGrpcClient.class.getName());
+    protected static final Logger logger = LogManager.getLogger(ZooGrpcClient.class.getName());
     protected String target;
     protected final String clientUUID;
     protected ManagedChannel channel;

--- a/zoo/src/main/java/com/intel/analytics/zoo/grpc/ZooGrpcServer.java
+++ b/zoo/src/main/java/com/intel/analytics/zoo/grpc/ZooGrpcServer.java
@@ -26,7 +26,7 @@ import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import io.grpc.netty.shaded.io.netty.handler.ssl.ClientAuth;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContextBuilder;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import javax.net.ssl.SSLException;
 import java.io.File;
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit;
  * This class could also be directly used for start a single service
  */
 public class ZooGrpcServer extends AbstractZooGrpc{
-    protected static final Logger logger = Logger.getLogger(ZooGrpcServer.class.getName());
+    protected static final Logger logger = LogManager.getLogger(ZooGrpcServer.class.getName());
     protected int port;
     protected Server server;
     protected LinkedList<BindableService> serverServices;

--- a/zoo/src/main/java/com/intel/analytics/zoo/grpc/service/azinference/AZInferenceClient.java
+++ b/zoo/src/main/java/com/intel/analytics/zoo/grpc/service/azinference/AZInferenceClient.java
@@ -39,7 +39,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class AZInferenceClient {
-    private static final Logger logger = Logger.getLogger(AZInferenceClient.class.getName());
+    private static final Logger logger = LogManager.getLogger(AZInferenceClient.class.getName());
 
     private final AZInferenceBlockingStub blockingStub;
     private final AZInferenceStub asyncStub;

--- a/zoo/src/main/java/com/intel/analytics/zoo/grpc/service/azinference/AZInferenceServer.java
+++ b/zoo/src/main/java/com/intel/analytics/zoo/grpc/service/azinference/AZInferenceServer.java
@@ -43,7 +43,7 @@ import java.util.logging.Logger;
  * This is an example class to run Analytics Zoo gRPC inference service
  */
 public class AZInferenceServer {
-    private static final Logger logger = Logger.getLogger(AZInferenceServer.class.getName());
+    private static final Logger logger = LogManager.getLogger(AZInferenceServer.class.getName());
 
     /**
      * Main method.  This comment makes the linter happy.

--- a/zoo/src/main/resources/log4j.properties
+++ b/zoo/src/main/resources/log4j.properties
@@ -1,8 +1,6 @@
-# Root logger option
-log4j.rootLogger=INFO, stdout
+log4j.rootLogger=INFO, consoleAppender
 
-# Direct log messages to stdout
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.Target=System.out
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+log4j.appender.consoleAppender=org.apache.log4j.ConsoleAppender
+log4j.appender.console.Target=System.out
+log4j.appender.consoleAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.consoleAppender.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/zoo/src/main/resources/log4j2.xml
+++ b/zoo/src/main/resources/log4j2.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{yy-MM-dd HH:mm:ss} [%t] %-5p %c{1}:%L - %msg%n"/>
+        </Console>
+
+        <RollingFile name="RollingFile" filename="log/test.log"
+                     filepattern="log/test-%d{yyMMddHHmmss}.log">
+            <PatternLayout pattern="%d{yy-MM-dd HH:mm:ss} [%t] %-5p %c{1}:%L - %msg%n"/>
+            <Policies>
+                <SizeBasedTriggeringPolicy size="100 MB"/>
+            </Policies>
+            <DefaultRolloverStrategy max="20"/>
+        </RollingFile>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+<!--        <Logger name="com.intel.analytics.zoo.faiss.examples.Examples" level="info"-->
+<!--                additivity="false">-->
+<!--            <AppenderRef ref="Console"/>-->
+<!--            <AppenderRef ref="RollingFile"/>-->
+<!--        </Logger>-->
+    </Loggers>
+</Configuration>

--- a/zoo/src/main/scala/com/intel/analytics/zoo/common/MKLBlas.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/common/MKLBlas.scala
@@ -20,12 +20,12 @@ import com.intel.analytics.bigdl.mkl.{MKL => BMKL}
 import com.intel.analytics.bigdl.tensor.{DoubleType, FloatType, Tensor}
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.zoo.mkl.MKL.{vdErf, vsErf}
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 
 import scala.reflect.ClassTag
 
 private[zoo] object MKLBlas {
-  private val logger = Logger.getLogger(getClass)
+  private val logger = LogManager.getLogger(getClass)
 
   def erf[T: ClassTag](tensor: Tensor[T])
     (implicit ev: TensorNumeric[T]): Unit = {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/common/NNContext.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/common/NNContext.scala
@@ -21,7 +21,7 @@ import java.util.Properties
 
 import com.intel.analytics.bigdl.utils.{Engine, OptimizerV1, OptimizerV2, OptimizerVersion}
 import com.intel.analytics.zoo.pipeline.api.keras.layers.utils.{EngineRef, KerasUtils}
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 import org.apache.spark.{SPARK_VERSION, SparkConf, SparkContext, SparkException}
 import sys.env
 
@@ -31,7 +31,7 @@ import sys.env
  */
 object NNContext {
 
-  private val logger = Logger.getLogger(getClass)
+  private val logger = LogManager.getLogger(getClass)
 
   private[zoo] def checkSparkVersion(reportWarning: Boolean = false) = {
     checkVersion(SPARK_VERSION, ZooBuildInfo.spark_version, "Spark", reportWarning)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/common/PythonInterpreter.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/common/PythonInterpreter.scala
@@ -21,13 +21,13 @@ import com.intel.analytics.zoo.core.TFNetNative
 import com.intel.analytics.zoo.pipeline.api.net.NetUtils
 import jep.{JepConfig, JepException, NamingConventionClassEnquirer, SharedInterpreter}
 import org.apache.commons.lang.exception.ExceptionUtils
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
 
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.Duration
 
 object PythonInterpreter {
-  protected val logger = Logger.getLogger(this.getClass)
+  protected val logger = LogManager.getLogger(this.getClass)
 
   private var threadPool: ExecutorService = null
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/common/Utils.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/common/Utils.scala
@@ -26,7 +26,7 @@ import org.apache.commons.io.filefilter.WildcardFileFilter
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FSDataInputStream, FSDataOutputStream, FileSystem, Path}
 import org.apache.hadoop.io.IOUtils
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 import org.apache.spark.rdd.RDD
 
 import scala.collection.mutable
@@ -34,7 +34,7 @@ import scala.collection.mutable.ArrayBuffer
 
 private[zoo] object Utils {
 
-  private val logger = Logger.getLogger(getClass)
+  private val logger = LogManager.getLogger(getClass)
 
   @inline
   def timeIt[T](name: String)(f: => T): T = {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/common/ZooDictionary.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/common/ZooDictionary.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.zoo.common
 
 import com.intel.analytics.bigdl.dataset.text.Dictionary
 import com.intel.analytics.bigdl.utils.RandomGenerator
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 import org.apache.spark.rdd.RDD
 
 import scala.collection.mutable
@@ -32,7 +32,7 @@ class ZooDictionary() extends Dictionary {
   private var _vocabulary: Seq[String] = null
   private var _discardVocab: Seq[String] = null
   @transient
-  private val logger = Logger.getLogger(getClass)
+  private val logger = LogManager.getLogger(getClass)
   @transient
   private val rng = RandomGenerator.RNG
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/anomalydetection/AnomalyDetection.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/anomalydetection/AnomalyDetection.scala
@@ -22,7 +22,8 @@ import com.intel.analytics.bigdl.utils.Shape
 import com.intel.analytics.zoo.common.NNContext
 import com.intel.analytics.zoo.models.anomalydetection._
 import com.intel.analytics.zoo.pipeline.api.keras.objectives.MeanSquaredError
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import org.apache.spark.SparkConf
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, SQLContext}
@@ -65,7 +66,7 @@ object AnomalyDetection {
   }
 
   def run(param: LocalParams): Unit = {
-    Logger.getLogger("org").setLevel(Level.ERROR)
+    Configurator.setLevel("org", Level.ERROR)
     val conf = new SparkConf()
     conf.setAppName("AnomalyDetectionExample")
     val sc = NNContext.initNNContext(conf)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/chatbot/Train.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/chatbot/Train.scala
@@ -31,21 +31,22 @@ import com.intel.analytics.zoo.common.{NNContext, ZooDictionary}
 import com.intel.analytics.zoo.models.seq2seq._
 import com.intel.analytics.zoo.pipeline.api.keras.layers._
 import com.intel.analytics.zoo.pipeline.api.keras.models.Sequential
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 
 import scala.collection.Iterator
 import scala.io.Source
 import scala.reflect.ClassTag
 
 object Train {
-  Logger.getLogger("org").setLevel(Level.ERROR)
-  Logger.getLogger("akka").setLevel(Level.ERROR)
-  Logger.getLogger("breeze").setLevel(Level.ERROR)
-  Logger.getLogger("com.intel.analytics.zoo").setLevel(Level.INFO)
+  Configurator.setLevel("org", Level.ERROR)
+  Configurator.setLevel("akka", Level.ERROR)
+  Configurator.setLevel("breeze", Level.ERROR)
+  Configurator.setLevel("com.intel.analytics.zoo", Level.INFO)
 
   import Utils._
 
-  val logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
 
   def main(args: Array[String]): Unit = {
     trainParser.parse(args, new TrainParams()).map(param => {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/imageclassification/Predict.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/imageclassification/Predict.scala
@@ -19,18 +19,19 @@ package com.intel.analytics.zoo.examples.imageclassification
 import com.intel.analytics.zoo.common.NNContext
 import com.intel.analytics.zoo.feature.image.ImageSet
 import com.intel.analytics.zoo.models.image.imageclassification.{ImageClassifier, LabelOutput}
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import scopt.OptionParser
 
 
 object Predict {
-  Logger.getLogger("org").setLevel(Level.ERROR)
-  Logger.getLogger("akka").setLevel(Level.ERROR)
-  Logger.getLogger("breeze").setLevel(Level.ERROR)
-  Logger.getLogger("com.intel.analytics.zoo").setLevel(Level.INFO)
-  Logger.getLogger("com.intel.analytics.zoo.feature.image").setLevel(Level.ERROR)
+  Configurator.setLevel("org", Level.ERROR)
+  Configurator.setLevel("akka", Level.ERROR)
+  Configurator.setLevel("breeze", Level.ERROR)
+  Configurator.setLevel("com.intel.analytics.zoo", Level.INFO)
+  Configurator.setLevel("com.intel.analytics.zoo.feature.image", Level.ERROR)
 
-  val logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
 
   case class TopNClassificationParam(imageFolder: String = "",
                                      model: String = "",

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/ImageNet2012.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/inception/ImageNet2012.scala
@@ -28,11 +28,11 @@ import com.intel.analytics.zoo.feature.{DistributedFeatureSet, FeatureSet}
 import com.intel.analytics.zoo.feature.pmem._
 import com.intel.analytics.zoo.pipeline.api.keras.layers.utils.EngineRef
 import org.apache.hadoop.io.Text
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 import org.apache.spark.SparkContext
 
 object ImageNet2012 {
-  val logger = Logger.getLogger(this.getClass)
+  val logger = LogManager.getLogger(this.getClass)
 
   /**
    * Extract hadoop sequence files from an HDFS path
@@ -141,7 +141,7 @@ object ImageNet2012 {
 
 
 object ImageNet2012Val {
-  val logger = Logger.getLogger(this.getClass)
+  val logger = LogManager.getLogger(this.getClass)
 
   def apply(
     path : String,

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/nnframes/imageTransferLearning/ImageTransferLearning.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/nnframes/imageTransferLearning/ImageTransferLearning.scala
@@ -23,7 +23,8 @@ import com.intel.analytics.zoo.pipeline.nnframes._
 import com.intel.analytics.zoo.common.NNContext
 import com.intel.analytics.zoo.feature.image._
 import org.apache.hadoop.fs.Path
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import org.apache.spark.ml.evaluation.MulticlassClassificationEvaluator
 import org.apache.spark.ml.Pipeline
 import org.apache.spark.sql.functions.{col, udf}
@@ -39,7 +40,7 @@ object ImageTransferLearning {
   def main(args: Array[String]): Unit = {
 
     val defaultParams = Utils.LocalParams()
-    Logger.getLogger("org").setLevel(Level.WARN)
+    Configurator.setLevel("org", Level.WARN)
 
     Utils.parser.parse(args, defaultParams).foreach { params =>
       val sc = NNContext.initNNContext()

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/objectdetection/finetune/ssd/Train.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/objectdetection/finetune/ssd/Train.scala
@@ -29,7 +29,8 @@ import com.intel.analytics.zoo.models.image.objectdetection.common.evaluation.Me
 import com.intel.analytics.zoo.models.image.objectdetection.common.loss.{MultiBoxLoss, MultiBoxLossParam}
 import com.intel.analytics.zoo.models.image.objectdetection.ssd.{SSDDataSet, SSDMiniBatch, SSDVGG}
 import com.intel.analytics.zoo.pipeline.estimator.Estimator
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import org.apache.spark.SparkConf
 import scopt.OptionParser
 
@@ -38,8 +39,8 @@ import scala.io.Source
 object Train {
 
   LoggerFilter.redirectSparkInfoLogs()
-  Logger.getLogger("com.intel.analytics.bigdl.optim").setLevel(Level.INFO)
-  Logger.getLogger("com.intel.analytics.zoo").setLevel(Level.INFO)
+  Configurator.setLevel("com.intel.analytics.bigdl.optim", Level.INFO)
+  Configurator.setLevel("com.intel.analytics.zoo", Level.INFO)
 
   case class TrainParams(
     trainFolder: String = "./",
@@ -115,7 +116,7 @@ object Train {
       .action((_, c) => c.copy(overWriteModel = true))
   }
 
-  val logger = Logger.getLogger(getClass.getName)
+  val logger = LogManager.getLogger(getClass.getName)
 
   def main(args: Array[String]): Unit = {
     trainParser.parse(args, TrainParams()).map(param => {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/objectdetection/inference/Predict.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/objectdetection/inference/Predict.scala
@@ -21,19 +21,20 @@ import java.nio.file.Paths
 import com.intel.analytics.zoo.common.{NNContext, Utils}
 import com.intel.analytics.zoo.feature.image.ImageSet
 import com.intel.analytics.zoo.models.image.objectdetection.{ObjectDetector, Visualizer}
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import org.apache.spark.SparkConf
 import org.opencv.imgcodecs.Imgcodecs
 import scopt.OptionParser
 
 object Predict {
-  Logger.getLogger("org").setLevel(Level.ERROR)
-  Logger.getLogger("akka").setLevel(Level.ERROR)
-  Logger.getLogger("breeze").setLevel(Level.ERROR)
-  Logger.getLogger("com.intel.analytics.zoo").setLevel(Level.INFO)
-  Logger.getLogger("com.intel.analytics.zoo.feature.image").setLevel(Level.ERROR)
+  Configurator.setLevel("org", Level.ERROR)
+  Configurator.setLevel("org", Level.ERROR)
+  Configurator.setLevel("breeze", Level.ERROR)
+  Configurator.setLevel("com.intel.analytics.zoo", Level.INFO)
+  Configurator.setLevel("com.intel.analytics.zoo.feature.image", Level.ERROR)
 
-  val logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
 
   case class PredictParam(image: String = "",
     outputFolder: String = "data/demo",

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/recommendation/CensusWideAndDeep.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/recommendation/CensusWideAndDeep.scala
@@ -26,7 +26,8 @@ import com.intel.analytics.zoo.feature.FeatureSet
 import com.intel.analytics.zoo.feature.pmem.{DISK_AND_DRAM, MemoryType}
 import com.intel.analytics.zoo.models.recommendation._
 import com.intel.analytics.zoo.pipeline.estimator.Estimator
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{DataFrame, SQLContext}
@@ -76,7 +77,7 @@ object CensusWideAndDeep {
   case class RecordSample[T: ClassTag](sample: Sample[T])
 
   def run(params: WNDParams): Unit = {
-    Logger.getLogger("org").setLevel(Level.ERROR)
+    Configurator.setLevel("org", Level.ERROR)
 
     val batchSize = params.batchSize
     val maxEpoch = params.maxEpoch

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/recommendation/Ml1mWideAndDeep.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/recommendation/Ml1mWideAndDeep.scala
@@ -21,7 +21,8 @@ import com.intel.analytics.bigdl.optim.{Adam, Top1Accuracy}
 import com.intel.analytics.zoo.common.NNContext
 import com.intel.analytics.zoo.models.recommendation._
 import com.intel.analytics.zoo.pipeline.api.keras.objectives.SparseCategoricalCrossEntropy
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import org.apache.spark.SparkConf
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{DataFrame, SQLContext}
@@ -34,7 +35,7 @@ case class Item(itemId: Int, title: String, genres: String)
 object Ml1mWideAndDeep {
 
   def run(params: WNDParams): Unit = {
-    Logger.getLogger("org").setLevel(Level.ERROR)
+    Configurator.setLevel("org", Level.ERROR)
     val conf = new SparkConf().setAppName("WideAndDeepExample")
     val sc = NNContext.initNNContext(conf)
     val sqlContext = SQLContext.getOrCreate(sc)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/recommendation/NeuralCFexample.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/recommendation/NeuralCFexample.scala
@@ -24,7 +24,8 @@ import com.intel.analytics.bigdl.utils.T
 import com.intel.analytics.zoo.common.NNContext
 import com.intel.analytics.zoo.models.recommendation.{NeuralCF, UserItemFeature, Utils}
 import com.intel.analytics.zoo.pipeline.api.keras.objectives.SparseCategoricalCrossEntropy
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import org.apache.spark.SparkConf
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, SQLContext}
@@ -70,7 +71,7 @@ object NeuralCFexample {
   }
 
   def run(param: NeuralCFParams): Unit = {
-    Logger.getLogger("org").setLevel(Level.ERROR)
+    Configurator.setLevel("org", Level.ERROR)
     val conf = new SparkConf()
     conf.setAppName("NCFExample").set("spark.sql.crossJoin.enabled", "true")
     val sc = NNContext.initNNContext(conf)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/recommendation/SessionRecExp.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/recommendation/SessionRecExp.scala
@@ -22,7 +22,8 @@ import com.intel.analytics.zoo.common.NNContext
 import com.intel.analytics.bigdl.numeric.NumericFloat
 import com.intel.analytics.zoo.models.recommendation.SessionRecommender
 import com.intel.analytics.zoo.pipeline.api.keras.objectives.SparseCategoricalCrossEntropy
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import org.apache.spark.SparkConf
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.functions._
@@ -74,7 +75,7 @@ object SessionRecExp {
   }
 
   def run(params: SessionParams): Unit = {
-    Logger.getLogger("org").setLevel(Level.ERROR)
+    Configurator.setLevel("org", Level.ERROR)
     val conf = new SparkConf().setAppName("SessionRecExp")
     val sc = NNContext.initNNContext(conf)
     val sqlContext = SQLContext.getOrCreate(sc)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/resnet/TrainImageNet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/resnet/TrainImageNet.scala
@@ -30,13 +30,14 @@ import com.intel.analytics.zoo.examples.resnet.Utils._
 import com.intel.analytics.zoo.feature.pmem.{DIRECT, DRAM, MemoryType, PMEM}
 import com.intel.analytics.zoo.pipeline.api.keras.layers.utils.EngineRef
 import com.intel.analytics.zoo.pipeline.estimator.Estimator
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import org.apache.spark.SparkConf
 
 object TrainImageNet {
   LoggerFilter.redirectSparkInfoLogs()
-  Logger.getLogger("com.intel.analytics.bigdl.optim").setLevel(Level.INFO)
-  val logger = Logger.getLogger(getClass)
+  Configurator.setLevel("com.intel.analytics.bigdl.optim", Level.INFO)
+  val logger = LogManager.getLogger(getClass)
 
   def imageNetDecay(epoch: Int): Double = {
     if (epoch >= 80) {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/serving/ClusterServingFlinkSqlExample.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/serving/ClusterServingFlinkSqlExample.scala
@@ -19,7 +19,8 @@ package com.intel.analytics.zoo.examples.serving
 
 import com.intel.analytics.zoo.serving.operator.ClusterServingFunction
 import org.apache.flink.table.api.{EnvironmentSettings, TableEnvironment}
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import scopt.OptionParser
 
 object ClusterServingFlinkSqlExample {
@@ -35,7 +36,7 @@ object ClusterServingFlinkSqlExample {
       .action((x, params) => params.copy(inputFile = x))
       .required()
   }
-  Logger.getLogger("org").setLevel(Level.ERROR)
+  Configurator.setLevel("org", Level.ERROR)
 
   def main(args: Array[String]): Unit = {
     val arg = parser.parse(args, ExampleParams()).head

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/serving/ClusterServingInferenceBlockOthersExample.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/serving/ClusterServingInferenceBlockOthersExample.scala
@@ -21,7 +21,8 @@ import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.functions.sink.{RichSinkFunction, SinkFunction}
 import org.apache.flink.streaming.api.functions.source.{RichParallelSourceFunction, SourceFunction}
 import org.apache.flink.streaming.api.scala.{StreamExecutionEnvironment, _}
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 
 object ClusterServingInferenceBlockOthersExample {
   class MySource extends RichParallelSourceFunction[String] {
@@ -78,7 +79,7 @@ object ClusterServingInferenceBlockOthersExample {
       println(s"value $value written to sink.")
     }
   }
-  Logger.getLogger("org").setLevel(Level.ERROR)
+  Configurator.setLevel("org", Level.ERROR)
   def main(args: Array[String]): Unit = {
     val serving = StreamExecutionEnvironment.getExecutionEnvironment
     serving.addSource(new MySource())

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/serving/ClusterServingOperatorUsageExample.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/serving/ClusterServingOperatorUsageExample.scala
@@ -23,7 +23,8 @@ import com.intel.analytics.zoo.serving.utils.Conventions
 import org.apache.flink.streaming.api.functions.sink.{RichSinkFunction, SinkFunction}
 import org.apache.flink.streaming.api.functions.source.{RichParallelSourceFunction, SourceFunction}
 import org.apache.flink.streaming.api.scala.{StreamExecutionEnvironment, _}
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import scopt.OptionParser
 
 object ClusterServingOperatorUsageExample {
@@ -34,7 +35,7 @@ object ClusterServingOperatorUsageExample {
       .action((x, params) => params.copy(modelPath = x))
       .required()
   }
-  Logger.getLogger("org").setLevel(Level.ERROR)
+  Configurator.setLevel("org", Level.ERROR)
   def main(args: Array[String]): Unit = {
     val arg = parser.parse(args, ExampleParams()).head
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/streaming/objectdetection/ImagePathWriter.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/streaming/objectdetection/ImagePathWriter.scala
@@ -18,7 +18,8 @@ package com.intel.analytics.zoo.examples.streaming.objectdetection
 
 import com.intel.analytics.zoo.common.Utils
 import org.apache.hadoop.fs.Path
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import scopt.OptionParser
 
 /*
@@ -27,9 +28,9 @@ import scopt.OptionParser
 object ImagePathWriter {
 
   def main(args: Array[String]): Unit = {
-    Logger.getLogger("org").setLevel(Level.WARN)
+    Configurator.setLevel("org", Level.WARN)
 
-    val logger = Logger.getLogger(getClass)
+    val logger = LogManager.getLogger(getClass)
 
     parser.parse(args, PathWriterParam()).foreach { params =>
       val fs = Utils.getFileSystem(params.imageSourcePath)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/streaming/objectdetection/StreamingInferenceObjectDetection.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/streaming/objectdetection/StreamingInferenceObjectDetection.scala
@@ -26,19 +26,20 @@ import com.intel.analytics.zoo.models.image.objectdetection.{LabelReader, ScaleD
 import com.intel.analytics.zoo.pipeline.inference.InferenceModel
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import org.apache.spark.streaming.{Seconds, StreamingContext}
 import org.opencv.imgcodecs.Imgcodecs
 import scopt.OptionParser
 
 object StreamingInferenceObjectDetection {
-  Logger.getLogger("org").setLevel(Level.ERROR)
-  Logger.getLogger("akka").setLevel(Level.ERROR)
-  Logger.getLogger("breeze").setLevel(Level.ERROR)
-  Logger.getLogger("com.intel.analytics.zoo").setLevel(Level.INFO)
-  Logger.getLogger("com.intel.analytics.zoo.feature.image").setLevel(Level.ERROR)
+  Configurator.setLevel("org", Level.ERROR)
+  Configurator.setLevel("akka", Level.ERROR)
+  Configurator.setLevel("breeze", Level.ERROR)
+  Configurator.setLevel("com.intel.analytics.zoo", Level.INFO)
+  Configurator.setLevel("com.intel.analytics.zoo.feature.image", Level.ERROR)
 
-  val logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
 
 
   val parser = new OptionParser[PredictParam]("Analytics Zoo Streaming Object Detection") {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/streaming/objectdetection/StreamingObjectDetection.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/streaming/objectdetection/StreamingObjectDetection.scala
@@ -22,19 +22,20 @@ import com.intel.analytics.zoo.common.{NNContext, Utils}
 import com.intel.analytics.zoo.feature.image.{ImageBytesToMat, ImageSet}
 import com.intel.analytics.zoo.models.image.objectdetection.{ObjectDetector, Visualizer}
 import org.apache.hadoop.fs.Path
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import org.apache.spark.streaming.{Seconds, StreamingContext}
 import org.opencv.imgcodecs.Imgcodecs
 import scopt.OptionParser
 
 object StreamingObjectDetection {
-  Logger.getLogger("org").setLevel(Level.ERROR)
-  Logger.getLogger("akka").setLevel(Level.ERROR)
-  Logger.getLogger("breeze").setLevel(Level.ERROR)
-  Logger.getLogger("com.intel.analytics.zoo").setLevel(Level.INFO)
-  Logger.getLogger("com.intel.analytics.zoo.feature.image").setLevel(Level.ERROR)
+  Configurator.setLevel("org", Level.ERROR)
+  Configurator.setLevel("akka", Level.ERROR)
+  Configurator.setLevel("breeze", Level.ERROR)
+  Configurator.setLevel("com.intel.analytics.zoo", Level.INFO)
+  Configurator.setLevel("com.intel.analytics.zoo.feature.image", Level.ERROR)
 
-  val logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
 
   case class PredictParam(streamingPath: String = "file:///tmp/zoo/streaming",
                           outputFolder: String = "file:///tmp/zoo/output",

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/tensorflow/tfnet/Predict.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/tensorflow/tfnet/Predict.scala
@@ -21,18 +21,19 @@ import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric.NumericF
 import com.intel.analytics.zoo.common.NNContext
 import com.intel.analytics.zoo.feature.image.{ImageMatToTensor, ImageResize, ImageSet, ImageSetToSample}
 import com.intel.analytics.zoo.pipeline.api.net.TFNet
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import scopt.OptionParser
 
 
 object Predict {
-  Logger.getLogger("org").setLevel(Level.ERROR)
-  Logger.getLogger("akka").setLevel(Level.ERROR)
-  Logger.getLogger("breeze").setLevel(Level.ERROR)
-  Logger.getLogger("com.intel.analytics.zoo").setLevel(Level.INFO)
-  Logger.getLogger("com.intel.analytics.zoo.feature.image").setLevel(Level.ERROR)
+  Configurator.setLevel("org", Level.ERROR)
+  Configurator.setLevel("akka", Level.ERROR)
+  Configurator.setLevel("akka", Level.ERROR)
+  Configurator.setLevel("com.intel.analytics.zoo", Level.INFO)
+  Configurator.setLevel("com.intel.analytics.zoo.feature.image", Level.ERROR)
 
-  val logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
 
   case class PredictParam(image: String = "/tmp/datasets/cat_dog/train_sampled",
                           model: String = "/tmp/models/ssd_mobilenet_v1_coco_2018_01_28" +

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/textclassification/TextClassification.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/textclassification/TextClassification.scala
@@ -23,7 +23,8 @@ import com.intel.analytics.zoo.feature.text.TextSet
 import com.intel.analytics.zoo.models.textclassification.TextClassifier
 import com.intel.analytics.zoo.pipeline.api.keras.metrics.Accuracy
 import com.intel.analytics.zoo.pipeline.api.keras.objectives.SparseCategoricalCrossEntropy
-import org.apache.log4j.{Level => Level4j, Logger => Logger4j}
+import org.apache.logging.log4j.{LogManager => Logger4j, Level => Level4j}
+import org.apache.logging.log4j.core.config.Configurator
 import scopt.OptionParser
 
 
@@ -39,7 +40,7 @@ case class TextClassificationParams(
 
 
 object TextClassification {
-  Logger4j.getLogger("com.intel.analytics.bigdl.optim").setLevel(Level4j.INFO)
+  Configurator.setLevel("com.intel.analytics.bigdl.optim", Level4j.INFO)
 
   def main(args: Array[String]): Unit = {
     val parser = new OptionParser[TextClassificationParams]("TextClassification Example") {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/ImageNetEvaluation.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/ImageNetEvaluation.scala
@@ -22,7 +22,8 @@ import com.intel.analytics.bigdl.utils.LoggerFilter
 import com.intel.analytics.zoo.common.NNContext
 import com.intel.analytics.zoo.feature.image.ImageSet
 import com.intel.analytics.zoo.models.image.imageclassification.ImageClassifier
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import scopt.OptionParser
 
 case class ImageNetEvaluationParams(folder: String = "./",
@@ -31,10 +32,10 @@ case class ImageNetEvaluationParams(folder: String = "./",
 
 object ImageNetEvaluation {
   LoggerFilter.redirectSparkInfoLogs()
-  Logger.getLogger("com.intel.analytics.bigdl.optim").setLevel(Level.INFO)
-  Logger.getLogger("com.intel.analytics.bigdl.transform.vision").setLevel(Level.ERROR)
+  Configurator.setLevel("com.intel.analytics.bigdl.optim", Level.INFO)
+  Configurator.setLevel("com.intel.analytics.bigdl.transform.vision", Level.ERROR)
 
-  val logger: Logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
 
   def main(args: Array[String]): Unit = {
     System.setProperty("bigdl.engineType", "mkldnn")

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Perf.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Perf.scala
@@ -20,7 +20,7 @@ import com.intel.analytics.bigdl.numeric.NumericFloat
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Engine
 import com.intel.analytics.zoo.models.image.imageclassification.ImageClassifier
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 import scopt.OptionParser
 
 case class PerfParams(model: String = "",
@@ -29,7 +29,7 @@ case class PerfParams(model: String = "",
 
 object Perf {
 
-  val logger: Logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
 
   def main(args: Array[String]): Unit = {
     System.setProperty("bigdl.localMode", "true")

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Predict.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/bigdl/Predict.scala
@@ -19,7 +19,8 @@ package com.intel.analytics.zoo.examples.vnni.bigdl
 import com.intel.analytics.zoo.common.NNContext
 import com.intel.analytics.zoo.feature.image.ImageSet
 import com.intel.analytics.zoo.models.image.imageclassification.{ImageClassifier, LabelOutput}
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import org.opencv.imgcodecs.Imgcodecs
 import scopt.OptionParser
 
@@ -28,10 +29,10 @@ case class PredictParams(folder: String = "./",
                          topN: Int = 5)
 
 object Predict {
-  Logger.getLogger("com.intel.analytics.bigdl.transform.vision").setLevel(Level.ERROR)
-  Logger.getLogger("com.intel.analytics.zoo.feature.image").setLevel(Level.ERROR)
+  Configurator.setLevel("com.intel.analytics.bigdl.transform.vision", Level.ERROR)
+  Configurator.setLevel("com.intel.analytics.zoo.feature.image", Level.ERROR)
 
-  val logger: Logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
 
   def main(args: Array[String]): Unit = {
     System.setProperty("bigdl.engineType", "mkldnn")

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/openvino/ImageNetEvaluation.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/openvino/ImageNetEvaluation.scala
@@ -23,7 +23,8 @@ import com.intel.analytics.bigdl.numeric.NumericFloat
 import com.intel.analytics.bigdl.optim.{Top1Accuracy, Top5Accuracy}
 import com.intel.analytics.zoo.feature.image.{ImageCenterCrop, ImageMatToTensor, ImageResize, ImageSet, ImageSetToSample}
 import com.intel.analytics.zoo.pipeline.inference.InferenceModel
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import scopt.OptionParser
 
 
@@ -35,13 +36,13 @@ case class ImageNetEvaluationParams(folder: String = "./",
 
 object ImageNetEvaluation {
   LoggerFilter.redirectSparkInfoLogs()
-  Logger.getLogger("org").setLevel(Level.ERROR)
-  Logger.getLogger("akka").setLevel(Level.ERROR)
-  Logger.getLogger("breeze").setLevel(Level.ERROR)
-  Logger.getLogger("com.intel.analytics.zoo.feature.image").setLevel(Level.ERROR)
-  Logger.getLogger("com.intel.analytics.zoo").setLevel(Level.INFO)
+  Configurator.setLevel("org", Level.ERROR)
+  Configurator.setLevel("akka", Level.ERROR)
+  Configurator.setLevel("breeze", Level.ERROR)
+  Configurator.setLevel("com.intel.analytics.zoo.feature.image", Level.ERROR)
+  Configurator.setLevel("com.intel.analytics.zoo", Level.INFO)
 
-  val logger: Logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
 
   def main(args: Array[String]): Unit = {
     val parser = new OptionParser[ImageNetEvaluationParams]("ImageNet Int8 Example") {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/openvino/Perf.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/openvino/Perf.scala
@@ -20,7 +20,7 @@ import com.intel.analytics.bigdl.numeric.NumericFloat
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.utils.Engine
 import com.intel.analytics.zoo.pipeline.inference.InferenceModel
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 import scopt.OptionParser
 
 
@@ -33,7 +33,7 @@ case class ResNet50PerfParams(model: String = "",
 
 object Perf {
 
-  val logger: Logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
 
   def main(args: Array[String]): Unit = {
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/openvino/Predict.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/examples/vnni/openvino/Predict.scala
@@ -24,7 +24,8 @@ import com.intel.analytics.zoo.common.NNContext
 import com.intel.analytics.zoo.feature.image.{ImageCenterCrop, ImageMatToTensor, ImageResize, ImageSet, ImageSetToSample}
 import com.intel.analytics.zoo.models.image.imageclassification.{LabelOutput, LabelReader}
 import com.intel.analytics.zoo.pipeline.inference.InferenceModel
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import org.opencv.imgcodecs.Imgcodecs
 import scopt.OptionParser
 
@@ -36,13 +37,13 @@ case class PredictParams(folder: String = "./",
                          partitionNum: Int = 4)
 
 object Predict {
-  Logger.getLogger("org").setLevel(Level.ERROR)
-  Logger.getLogger("akka").setLevel(Level.ERROR)
-  Logger.getLogger("breeze").setLevel(Level.ERROR)
-  Logger.getLogger("com.intel.analytics.zoo.feature.image").setLevel(Level.ERROR)
-  Logger.getLogger("com.intel.analytics.zoo").setLevel(Level.INFO)
+  Configurator.setLevel("org", Level.ERROR)
+  Configurator.setLevel("akka", Level.ERROR)
+  Configurator.setLevel("breeze", Level.ERROR)
+  Configurator.setLevel("com.intel.analytics.zoo.feature.image", Level.ERROR)
+  Configurator.setLevel("com.intel.analytics.zoo", Level.INFO)
 
-  val logger: Logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
 
   def main(args: Array[String]): Unit = {
     val parser = new OptionParser[PredictParams]("ResNet50 Int8 Inference Example") {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/FeatureSet.scala
@@ -646,7 +646,7 @@ object DRAMFeatureSet {
 }
 
 object FeatureSet {
-  val logger: Logger = LoggerFactory.getLogger(this.getClass)
+  val logger = LoggerFactory.getLogger(this.getClass)
   private[zoo] def python[T: ClassTag](
       dataset: Array[Byte],
       getLoader: (Int, Int, String) => String,

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageBytesToMat.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageBytesToMat.scala
@@ -15,7 +15,7 @@
  */
 package com.intel.analytics.zoo.feature.image
 
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
 import com.intel.analytics.bigdl.transform.vision.image.opencv.OpenCVMat
 import org.opencv.imgcodecs.Imgcodecs
@@ -39,7 +39,7 @@ class ImageBytesToMat(byteKey: String = ImageFeature.bytes,
 }
 
 object ImageBytesToMat {
-  val logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
 
   def apply(byteKey: String = ImageFeature.bytes,
             imageCodec: Int = Imgcodecs.CV_LOAD_IMAGE_UNCHANGED): ImageBytesToMat =

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImagePixelBytesToMat.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImagePixelBytesToMat.scala
@@ -16,7 +16,7 @@
 package com.intel.analytics.zoo.feature.image
 
 import com.intel.analytics.bigdl.transform.vision.image.{ImageFeature, PixelBytesToMat, augmentation}
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 
 /**
  * Transform byte array(pixels in byte) to OpenCVMat
@@ -37,7 +37,7 @@ class ImagePixelBytesToMat(
 }
 
 object ImagePixelBytesToMat {
-  val logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
   def apply(byteKey: String = ImageFeature.bytes): ImagePixelBytesToMat = {
     new ImagePixelBytesToMat(byteKey)
   }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageSetToSample.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/image/ImageSetToSample.scala
@@ -19,7 +19,7 @@ import com.intel.analytics.bigdl.dataset.ArraySample
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 
 import scala.reflect.ClassTag
 
@@ -84,7 +84,7 @@ class ImageSetToSample[T: ClassTag](inputKeys: Array[String] = Array(ImageFeatur
 }
 
 object ImageSetToSample {
-  val logger: Logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
 
   def apply[T: ClassTag](inputKeys: Array[String] = Array(ImageFeature.imageTensor),
             targetKeys: Array[String] = Array(ImageFeature.label),

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/image3d/ImageFeature3D.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/image3d/ImageFeature3D.scala
@@ -19,7 +19,7 @@ package com.intel.analytics.zoo.feature.image3d
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
 import com.intel.analytics.bigdl.transform.vision.image.ImageFeature.getClass
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 
 
 /**
@@ -101,6 +101,6 @@ object ImageFeature3D {
 
   def apply(): ImageFeature3D = new ImageFeature3D()
 
-  val logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
 }
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/image3d/ImageProcessing3D.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/image3d/ImageProcessing3D.scala
@@ -19,7 +19,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.transform.vision.image.FeatureTransformer._
 import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
 import com.intel.analytics.zoo.feature.image.{ImageProcessing, ImageSet}
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 
 private[zoo] abstract class ImageProcessing3D extends ImageProcessing {
 
@@ -92,5 +92,5 @@ private[zoo] abstract class ImageProcessing3D extends ImageProcessing {
 }
 
 object ImageProcessing3D {
-  val logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextFeature.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextFeature.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.zoo.feature.text
 
 import com.intel.analytics.bigdl.dataset.Sample
 import com.intel.analytics.bigdl.tensor.Tensor
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 
 import scala.collection.{Set, mutable}
 import scala.reflect.ClassTag
@@ -172,7 +172,7 @@ object TextFeature {
    */
   val predict = "predict"
 
-  val logger: Logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
 
   /**
    * Create a TextFeature without label.

--- a/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextSet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/feature/text/TextSet.scala
@@ -26,7 +26,7 @@ import com.intel.analytics.zoo.feature.text.TruncMode.TruncMode
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.util.StringUtils
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
@@ -246,7 +246,7 @@ abstract class TextSet {
 
 object TextSet {
 
-  val logger: Logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
 
   /**
    * Create a LocalTextSet from array of TextFeature.

--- a/zoo/src/main/scala/com/intel/analytics/zoo/grpc/utils/Utils.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/grpc/utils/Utils.scala
@@ -28,7 +28,7 @@ import org.slf4j.{Logger, LoggerFactory}
 import scala.collection.JavaConverters._
 
 object Utils {
-  val logger: Logger = LoggerFactory.getLogger(getClass)
+  val logger = LoggerFactory.getLogger(getClass)
 
   def timing[T](name: String)(timers: Timer*)(f: => T): T = {
     val begin = System.nanoTime()

--- a/zoo/src/main/scala/com/intel/analytics/zoo/grpc/utils/gRPCHelper.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/grpc/utils/gRPCHelper.scala
@@ -75,7 +75,7 @@ class gRPCHelper extends Serializable {
   var itemFeatureColArr: Array[String] = _
   var inferenceColArr: Array[String] = _
 
-  val logger: Logger = LoggerFactory.getLogger(getClass)
+  val logger = LoggerFactory.getLogger(getClass)
 
   def parseConfigStrings(): Unit = {
     redisHost = redisUrl.split(":").head.trim

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/caffe/CaffeLoader.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/caffe/CaffeLoader.scala
@@ -29,7 +29,7 @@ import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.{Node, Table}
 import com.intel.analytics.bigdl.utils.caffe.{CaffeConversionException, LayerConverter, V1LayerConverter}
 import com.intel.analytics.zoo.utils.FileReader
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 
 import scala.collection.JavaConverters._
 import scala.collection.mutable
@@ -65,7 +65,7 @@ class CaffeLoader[T: ClassTag](prototxtPath: String, modelPath: String,
                                customizedConverters: mutable.HashMap[String, Customizable[T]] = null
                               )(implicit ev: TensorNumeric[T]) {
 
-  private val logger = Logger.getLogger(getClass)
+  private val logger = LogManager.getLogger(getClass)
 
   private var netparam: Caffe.NetParameter = _
   private var name2LayerV1: Map[String, V1LayerParameter] = Map[String, V1LayerParameter]()

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/common/Ranker.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/common/Ranker.scala
@@ -21,7 +21,7 @@ import com.intel.analytics.bigdl.nn.abstractnn.{AbstractModule, Activity}
 import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.zoo.feature.text.{DistributedTextSet, LocalTextSet, TextSet}
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 
 import scala.reflect.ClassTag
 import scala.util.Random
@@ -108,7 +108,7 @@ trait Ranker[T] {
 
 object Ranker {
 
-  val logger: Logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
 
   def ndcg[@specialized(Float, Double) T: ClassTag](
       k: Int, threshold: Double = 0.0)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/image/common/ImageConfigure.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/image/common/ImageConfigure.scala
@@ -22,7 +22,7 @@ import com.intel.analytics.bigdl.transform.vision.image.{ImageFeature}
 import com.intel.analytics.zoo.feature.common.{Preprocessing}
 import com.intel.analytics.zoo.models.image.objectdetection.ObjectDetectionConfig
 import com.intel.analytics.zoo.models.image.imageclassification.ImageClassificationConfig
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 
 import scala.reflect.ClassTag
 
@@ -44,7 +44,7 @@ case class ImageConfigure[T: ClassTag](
 }
 
 object ImageConfigure {
-  val logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
 
   val splitter = "_"
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/image/common/ImageModel.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/image/common/ImageModel.scala
@@ -25,7 +25,7 @@ import com.intel.analytics.zoo.models.common.ZooModel
 import com.intel.analytics.zoo.models.image.imageclassification.ImageClassifier
 import com.intel.analytics.zoo.models.image.objectdetection.ObjectDetector
 import com.intel.analytics.zoo.pipeline.api.keras.layers.utils.MklInt8ConvertibleRef
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 
 import scala.reflect.ClassTag
 
@@ -115,7 +115,7 @@ abstract class ImageModel[T: ClassTag]()(implicit ev: TensorNumeric[T])
 
 object ImageModel {
 
-  val logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
   /**
    * Load an pre-trained image model (with weights).
    *

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/image/objectdetection/common/BboxUtil.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/image/objectdetection/common/BboxUtil.scala
@@ -20,7 +20,7 @@ import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.tensor.{Storage, Tensor}
 import com.intel.analytics.bigdl.transform.vision.image.label.roi.RoiLabel
 import com.intel.analytics.bigdl.transform.vision.image.util.BoundingBox
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 
 import scala.reflect.ClassTag
 
@@ -502,7 +502,7 @@ object BboxUtil {
     //    indices.map(x => x._1 -> result.narrow(1, x._2._1, x._2._2))
   }
 
-  val logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
 
   /**
    * Note that the output are stored in input deltas

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/image/objectdetection/common/ModuleUtil.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/image/objectdetection/common/ModuleUtil.scala
@@ -24,13 +24,13 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.Table
 
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 
 import scala.reflect.ClassTag
 
 object ModuleUtil {
 
-  private val logger = Logger.getLogger(getClass)
+  private val logger = LogManager.getLogger(getClass)
   val shareFinput = Tensor[Float](1)
 
   /**

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/image/objectdetection/common/dataset/Coco.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/image/objectdetection/common/dataset/Coco.scala
@@ -24,7 +24,7 @@ import com.intel.analytics.bigdl.transform.vision.image.ImageFeature
 import com.intel.analytics.bigdl.transform.vision.image.label.roi.RoiLabel
 import com.intel.analytics.zoo.feature.image.{ImageSet, LocalImageSet}
 import org.apache.commons.io.FileUtils
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 
 import scala.collection.mutable.ArrayBuffer
 import scala.io.Source
@@ -53,7 +53,7 @@ class Coco(val imageSet: String, devkitPath: String) extends Imdb {
 
 object Coco {
 
-  val logger = Logger.getLogger(getClass.getName)
+  val logger = LogManager.getLogger(getClass.getName)
 
   // original coco category id and corresponding class names
   val cocoCatIdAndClassName = Array(

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/image/objectdetection/common/evaluation/PascalVocEvaluator.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/image/objectdetection/common/evaluation/PascalVocEvaluator.scala
@@ -21,7 +21,7 @@ import com.intel.analytics.bigdl.transform.vision.image.label.roi.RoiLabel
 import com.intel.analytics.zoo.models.image.objectdetection.common.BboxUtil
 import com.intel.analytics.zoo.models.image.objectdetection.common.dataset.PascalVoc._
 import org.apache.commons.lang3.SerializationUtils
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 
 import scala.collection.mutable.ArrayBuffer
 
@@ -95,7 +95,7 @@ class PascalVocEvaluator(imageSet: String) extends DetectionEvaluator {
 }
 
 object PascalVocEvaluator {
-  val logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
 
   def meanAveragePrecision(results: Array[(Int, Array[(Float, Int, Int)])],
     use07metric: Boolean, classes: Array[String]): ArrayBuffer[(String, Float)] = {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/image/objectdetection/common/loss/MultiBoxLoss.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/image/objectdetection/common/loss/MultiBoxLoss.scala
@@ -22,7 +22,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.utils.Table
 import com.intel.analytics.zoo.models.image.objectdetection.common.BboxUtil
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
@@ -616,7 +616,7 @@ class MultiBoxLoss[T: ClassTag](param: MultiBoxLossParam)
 }
 
 object MultiBoxLoss {
-  val logger = Logger.getLogger(getClass.getName)
+  val logger = LogManager.getLogger(getClass.getName)
   def apply[@specialized(Float, Double) T: ClassTag](param: MultiBoxLossParam)
     (implicit ev: TensorNumeric[T]): MultiBoxLoss[T] = new MultiBoxLoss[T](param)
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/models/image/objectdetection/ssd/SSDGraph.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/models/image/objectdetection/ssd/SSDGraph.scala
@@ -26,7 +26,7 @@ import com.intel.analytics.bigdl.tensor.Storage
 import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.zoo.models.image.objectdetection.common.ModuleUtil
 import com.intel.analytics.bigdl.nn.DetectionOutputSSD
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 
 import scala.reflect.ClassTag
 
@@ -216,5 +216,5 @@ object SSDGraph {
       .setName(s"${ name }_mbox_priorbox").inputs(conv)
   }
 
-  private val logger = Logger.getLogger(getClass)
+  private val logger = LogManager.getLogger(getClass)
 }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/Net.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/Net.scala
@@ -39,7 +39,7 @@ import com.intel.analytics.zoo.pipeline.api.keras.layers.utils.KerasUtils
 import com.intel.analytics.zoo.pipeline.api.keras.models.{KerasNet, Model, Sequential}
 import com.intel.analytics.zoo.pipeline.api.net.{GraphNet, NetUtils}
 import org.apache.commons.io.FileUtils
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 import org.apache.spark.bigdl.api.python.BigDLSerDe
 import org.apache.zookeeper.KeeperException.UnimplementedException
 
@@ -275,7 +275,7 @@ object Net {
   }
 
   protected object NetSaver {
-    private val logger = Logger.getLogger(getClass)
+    private val logger = LogManager.getLogger(getClass)
 
     protected val header =
       """

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/BERT.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/layers/BERT.scala
@@ -30,7 +30,7 @@ import com.intel.analytics.zoo.pipeline.api.autograd.{AutoGrad, Variable}
 import com.intel.analytics.zoo.pipeline.api.keras.layers.utils.{GraphRef, KerasUtils}
 import com.intel.analytics.zoo.pipeline.api.keras.models.Model
 import com.intel.analytics.zoo.pipeline.api.keras.models.Model.{apply => _, _}
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
@@ -113,7 +113,7 @@ object BERT extends KerasLayerSerializable {
     "com.intel.analytics.zoo.pipeline.api.keras.layers.BERT",
     BERT)
 
-  private val logger = Logger.getLogger(getClass)
+  private val logger = LogManager.getLogger(getClass)
 
   /**
    * [[BERT]] A self attention keras like layer

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/keras/models/Topology.scala
@@ -55,7 +55,7 @@ import org.apache.commons.lang.exception.ExceptionUtils
 import org.apache.commons.lang3.SerializationUtils
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 import org.apache.spark.{SparkContext, TaskContext}
 import org.apache.spark.rdd.{RDD, ZippedPartitionsWithLocalityRDD}
 
@@ -1708,7 +1708,7 @@ private[zoo] class InternalDistriOptimizerV2[T: ClassTag] (
 }
 
 object InternalDistriOptimizer {
-  val logger = Logger.getLogger(this.getClass)
+  val logger = LogManager.getLogger(this.getClass)
 
   protected def validate[T](validationFeatureSet: FeatureSet[MiniBatch[T]],
                             validationMethods: Array[ValidationMethod[T]],
@@ -1862,7 +1862,7 @@ object InternalDistriOptimizer {
 }
 
 object InternalDistriOptimizerV2 {
-  val logger = Logger.getLogger(this.getClass)
+  val logger = LogManager.getLogger(this.getClass)
 
   protected def validate[T](validationFeatureSet: FeatureSet[MiniBatch[T]],
                             validationMethods: Array[ValidationMethod[T]],

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/python/PythonZooNet.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/api/net/python/PythonZooNet.scala
@@ -26,7 +26,7 @@ import com.intel.analytics.bigdl.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.zoo.common.PythonZoo
 import com.intel.analytics.zoo.pipeline.api.Net
 import com.intel.analytics.zoo.pipeline.api.net._
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
 
 import scala.collection.JavaConverters._
 import scala.reflect.ClassTag

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/estimator/Estimator.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/estimator/Estimator.scala
@@ -24,7 +24,7 @@ import com.intel.analytics.bigdl.visualization.{TrainSummary, ValidationSummary}
 import com.intel.analytics.zoo.feature.{DiskFeatureSet, DistributedFeatureSet, FeatureSet}
 import com.intel.analytics.zoo.pipeline.api.keras.models.{InternalDistriOptimizer, InternalDistriOptimizerV2}
 import com.intel.analytics.zoo.pipeline.api.keras.layers.utils.EngineRef
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 
 import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
@@ -228,7 +228,7 @@ class Estimator[T: ClassTag] private[zoo](
 }
 
 object Estimator {
-  val logger = Logger.getLogger(this.getClass)
+  val logger = LogManager.getLogger(this.getClass)
   /**
    * Create an estimator
    * @param model model

--- a/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimator.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/pipeline/nnframes/NNEstimator.scala
@@ -35,7 +35,7 @@ import com.intel.analytics.zoo.pipeline.api.Net
 import com.intel.analytics.zoo.pipeline.api.keras.layers.utils.EngineRef
 import com.intel.analytics.zoo.pipeline.api.keras.models.InternalDistriOptimizer
 import org.apache.hadoop.fs.Path
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 import org.apache.spark.SparkContext
 import org.apache.spark.ml.adapter.{HasFeaturesCol, HasPredictionCol, SchemaUtils}
 import org.apache.spark.ml.param._
@@ -683,7 +683,7 @@ class NNModel[T: ClassTag] private[zoo](
     with HasBatchSize with MLWritable {
 
   @transient
-  private val logger = Logger.getLogger(getClass)
+  private val logger = LogManager.getLogger(getClass)
 
   setDefault(this.batchSize, EngineRef.getCoreNumber() * EngineRef.getNodeNumber() * 4)
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/ClusterServing.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/ClusterServing.scala
@@ -23,7 +23,7 @@ import com.intel.analytics.zoo.serving.engine.{FlinkInference, FlinkRedisSink, F
 import com.intel.analytics.zoo.serving.pipeline.RedisUtils
 import com.intel.analytics.zoo.serving.utils.{ClusterServingHelper, ConfigParser, Conventions, DeprecatedUtils}
 import org.apache.flink.streaming.api.scala.{StreamExecutionEnvironment, _}
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
 import redis.clients.jedis.{JedisPool, JedisPoolConfig}
 import scopt.OptionParser
 
@@ -31,7 +31,7 @@ import scopt.OptionParser
 object ClusterServing {
   case class ServingParams(configPath: String = "config.yaml",
                            timerMode: Boolean = false)
-  val logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
   var argv: ServingParams = _
   var helper: ClusterServingHelper = _
   var streamingEnv: StreamExecutionEnvironment = _
@@ -59,7 +59,7 @@ object ClusterServing {
      * Flink environment parallelism depends on model parallelism
      */
     // Uncomment this line if you need to check predict time in debug
-    // Logger.getLogger("com.intel.analytics.zoo").setLevel(Level.DEBUG)
+    // LogManager.getLogger("com.intel.analytics.zoo").setLevel(Level.DEBUG)
     streamingEnv.setParallelism(helper.modelParallelism)
     streamingEnv.addSource(new FlinkRedisSource())
       .map(new FlinkInference())

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/ClusterServingInference.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/ClusterServingInference.scala
@@ -24,13 +24,13 @@ import com.intel.analytics.zoo.serving.ClusterServing
 import com.intel.analytics.zoo.serving.postprocessing.PostProcessing
 import com.intel.analytics.zoo.serving.preprocessing.PreProcessing
 import com.intel.analytics.zoo.serving.utils.{ClusterServingHelper, Conventions}
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 
 /**
  * Inference Logic of Cluster Serving
  */
 class ClusterServingInference() {
-  val logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
   val helper = ClusterServing.helper
   val preProcessing = new PreProcessing()
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/FlinkInference.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/FlinkInference.scala
@@ -29,7 +29,7 @@ import com.intel.analytics.zoo.serving.serialization.StreamSerializer
 import com.intel.analytics.zoo.serving.utils.{ClusterServingHelper, Conventions}
 import org.apache.flink.api.common.functions.RichMapFunction
 import org.apache.flink.configuration.Configuration
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.{LogManager, Logger}
 
 
 
@@ -41,7 +41,7 @@ class FlinkInference()
   var helper: ClusterServingHelper = null
 
   override def open(parameters: Configuration): Unit = {
-    logger = Logger.getLogger(getClass)
+    logger = LogManager.getLogger(getClass)
     helper = ClusterServing.helper
 //    val t = Tensor[Float](1, 2, 3).rand()
 //    val x = T.array(Array(t))

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/FlinkKafkaSink.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/FlinkKafkaSink.scala
@@ -23,7 +23,7 @@ import com.intel.analytics.zoo.serving.utils.{ClusterServingHelper, Conventions}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.functions.sink.{RichSinkFunction, SinkFunction}
 import org.apache.kafka.clients.producer.{KafkaProducer, ProducerConfig, ProducerRecord}
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.{LogManager, Logger}
 
 class FlinkKafkaSink(params: ClusterServingHelper)
   extends RichSinkFunction[List[(String, String)]] {
@@ -33,7 +33,7 @@ class FlinkKafkaSink(params: ClusterServingHelper)
 
 
   override def open(parameters: Configuration): Unit = {
-    logger = Logger.getLogger(getClass)
+    logger = LogManager.getLogger(getClass)
     ClusterServing.helper = params
     topic = Conventions.RESULT_PREFIX + params.jobName
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/FlinkKafkaSource.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/FlinkKafkaSource.scala
@@ -23,7 +23,7 @@ import scala.collection.JavaConverters._
 import com.intel.analytics.zoo.serving.utils.{ClusterServingHelper, Conventions}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.functions.source.{RichParallelSourceFunction, SourceFunction}
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.{LogManager, Logger}
 import org.apache.kafka.clients.consumer.{ConsumerConfig, ConsumerRecords, KafkaConsumer}
 import org.apache.kafka.common.TopicPartition
 
@@ -34,7 +34,7 @@ class FlinkKafkaSource(params: ClusterServingHelper)
   var consumer: KafkaConsumer[String, String] = null
 
   override def open(parameters: Configuration): Unit = {
-    logger = Logger.getLogger(getClass)
+    logger = LogManager.getLogger(getClass)
 
     val props = new Properties()
     props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092")

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/FlinkRedisSink.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/FlinkRedisSink.scala
@@ -22,7 +22,7 @@ import com.intel.analytics.zoo.serving.pipeline.RedisUtils
 import com.intel.analytics.zoo.serving.utils.{ClusterServingHelper, Conventions}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.functions.sink.{RichSinkFunction, SinkFunction}
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.{LogManager, Logger}
 import redis.clients.jedis.{Jedis, JedisPool, JedisPoolConfig, StreamEntryID}
 
 
@@ -33,7 +33,7 @@ class FlinkRedisSink(helperSer: ClusterServingHelper)
   var logger: Logger = null
   var helper: ClusterServingHelper = null
   override def open(parameters: Configuration): Unit = {
-    logger = Logger.getLogger(getClass)
+    logger = LogManager.getLogger(getClass)
     // Sink is first initialized among Source, Map, Sink, so initialize static variable in sink.
     ClusterServing.helper = helperSer
     if (ClusterServing.helper.redisSecureEnabled) {

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/FlinkRedisSource.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/FlinkRedisSource.scala
@@ -24,7 +24,7 @@ import com.intel.analytics.zoo.serving.pipeline.RedisUtils
 import com.intel.analytics.zoo.serving.utils.{ClusterServingHelper, Conventions, FileUtils}
 import org.apache.flink.configuration.Configuration
 import org.apache.flink.streaming.api.functions.source.{RichParallelSourceFunction, RichSourceFunction, SourceFunction}
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.{LogManager, Logger}
 import redis.clients.jedis.{Jedis, JedisPool, JedisPoolConfig, StreamEntryID}
 
 import scala.collection.JavaConverters._
@@ -36,7 +36,7 @@ class FlinkRedisSource()
   var logger: Logger = null
   var helper: ClusterServingHelper = null
   override def open(parameters: Configuration): Unit = {
-    logger = Logger.getLogger(getClass)
+    logger = LogManager.getLogger(getClass)
     helper = ClusterServing.helper
     ClusterServing.initializeRedis()
     jedis = RedisUtils.getRedisClient(ClusterServing.jedisPool)

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/Operations.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/Operations.scala
@@ -21,7 +21,7 @@ import com.intel.analytics.zoo.serving.serialization.JsonInputDeserializer
 import com.intel.analytics.zoo.serving.http.Supportive
 import com.intel.analytics.zoo.serving.http.JsonUtil
 import com.intel.analytics.zoo.serving.http.ServingTimerMetrics
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 import com.codahale.metrics.MetricRegistry
 import scopt.OptionParser
 
@@ -45,7 +45,7 @@ object Operations extends Supportive {
       .required()
   }
 
-  // val logger = Logger.getLogger(getClass)
+  // val logger = LogManager.getLogger(getClass)
   def main(args: Array[String]): Unit = {
     // read the path of model
     val arg = parser.parse(args, Config()).head

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/Timer.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/engine/Timer.scala
@@ -18,7 +18,7 @@ package com.intel.analytics.zoo.serving.engine
 
 import java.util.PriorityQueue
 
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 
 /**
  * Timer class
@@ -70,7 +70,7 @@ class Timer() {
     val result = f
     val end = System.nanoTime()
     val cost = (end - begin) / 1e6
-    Logger.getLogger(getClass).info(s"$name time elapsed [${(cost / 1e3).toInt} s, $cost ms].")
+    LogManager.getLogger(getClass).info(s"$name time elapsed [${(cost / 1e3).toInt} s, $cost ms].")
     if (!timerMap.contains(name)) {
       timerMap += (name -> new TimerUnit())
     }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/Frontend2.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/http/Frontend2.scala
@@ -36,7 +36,7 @@ import com.intel.analytics.zoo.serving.utils.Conventions
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.intel.analytics.bigdl.nn.abstractnn.Activity
 import com.intel.analytics.zoo.serving.ClusterServing
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 import org.slf4j.LoggerFactory
 import redis.clients.jedis.JedisPool
 

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/operator/ClusterServingInferenceOperator.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/operator/ClusterServingInferenceOperator.scala
@@ -22,7 +22,7 @@ import com.intel.analytics.zoo.serving.engine.ClusterServingInference
 import com.intel.analytics.zoo.serving.utils.{ClusterServingHelper, Conventions}
 import org.apache.flink.api.common.functions.RichMapFunction
 import org.apache.flink.configuration.Configuration
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.{LogManager, Logger}
 
 
 class ClusterServingInferenceOperator(var params: ClusterServingParams = new ClusterServingParams())
@@ -32,7 +32,7 @@ class ClusterServingInferenceOperator(var params: ClusterServingParams = new Clu
   ClusterServing.helper = new ClusterServingHelper()
 
   override def open(parameters: Configuration): Unit = {
-    logger = Logger.getLogger(getClass)
+    logger = LogManager.getLogger(getClass)
     if (params == null) {
       params = new ClusterServingParams()
     }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/pipeline/RedisUtils.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/pipeline/RedisUtils.scala
@@ -21,9 +21,9 @@ import com.intel.analytics.zoo.serving.utils.Conventions
 import scala.collection.JavaConverters._
 import redis.clients.jedis.exceptions.JedisConnectionException
 import redis.clients.jedis._
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 object RedisUtils {
-  val logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
   def createRedisGroupIfNotExist(jedis: Jedis, streamName: String): Unit = {
     try {
       jedis.xgroupCreate(streamName,

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/preprocessing/PreProcessing.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/preprocessing/PreProcessing.scala
@@ -22,7 +22,7 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.bigdl.transform.vision.image.opencv.OpenCVMat
 import com.intel.analytics.zoo.feature.image.OpenCVMethod
 import org.opencv.imgcodecs.Imgcodecs
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 
 import scala.collection.mutable.ArrayBuffer
 import com.intel.analytics.bigdl.utils.{T, Table}
@@ -39,7 +39,7 @@ import redis.clients.jedis.Jedis
 
 class PreProcessing()
   extends EncryptSupportive with InferenceSupportive {
-  val logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
   if (ClusterServing.helper == null) {
     ClusterServing.helper = new ClusterServingHelper
   }

--- a/zoo/src/main/scala/com/intel/analytics/zoo/serving/utils/Supportive.scala
+++ b/zoo/src/main/scala/com/intel/analytics/zoo/serving/utils/Supportive.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.zoo.serving.utils
 
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 
 trait Supportive {
   def timing[T](name: String)(f: => T): T = {
@@ -24,7 +24,7 @@ trait Supportive {
     val result = f
     val end = System.nanoTime()
     val cost = (end - begin)
-    Logger.getLogger(getClass).info(s"$name time elapsed [${cost / 1e6} ms].")
+    LogManager.getLogger(getClass).info(s"$name time elapsed [${cost / 1e6} ms].")
     result
   }
 }

--- a/zoo/src/test/scala/com/intel/analytics/zoo/common/PythonInterpreterSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/common/PythonInterpreterSpec.scala
@@ -31,7 +31,7 @@ class PythonInterpreterSpec extends ZooSpecHelper{
       cancel("Please export PYTHONHOME before this test.")
     } else {
       logger.info(s"use python home: ${System.getenv("PYTHONHOME")}")
-      Configurator.setLevel("PythonInterpreter.getClass()", Level.DEBUG)
+      Configurator.setLevel(PythonInterpreter.getClass().getName, Level.DEBUG)
       // Load TFNet before create interpreter, or the TFNet will throw an OMP error #13
       TFNetNative.isLoaded
     }

--- a/zoo/src/test/scala/com/intel/analytics/zoo/common/PythonInterpreterSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/common/PythonInterpreterSpec.scala
@@ -19,7 +19,8 @@ import com.intel.analytics.zoo.core.TFNetNative
 import com.intel.analytics.zoo.pipeline.api.keras.ZooSpecHelper
 import com.intel.analytics.zoo.pipeline.api.net.NetUtils
 import jep.{NDArray, SharedInterpreter}
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import org.apache.spark.{SparkConf, SparkContext}
 
 @PythonInterpreterTest
@@ -30,7 +31,7 @@ class PythonInterpreterSpec extends ZooSpecHelper{
       cancel("Please export PYTHONHOME before this test.")
     } else {
       logger.info(s"use python home: ${System.getenv("PYTHONHOME")}")
-      Logger.getLogger(PythonInterpreter.getClass()).setLevel(Level.DEBUG)
+      Configurator.setLevel("PythonInterpreter.getClass()", Level.DEBUG)
       // Load TFNet before create interpreter, or the TFNet will throw an OMP error #13
       TFNetNative.isLoaded
     }

--- a/zoo/src/test/scala/com/intel/analytics/zoo/feature/FeatureSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/feature/FeatureSpec.scala
@@ -26,7 +26,7 @@ import com.intel.analytics.zoo.common.{NNContext, Utils}
 import com.intel.analytics.zoo.feature.common.{BigDLAdapter, Preprocessing}
 import com.intel.analytics.zoo.feature.image._
 import org.apache.commons.io.FileUtils
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 import org.apache.spark.{SparkConf, SparkContext}
 import org.opencv.imgcodecs.Imgcodecs
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}

--- a/zoo/src/test/scala/com/intel/analytics/zoo/friesian/FriesianSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/friesian/FriesianSpec.scala
@@ -21,7 +21,8 @@ import java.net.URL
 import com.intel.analytics.zoo.common.NNContext
 import com.intel.analytics.zoo.pipeline.api.keras.ZooSpecHelper
 import com.intel.analytics.zoo.friesian.python.PythonFriesian
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types.{StructField, _}
 import org.apache.spark.{SparkConf, SparkContext}
@@ -38,7 +39,7 @@ class FriesianSpec extends ZooSpecHelper {
   val friesian = PythonFriesian.ofFloat()
 
   override def doBefore(): Unit = {
-    Logger.getLogger("org").setLevel(Level.ERROR)
+    Configurator.setLevel("org", Level.ERROR)
     val conf = new SparkConf().setMaster("local[1]").setAppName("FriesianTest")
     sc = NNContext.initNNContext(conf)
     sqlContext = SQLContext.getOrCreate(sc)

--- a/zoo/src/test/scala/com/intel/analytics/zoo/models/anomalydetection/AnomalyDetectorSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/models/anomalydetection/AnomalyDetectorSpec.scala
@@ -21,7 +21,8 @@ import com.intel.analytics.bigdl.utils.{Shape, T}
 import com.intel.analytics.zoo.common.NNContext
 import com.intel.analytics.zoo.pipeline.api.keras.ZooSpecHelper
 import com.intel.analytics.zoo.pipeline.api.keras.serializer.ModuleSerializationTest
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, SQLContext}
 import org.apache.spark.{SparkConf, SparkContext}
@@ -33,7 +34,7 @@ class AnomalyDetectorSpec extends ZooSpecHelper {
   var sc: SparkContext = _
 
   override def doBefore(): Unit = {
-    Logger.getLogger("org").setLevel(Level.ERROR)
+    Configurator.setLevel("org", Level.ERROR)
     val conf = new SparkConf().setMaster("local[1]").setAppName("AnomalyTest")
     sc = NNContext.initNNContext(conf)
     sqlContext = SQLContext.getOrCreate(sc)

--- a/zoo/src/test/scala/com/intel/analytics/zoo/models/image/objectdetection/ssd/SSDSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/models/image/objectdetection/ssd/SSDSpec.scala
@@ -25,7 +25,7 @@ import com.intel.analytics.zoo.models.image.objectdetection.ObjectDetector
 import com.intel.analytics.zoo.models.image.objectdetection.common.dataset.Imdb
 import com.intel.analytics.zoo.pipeline.api.keras.ZooSpecHelper
 import com.intel.analytics.zoo.pipeline.api.keras.serializer.ModuleSerializationTest
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 import org.apache.spark.{SparkConf, SparkContext}
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
@@ -69,7 +69,7 @@ class SSDSpec extends FlatSpec with Matchers with BeforeAndAfter {
 }
 
 class SSDVGGSerialTest extends ModuleSerializationTest {
-  protected val logger = Logger.getLogger(getClass)
+  protected val logger = LogManager.getLogger(getClass)
   override def test(): Unit = {
     val model1 = SSDVGG[Float](20)
 

--- a/zoo/src/test/scala/com/intel/analytics/zoo/models/recommendation/NeuralCFSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/models/recommendation/NeuralCFSpec.scala
@@ -31,7 +31,8 @@ import com.intel.analytics.zoo.pipeline.api.keras.objectives.SparseCategoricalCr
 import com.intel.analytics.zoo.pipeline.api.keras.python.PythonZooKeras
 import com.intel.analytics.zoo.pipeline.api.keras.serializer.ModuleSerializationTest
 import com.intel.analytics.zoo.pipeline.estimator.Estimator
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.{DataFrame, SQLContext}
@@ -46,7 +47,7 @@ class NeuralCFSpec extends ZooSpecHelper {
   val itemCount = 100
 
   override def doBefore(): Unit = {
-    Logger.getLogger("org").setLevel(Level.ERROR)
+    Configurator.setLevel("org", Level.ERROR)
     val conf = new SparkConf().setMaster("local[1]").setAppName("NCFTest")
     sc = NNContext.initNNContext(conf)
     sqlContext = SQLContext.getOrCreate(sc)

--- a/zoo/src/test/scala/com/intel/analytics/zoo/models/recommendation/SessionRecommenderSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/models/recommendation/SessionRecommenderSpec.scala
@@ -23,7 +23,8 @@ import com.intel.analytics.zoo.common.NNContext
 import com.intel.analytics.zoo.models.anomalydetection.AnomalyDetector
 import com.intel.analytics.zoo.pipeline.api.keras.ZooSpecHelper
 import com.intel.analytics.zoo.pipeline.api.keras.serializer.ModuleSerializationTest
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, SQLContext}
 import org.apache.spark.{SparkConf, SparkContext}
@@ -35,7 +36,7 @@ class SessionRecommenderSpec extends ZooSpecHelper {
   var sc: SparkContext = _
 
   override def doBefore(): Unit = {
-    Logger.getLogger("org").setLevel(Level.ERROR)
+    Configurator.setLevel("org", Level.ERROR)
     val conf = new SparkConf().setMaster("local[1]").setAppName("NCFTest")
     sc = NNContext.initNNContext(conf)
     sqlContext = SQLContext.getOrCreate(sc)

--- a/zoo/src/test/scala/com/intel/analytics/zoo/models/recommendation/WideAndDeepSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/models/recommendation/WideAndDeepSpec.scala
@@ -26,7 +26,8 @@ import com.intel.analytics.zoo.common.NNContext
 import com.intel.analytics.zoo.pipeline.api.keras.ZooSpecHelper
 import com.intel.analytics.zoo.pipeline.api.keras.objectives.SparseCategoricalCrossEntropy
 import com.intel.analytics.zoo.pipeline.api.keras.serializer.ModuleSerializationTest
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.sql.{DataFrame, SQLContext}
 import org.apache.spark.rdd.RDD
@@ -43,7 +44,7 @@ class WideAndDeepSpec extends ZooSpecHelper {
   val bucketUDF = udf(Utils.buckBucket(100))
 
   override def doBefore(): Unit = {
-    Logger.getLogger("org").setLevel(Level.ERROR)
+    Configurator.setLevel("org", Level.ERROR)
     val conf = new SparkConf().setMaster("local[1]").setAppName("WideNdeepTest")
     sc = NNContext.initNNContext(conf)
     sqlContext = SQLContext.getOrCreate(sc)

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/ZooSpecHelper.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/ZooSpecHelper.scala
@@ -25,14 +25,14 @@ import com.intel.analytics.bigdl.utils.{RandomGenerator, Table}
 import com.intel.analytics.zoo.common.Utils
 import com.intel.analytics.zoo.models.common.ZooModel
 import org.apache.commons.io.FileUtils
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 import org.scalactic.TolerantNumerics
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
 
 import scala.collection.mutable.ArrayBuffer
 
 abstract class ZooSpecHelper extends FlatSpec with Matchers with BeforeAndAfter {
-  protected val logger = Logger.getLogger(getClass)
+  protected val logger = LogManager.getLogger(getClass)
 
   private val epsilon = 1e-4f
 

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/optimizers/OptimizersSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/keras/optimizers/OptimizersSpec.scala
@@ -23,7 +23,8 @@ import com.intel.analytics.bigdl.utils.Engine
 import com.intel.analytics.bigdl.utils.RandomGenerator.RNG
 import com.intel.analytics.zoo.common.NNContext
 import com.intel.analytics.zoo.pipeline.nnframes.{NNClassifier, NNClassifierModel, NNEstimatorSpec}
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.SQLContext
 import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
@@ -37,7 +38,7 @@ class OptimizersSpec extends FlatSpec with Matchers with BeforeAndAfter {
   val nRecords = 100
 
   before {
-    Logger.getLogger("org").setLevel(Level.ERROR)
+    Configurator.setLevel("org", Level.ERROR)
     val conf = Engine.createSparkConf().setAppName("OptimizersSpec").setMaster("local[1]")
     sc = NNContext.initNNContext(conf)
     sqlContext = new SQLContext(sc)

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModelSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModelSpec.scala
@@ -36,7 +36,7 @@ class TorchModelSpec extends ZooSpecHelper{
       cancel("Please export PYTHONHOME before this test.")
     } else {
       logger.info(s"use python home: ${System.getenv("PYTHONHOME")}")
-      Configurator.setLevel("PythonInterpreter.getClass()", Level.DEBUG)
+      Configurator.setLevel(PythonInterpreter.getClass().getName, Level.DEBUG)
       // Load TFNet before create interpreter, or the TFNet will throw an OMP error #13
       TFNetNative.isLoaded
     }

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModelSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/net/TorchModelSpec.scala
@@ -22,7 +22,8 @@ import com.intel.analytics.zoo.common.{PythonInterpreter, PythonInterpreterTest}
 import com.intel.analytics.zoo.core.TFNetNative
 import com.intel.analytics.zoo.pipeline.api.keras.ZooSpecHelper
 import jep.NDArray
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import org.apache.spark.{SparkConf, SparkContext}
 import com.intel.analytics.zoo.common.NNContext.initNNContext
 
@@ -35,7 +36,7 @@ class TorchModelSpec extends ZooSpecHelper{
       cancel("Please export PYTHONHOME before this test.")
     } else {
       logger.info(s"use python home: ${System.getenv("PYTHONHOME")}")
-      Logger.getLogger(PythonInterpreter.getClass()).setLevel(Level.DEBUG)
+      Configurator.setLevel("PythonInterpreter.getClass()", Level.DEBUG)
       // Load TFNet before create interpreter, or the TFNet will throw an OMP error #13
       TFNetNative.isLoaded
     }

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/net/TorchOptimSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/net/TorchOptimSpec.scala
@@ -36,7 +36,7 @@ class TorchOptimSpec extends ZooSpecHelper{
       cancel("Please export PYTHONHOME before this test.")
     } else {
       logger.info(s"use python home: ${System.getenv("PYTHONHOME")}")
-      Configurator.setLevel("PythonInterpreter.getClass()", Level.DEBUG)
+      Configurator.setLevel(PythonInterpreter.getClass().getName, Level.DEBUG)
       // Load TFNet before create interpreter, or the TFNet will throw an OMP error #13
       TFNetNative.isLoaded
     }

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/net/TorchOptimSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/api/net/TorchOptimSpec.scala
@@ -24,7 +24,8 @@ import com.intel.analytics.zoo.core.TFNetNative
 import com.intel.analytics.zoo.pipeline.api.keras.ZooSpecHelper
 import com.intel.analytics.zoo.pipeline.api.keras.models.InternalOptimizerUtil.getStateFromOptiMethod
 import com.intel.analytics.zoo.pipeline.api.net.TorchOptim.{EpochDecay, EpochDecayByScore, IterationDecay}
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 
 @PythonInterpreterTest
 class TorchOptimSpec extends ZooSpecHelper{
@@ -35,7 +36,7 @@ class TorchOptimSpec extends ZooSpecHelper{
       cancel("Please export PYTHONHOME before this test.")
     } else {
       logger.info(s"use python home: ${System.getenv("PYTHONHOME")}")
-      Logger.getLogger(PythonInterpreter.getClass()).setLevel(Level.DEBUG)
+      Configurator.setLevel("PythonInterpreter.getClass()", Level.DEBUG)
       // Load TFNet before create interpreter, or the TFNet will throw an OMP error #13
       TFNetNative.isLoaded
     }

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/estimator/DistriEstimatorSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/estimator/DistriEstimatorSpec.scala
@@ -26,7 +26,8 @@ import com.intel.analytics.zoo.feature.pmem.DISK_AND_DRAM
 import com.intel.analytics.zoo.feature.{DistributedDataSetWrapper, DistributedFeatureSet, FeatureSet}
 import com.intel.analytics.zoo.pipeline.api.keras.ZooSpecHelper
 import com.intel.analytics.zoo.pipeline.api.keras.models.InternalOptimizerUtil
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
@@ -106,8 +107,8 @@ class DistriEstimatorSpec extends ZooSpecHelper {
   import DistriEstimatorSpec._
   import EstimatorSpecModel._
 
-  Logger.getLogger("org").setLevel(Level.WARN)
-  Logger.getLogger("akka").setLevel(Level.WARN)
+  Configurator.setLevel("org", Level.WARN)
+  Configurator.setLevel("akka", Level.WARN)
 
   private var sc: SparkContext = _
 

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/inference/PyTorchModelSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/inference/PyTorchModelSpec.scala
@@ -53,7 +53,7 @@ class PyTorchModelSpec extends ZooSpecHelper with InferenceSupportive {
       cancel("Please export PYTHONHOME before this test.")
     } else {
       logger.info(s"use python home: ${System.getenv("PYTHONHOME")}")
-      Configurator.setLevel("PythonInterpreter.getClass()", Level.DEBUG)
+      Configurator.setLevel(PythonInterpreter.getClass().getName, Level.DEBUG)
       // Load TFNet before create interpreter, or the TFNet will throw an OMP error #13
       TFNetNative.isLoaded
       val resnetModel =

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/inference/PyTorchModelSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/inference/PyTorchModelSpec.scala
@@ -22,7 +22,8 @@ import com.intel.analytics.bigdl.tensor.Tensor
 import com.intel.analytics.zoo.common.{PythonInterpreter, PythonInterpreterTest}
 import com.intel.analytics.zoo.core.TFNetNative
 import com.intel.analytics.zoo.pipeline.api.keras.ZooSpecHelper
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 
 import scala.language.postfixOps
 
@@ -52,7 +53,7 @@ class PyTorchModelSpec extends ZooSpecHelper with InferenceSupportive {
       cancel("Please export PYTHONHOME before this test.")
     } else {
       logger.info(s"use python home: ${System.getenv("PYTHONHOME")}")
-      Logger.getLogger(PythonInterpreter.getClass()).setLevel(Level.DEBUG)
+      Configurator.setLevel("PythonInterpreter.getClass()", Level.DEBUG)
       // Load TFNet before create interpreter, or the TFNet will throw an OMP error #13
       TFNetNative.isLoaded
       val resnetModel =

--- a/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/nnframes/NNClassifierSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/pipeline/nnframes/NNClassifierSpec.scala
@@ -30,7 +30,8 @@ import com.intel.analytics.bigdl.visualization.{TrainSummary, ValidationSummary}
 import com.intel.analytics.zoo.feature.common._
 import com.intel.analytics.zoo.feature.image._
 import com.intel.analytics.zoo.pipeline.api.keras.ZooSpecHelper
-import org.apache.log4j.{Level, Logger}
+import org.apache.logging.log4j.{Level, LogManager}
+import org.apache.logging.log4j.core.config.Configurator
 import org.apache.spark.SparkContext
 import org.apache.spark.ml.feature.{MinMaxScaler, VectorAssembler}
 import org.apache.spark.ml.linalg.Vector
@@ -206,8 +207,8 @@ class NNClassifierSpec extends ZooSpecHelper {
   }
 
   "NNClassifier" should "get the same classification result with BigDL model" in {
-    Logger.getLogger("org").setLevel(Level.WARN)
-    Logger.getLogger("akka").setLevel(Level.WARN)
+    Configurator.setLevel("org", Level.WARN)
+    Configurator.setLevel("akka", Level.WARN)
 
     val model = LeNet5(10)
 

--- a/zoo/src/test/scala/com/intel/analytics/zoo/serving/CorrectnessSpec.scala
+++ b/zoo/src/test/scala/com/intel/analytics/zoo/serving/CorrectnessSpec.scala
@@ -19,7 +19,7 @@ package com.intel.analytics.zoo.serving
 import java.io.{ByteArrayOutputStream, File, PrintWriter}
 import java.util.Base64
 
-import org.apache.log4j.Logger
+import org.apache.logging.log4j.LogManager
 import org.scalatest.{FlatSpec, Matchers}
 
 import sys.process._
@@ -53,7 +53,7 @@ class CorrectnessSpec extends FlatSpec with Matchers {
 //  val configPath = "/home/litchy/pro/analytics-zoo/config.yaml"
   var redisHost: String = "localhost"
   var redisPort: Int = 6379
-  val logger = Logger.getLogger(getClass)
+  val logger = LogManager.getLogger(getClass)
   def resize(p: String): String = {
     val source = ImageIO.read(new File(p))
     val outputImage: BufferedImage = new BufferedImage(224, 224, source.getType)


### PR DESCRIPTION
```
joy@joy:~/workspace/BigDL2.0/log4j013/analytics-zoo/zoo$ mvn dependency:tree | egrep "log4j"
[WARNING] 'artifactId' contains an expression but should be a constant. @ com.intel.analytics.zoo:analytics-zoo-bigdl_${bigdl.version}-spark_${spark.version}:0.12.0-SNAPSHOT, /home/joy/workspace/BigDL2.0/log4j013/analytics-zoo/zoo/pom.xml, line 8, column 17
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ com.intel.analytics.zoo:analytics-zoo-bigdl_${bigdl.version}-spark_${spark.version}:0.12.0-SNAPSHOT, /home/joy/workspace/BigDL2.0/log4j013/analytics-zoo/zoo/pom.xml, line 917, column 21
[INFO] +- org.slf4j:slf4j-log4j12:jar:1.7.5:compile
[INFO] +- org.apache.logging.log4j:log4j-api:jar:2.16.0:compile
[INFO] \- org.apache.logging.log4j:log4j-core:jar:2.16.0:compile
joy@joy:~/workspace/BigDL2.0/log4j013/analytics-zoo/zoo$
```