### PR TITLE
Support pyspark.sql.types.ArrayType with pyspark.sql.types.StringType elements

### DIFF
--- a/pyzoo/test/zoo/orca/learn/ray/tf/test_tf_ray_estimator.py
+++ b/pyzoo/test/zoo/orca/learn/ray/tf/test_tf_ray_estimator.py
@@ -636,7 +636,9 @@ class TestTFRayEstimator(TestCase):
             import tensorflow as tf
             model = tf.keras.models.Sequential([
                 tf.keras.Input(shape=(None,), dtype=tf.string),
-                tf.keras.layers.experimental.preprocessing.StringLookup(vocabulary=config["vocabulary"])
+                tf.keras.layers.experimental.preprocessing.StringLookup(
+                    vocabulary=config["vocabulary"]
+                )
             ])
             return model
 

--- a/pyzoo/test/zoo/orca/learn/ray/tf/test_tf_ray_estimator.py
+++ b/pyzoo/test/zoo/orca/learn/ray/tf/test_tf_ray_estimator.py
@@ -637,7 +637,7 @@ class TestTFRayEstimator(TestCase):
         def model_creator(config):
             import tensorflow as tf
             model = tf.keras.models.Sequential([
-	        tf.keras.Input(shape=(None,), dtype=tf.string, ragged=True),
+                tf.keras.Input(shape=(None,), dtype=tf.string, ragged=True),
                 tf.keras.layers.StringLookup(vocabulary=config["vocabulary"])
             ])
             return model

--- a/pyzoo/zoo/util/utils.py
+++ b/pyzoo/zoo/util/utils.py
@@ -178,7 +178,10 @@ def convert_row_to_numpy(row, schema, feature_cols, label_cols, accept_str_col=F
             if _is_scalar_type(feature_type, accept_str_col):
                 result.append(np.array(row[name]))
             elif isinstance(feature_type, df_types.ArrayType):
-                result.append(np.array(row[name]).astype(np.float32))
+                if accept_str_col and isinstance(feature_type.elementType, df_types.StringType):
+                    result.append(np.array(row[name]).astype(np.str))
+                else:
+                    result.append(np.array(row[name]).astype(np.float32))
             elif isinstance(row[name], DenseVector):
                 result.append(row[name].values.astype(np.float32))
             else:


### PR DESCRIPTION
This modification has been tested using  ```pyzoo/test/zoo/orca/learn/ray/tf/test_tf_ray_estimator.py``` adding ```test_array_string_input()```.   (I also modified ```test_string_input()```  to adapt a vocabulary.)

results are:
```test_array_string_input()```:
```
[Row(id=0, input=['foo', 'qux', 'bar'], prediction=DenseVector([4.0, 1.0, 2.0])), Row(id=1, input=['qux', 'baz'], prediction=DenseVector([1.0, 3.0]))]
```
```test_string_input()```:
```
[Row(input='foo qux bar', prediction=DenseVector([3.0, 2.0, 5.0, 0.0])), Row(input='qux baz', prediction=DenseVector([2.0, 4.0, 0.0, 0.0]))]
```

test env:
- python3.7
- tensorflow==2.7.0
- ray==1.9.2