### PR TITLE
fix snakeyaml cve issue

### DIFF
--- a/zoo/pom.xml
+++ b/zoo/pom.xml
@@ -626,12 +626,6 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>2.17.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>1.7.16</version>
@@ -647,11 +641,6 @@
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
             <version>3.3.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-	    <version>1.32</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>


### PR DESCRIPTION
1. `com.fasterxml.jackson.dataformat` contains org.yaml:snakeyaml
https://github.com/intel-analytics/analytics-zoo/blob/master/zoo/pom.xml#L691
      <dependency>
            <groupId>com.fasterxml.jackson.dataformat</groupId>
            <artifactId>jackson-dataformat-yaml</artifactId>
            <version>${jackson.version}</version>
        </dependency>
3. log4j:log4j does not has version 2.17.1, and it has CVE issue. 