### PR TITLE
Bump com.google.protobuf:protobuf-java from 3.16.3 to 3.25.5

### DIFF
--- a/zoo/pom.xml
+++ b/zoo/pom.xml
@@ -835,7 +835,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.16.3</version>
+            <version>3.25.5</version>
             <scope>${grpc.scope}</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Fix https://github.com/intel-analytics/analytics-zoo/security/dependabot/573